### PR TITLE
Spoofax 3: Migration to Spoofax 2.5.10

### DIFF
--- a/core/constraint.common/src/main/java/mb/constraint/common/ConstraintAnalyzer.java
+++ b/core/constraint.common/src/main/java/mb/constraint/common/ConstraintAnalyzer.java
@@ -217,14 +217,18 @@ public class ConstraintAnalyzer {
             }
         }
 
+        // Progress and cancel terms
+        final IStrategoTerm progressTerm = mkTuple();   // ()
+        final IStrategoTerm cancelTerm = mkTuple();     // ()
+
         /// 3. Call analysis, and list results.
 
         final Map<ResourceKey, IStrategoTerm> resultTerms = new HashMap<>();
         final IStrategoTerm action;
         if(multiFile && root != null) {
-            action = mkAppl("AnalyzeMulti", rootChange, termFactory.makeList(changeTerms));
+            action = mkAppl("AnalyzeMulti", rootChange, termFactory.makeList(changeTerms), progressTerm, cancelTerm);
         } else {
-            action = mkAppl("AnalyzeSingle", termFactory.makeList(changeTerms));
+            action = mkAppl("AnalyzeSingle", termFactory.makeList(changeTerms), progressTerm, cancelTerm);
         }
 
         final @Nullable IStrategoTerm allResultsTerm;

--- a/core/jsglr.common/src/main/java/mb/jsglr/common/RegionUtil.java
+++ b/core/jsglr.common/src/main/java/mb/jsglr/common/RegionUtil.java
@@ -17,7 +17,7 @@ public class RegionUtil {
         int rightEndOffset = right.getEndOffset();
 
         // To fix the difference between offset and cursor position
-        if(left.getKind() != IToken.TK_LAYOUT && !isNullable) {
+        if(left.getKind() != IToken.Kind.TK_LAYOUT && !isNullable) {
             leftStartOffset++;
         }
 

--- a/core/jsglr.common/src/main/java/mb/jsglr/common/TokenUtil.java
+++ b/core/jsglr.common/src/main/java/mb/jsglr/common/TokenUtil.java
@@ -7,6 +7,7 @@ import mb.common.token.TokenType;
 import mb.common.token.TokenTypes;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.imploder.IToken;
+import org.spoofax.jsglr.client.imploder.ITokenizer;
 import org.spoofax.jsglr.client.imploder.ITokens;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 
@@ -15,13 +16,13 @@ import java.util.ArrayList;
 public class TokenUtil {
     public static ArrayList<Token<IStrategoTerm>> extract(IStrategoTerm ast) {
         final ImploderAttachment rootImploderAttachment = ImploderAttachment.get(ast);
-        final ITokens tokens = rootImploderAttachment.getLeftToken().getTokenizer();
-        final int tokenCount = tokens.getTokenCount();
+        final ITokenizer tokenizer = (ITokenizer)rootImploderAttachment.getLeftToken().getTokenizer();
+        final int tokenCount = tokenizer.getTokenCount();
         final ArrayList<Token<IStrategoTerm>> tokenStream = new ArrayList<>(tokenCount);
         int offset = -1;
         for(int i = 0; i < tokenCount; ++i) {
-            final IToken jsglrToken = tokens.getTokenAt(i);
-            if(tokens.isAmbiguous() && jsglrToken.getStartOffset() < offset) {
+            final IToken jsglrToken = tokenizer.getTokenAt(i);
+            if(tokenizer.isAmbiguous() && jsglrToken.getStartOffset() < offset) {
                 // In case of ambiguities, tokens inside the ambiguity are duplicated, ignore.
                 continue;
             }
@@ -47,19 +48,19 @@ public class TokenUtil {
         return new TokenImpl<>(tokenType, region, fragment);
     }
 
-    private static TokenType convertTokenKind(int kind) {
+    private static TokenType convertTokenKind(IToken.Kind kind) {
         switch(kind) {
-            case IToken.TK_IDENTIFIER:
+            case TK_IDENTIFIER:
                 return TokenTypes.identifier();
-            case IToken.TK_STRING:
+            case TK_STRING:
                 return TokenTypes.string();
-            case IToken.TK_NUMBER:
+            case TK_NUMBER:
                 return TokenTypes.number();
-            case IToken.TK_KEYWORD:
+            case TK_KEYWORD:
                 return TokenTypes.keyword();
-            case IToken.TK_OPERATOR:
+            case TK_OPERATOR:
                 return TokenTypes.operator();
-            case IToken.TK_LAYOUT:
+            case TK_LAYOUT:
                 return TokenTypes.layout();
             default:
                 return TokenTypes.unknown();

--- a/core/jsglr1.common/src/main/java/mb/jsglr1/common/MessagesUtil.java
+++ b/core/jsglr1.common/src/main/java/mb/jsglr1/common/MessagesUtil.java
@@ -13,6 +13,7 @@ import org.spoofax.jsglr.client.ParseTimeoutException;
 import org.spoofax.jsglr.client.RegionRecovery;
 import org.spoofax.jsglr.client.imploder.AbstractTokenizer;
 import org.spoofax.jsglr.client.imploder.IToken;
+import org.spoofax.jsglr.client.imploder.ITokenizer;
 import org.spoofax.jsglr.client.imploder.ITokens;
 import org.spoofax.jsglr.client.imploder.Token;
 import org.spoofax.jsglr.shared.BadTokenException;
@@ -55,20 +56,20 @@ class MessagesUtil {
      */
 
     void gatherNonFatalErrors(IStrategoTerm top) {
-        final ITokens tokens = getTokenizer(top);
+        final ITokenizer tokens = (ITokenizer)getTokenizer(top);
         if(tokens != null) {
             for(int i = 0, max = tokens.getTokenCount(); i < max; i++) {
-                final IToken token = tokens.getTokenAt(i);
+                final Token token = tokens.getTokenAt(i);
                 final @Nullable String error = token.getError();
                 if(error != null) {
-                    if(error.equals(ITokens.ERROR_SKIPPED_REGION)) {
+                    if(error.equals(ITokenizer.ERROR_SKIPPED_REGION)) {
                         i = findRightMostWithSameError(token, null);
                         reportSkippedRegion(token, tokens.getTokenAt(i));
-                    } else if(error.startsWith(ITokens.ERROR_WARNING_PREFIX)) {
+                    } else if(error.startsWith(ITokenizer.ERROR_WARNING_PREFIX)) {
                         i = findRightMostWithSameError(token, null);
                         reportWarningAtTokens(token, tokens.getTokenAt(i), error);
-                    } else if(error.startsWith(ITokens.ERROR_WATER_PREFIX)) {
-                        i = findRightMostWithSameError(token, ITokens.ERROR_WATER_PREFIX);
+                    } else if(error.startsWith(ITokenizer.ERROR_WATER_PREFIX)) {
+                        i = findRightMostWithSameError(token, ITokenizer.ERROR_WATER_PREFIX);
                         reportErrorAtTokens(token, tokens.getTokenAt(i), error);
                     } else {
                         i = findRightMostWithSameError(token, null);
@@ -81,9 +82,9 @@ class MessagesUtil {
         }
     }
 
-    private static int findRightMostWithSameError(IToken token, @Nullable String prefix) {
+    private static int findRightMostWithSameError(Token token, @Nullable String prefix) {
         final String expectedError = token.getError();
-        final ITokens tokens = token.getTokenizer();
+        final ITokenizer tokens = (ITokenizer)token.getTokenizer();
         int i = token.getIndex();
         for(int max = tokens.getTokenCount(); i + 1 < max; i++) {
             final String error = tokens.getTokenAt(i + 1).getError();
@@ -107,7 +108,7 @@ class MessagesUtil {
 
         if(reportedLine == -1) {
             // Report entire region
-            reportErrorAtTokens(left, right, ITokens.ERROR_SKIPPED_REGION);
+            reportErrorAtTokens(left, right, ITokenizer.ERROR_SKIPPED_REGION);
         } else if(reportedLine - line >= LARGE_REGION_SIZE) {
             // Warn at start of region
             reportErrorAtTokens(findLeftMostTokenOnSameLine(left), findRightMostTokenOnSameLine(left),
@@ -172,7 +173,7 @@ class MessagesUtil {
         } else {
             @Nullable IToken token = tokens.getTokenAtOffset(exception.getOffset()); // TODO: token can be null?
             token = findNextNonEmptyToken(token);
-            message = ITokens.ERROR_WATER_PREFIX + ": " + token.toString().trim();
+            message = ITokenizer.ERROR_WATER_PREFIX + ": " + token.toString().trim();
         }
         reportErrorNearOffset(tokens, exception.getOffset(), message);
     }
@@ -185,7 +186,7 @@ class MessagesUtil {
     }
 
     private static @Nullable IToken findNextNonEmptyToken(IToken token) {
-        final ITokens tokens = token.getTokenizer();
+        final ITokenizer tokens = (ITokenizer)token.getTokenizer();
         @Nullable IToken result = null;
         for(int i = token.getIndex(), max = tokens.getTokenCount(); i < max; i++) {
             result = tokens.getTokenAt(i);

--- a/core/spoofax.compiler.gradle/src/main/kotlin/mb/spoofax/compiler/gradle/spoofaxcore/LanguagePlugin.kt
+++ b/core/spoofax.compiler.gradle/src/main/kotlin/mb/spoofax/compiler/gradle/spoofaxcore/LanguagePlugin.kt
@@ -199,7 +199,6 @@ open class LanguagePlugin : Plugin<Project> {
     val input = finalized.input
     val destinationPackage = input.languageProject().packagePath()
     val includeStrategoClasses = input.strategoRuntime().map { it.copyClasses() }.orElse(false)
-    val includeStrategoJavastratClasses = input.strategoRuntime().map { it.copyJavaStrategyClasses() }.orElse(false)
     val copyResources = finalized.compiler.getCopyResources(input)
 
     // Add language dependency.
@@ -222,9 +221,6 @@ open class LanguagePlugin : Plugin<Project> {
       if(includeStrategoClasses) {
         allCopyResources.add("target/metaborg/stratego.jar")
       }
-      if(includeStrategoJavastratClasses) {
-        allCopyResources.add("target/metaborg/stratego-javastrat.jar")
-      }
       include(allCopyResources)
     }
 
@@ -237,19 +233,12 @@ open class LanguagePlugin : Plugin<Project> {
       from(project.zipTree("$unpackSpoofaxLanguageDir/target/metaborg/stratego.jar"))
       exclude("META-INF")
     }
-    val strategoJavastratCopySpec = project.copySpec {
-      from(project.zipTree("$unpackSpoofaxLanguageDir/target/metaborg/stratego-javastrat.jar"))
-      exclude("META-INF")
-    }
     val copyMainTask = project.tasks.register<Copy>("copyMainResources") {
       dependsOn(unpackSpoofaxLanguageTask)
       into(project.the<SourceSetContainer>()["main"].java.outputDir)
       into(destinationPackage) { with(resourcesCopySpec) }
       if(includeStrategoClasses) {
         into(".") { with(strategoCopySpec) }
-      }
-      if(includeStrategoJavastratClasses) {
-        into(".") { with(strategoJavastratCopySpec) }
       }
     }
     project.tasks.getByName(JavaPlugin.CLASSES_TASK_NAME).dependsOn(copyMainTask)
@@ -259,9 +248,6 @@ open class LanguagePlugin : Plugin<Project> {
       into(destinationPackage) { with(resourcesCopySpec) }
       if(includeStrategoClasses) {
         into(".") { with(strategoCopySpec) }
-      }
-      if(includeStrategoJavastratClasses) {
-        into(".") { with(strategoJavastratCopySpec) }
       }
     }
     project.tasks.getByName(JavaPlugin.TEST_CLASSES_TASK_NAME).dependsOn(copyTestTask)

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/spoofaxcore/StrategoRuntimeCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/spoofaxcore/StrategoRuntimeCompiler.java
@@ -107,8 +107,6 @@ public class StrategoRuntimeCompiler {
             return true;
         }
 
-        boolean copyJavaStrategyClasses();
-
 
         /// Kinds of classes (generated/extended/manual)
 

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/tiger/TigerInputs.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/tiger/TigerInputs.java
@@ -143,7 +143,7 @@ public class TigerInputs {
             )
             .enableNaBL2(true)
             .enableStatix(false)
-            .copyJavaStrategyClasses(true)
+            .copyClasses(true)
             .shared(shared)
             .languageProject(languageProject)
             ;

--- a/core/statix.multilang/src/main/java/mb/statix/multilang/tasks/SmlAnalyzeProject.java
+++ b/core/statix.multilang/src/main/java/mb/statix/multilang/tasks/SmlAnalyzeProject.java
@@ -26,6 +26,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.Level;
 import org.metaborg.util.log.LoggerUtils;
+import org.metaborg.util.task.NullCancel;
+import org.metaborg.util.task.NullProgress;
 
 import javax.inject.Inject;
 import java.io.Serializable;
@@ -190,7 +192,7 @@ public class SmlAnalyzeProject implements TaskDef<SmlAnalyzeProject.Input, SmlAn
             .reduce(globalState.getResult().delayed(), CConj::new);
 
         long t0 = System.currentTimeMillis();
-        SolverResult finalResult = Solver.solve(combinedSpec, combinedState, combinedConstraint, (s, l, st) -> true, debug);
+        SolverResult finalResult = Solver.solve(combinedSpec, combinedState, combinedConstraint, (s, l, st) -> true, debug, new NullProgress(), new NullCancel());
         long dt = System.currentTimeMillis() - t0;
         logger.info("{} analyzed in {} ms] ", input.analysisContext.contextId(), dt);
 

--- a/core/statix.multilang/src/main/java/mb/statix/multilang/tasks/SmlInstantiateGlobalScope.java
+++ b/core/statix.multilang/src/main/java/mb/statix/multilang/tasks/SmlInstantiateGlobalScope.java
@@ -2,7 +2,7 @@ package mb.statix.multilang.tasks;
 
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.ITermVar;
-import mb.nabl2.terms.build.ImmutableTermVar;
+import mb.nabl2.terms.build.TermVar;
 import mb.pie.api.ExecContext;
 import mb.pie.api.TaskDef;
 import mb.statix.constraints.CExists;
@@ -15,6 +15,8 @@ import mb.statix.solver.persistent.SolverResult;
 import mb.statix.solver.persistent.State;
 import mb.statix.spec.Spec;
 import org.metaborg.util.iterators.Iterables2;
+import org.metaborg.util.task.NullCancel;
+import org.metaborg.util.task.NullProgress;
 
 import javax.inject.Inject;
 import java.io.Serializable;
@@ -110,12 +112,12 @@ public class SmlInstantiateGlobalScope implements TaskDef<SmlInstantiateGlobalSc
     @Override
     public Output exec(ExecContext context, Input input) throws Exception {
         // Create uniquely named scope variable
-        ITermVar globalScopeVar = ImmutableTermVar.of("", String.format("global-%s", input.globalScopeName));
+        ITermVar globalScopeVar = TermVar.of("", String.format("global-%s", input.globalScopeName));
         Iterable<ITermVar> scopeArgs = Iterables2.singleton(globalScopeVar);
         IConstraint globalConstraint = new CExists(scopeArgs, new CNew(Iterables2.fromConcat(scopeArgs)));
         IState.Immutable state = State.of(input.spec);
 
-        SolverResult result = SolverUtils.partialSolve(input.spec, state, globalConstraint, input.debug);
+        SolverResult result = SolverUtils.partialSolve(input.spec, state, globalConstraint, input.debug, new NullProgress(), new NullCancel());
 
         ITerm globalScope = result.state().unifier()
             .findRecursive(result.existentials().get(globalScopeVar));

--- a/core/statix.multilang/src/main/java/mb/statix/multilang/tasks/SmlPartialSolveFile.java
+++ b/core/statix.multilang/src/main/java/mb/statix/multilang/tasks/SmlPartialSolveFile.java
@@ -17,6 +17,8 @@ import mb.statix.spec.Spec;
 import org.metaborg.util.iterators.Iterables2;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
+import org.metaborg.util.task.NullCancel;
+import org.metaborg.util.task.NullProgress;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 
@@ -132,7 +134,9 @@ public class SmlPartialSolveFile implements TaskDef<SmlPartialSolveFile.Input, S
         SolverResult fileResult = SolverUtils.partialSolve(input.spec,
             input.globalResult.state().withResource(input.resourceKey.toString()),
             fileConstraint,
-            input.debug);
+            input.debug,
+            new NullProgress(),
+            new NullCancel());
         long dt = System.currentTimeMillis() - t0;
         logger.info("{} analyzed in {} ms] ", input.resourceKey, dt);
 

--- a/core/statix.multilang/src/main/java/mb/statix/multilang/tasks/SmlPartialSolveProject.java
+++ b/core/statix.multilang/src/main/java/mb/statix/multilang/tasks/SmlPartialSolveProject.java
@@ -10,6 +10,8 @@ import mb.statix.solver.log.IDebugContext;
 import mb.statix.solver.persistent.SolverResult;
 import mb.statix.spec.Spec;
 import org.metaborg.util.iterators.Iterables2;
+import org.metaborg.util.task.NullCancel;
+import org.metaborg.util.task.NullProgress;
 
 import javax.inject.Inject;
 import java.io.Serializable;
@@ -100,7 +102,8 @@ public class SmlPartialSolveProject implements TaskDef<SmlPartialSolveProject.In
         Iterable<ITermVar> scopeArgs = Iterables2.singleton(input.globalScopeVar);
         IConstraint projectConstraint = new CUser(input.projectConstraint, scopeArgs);
 
-        SolverResult result = SolverUtils.partialSolve(input.spec, input.globalResult.state(), projectConstraint, input.debug);
+        SolverResult result = SolverUtils.partialSolve(input.spec, input.globalResult.state(), projectConstraint,
+            input.debug, new NullProgress(), new NullCancel());
 
         return new Output(result);
     }

--- a/core/statix.multilang/src/main/java/mb/statix/multilang/utils/SolverUtils.java
+++ b/core/statix.multilang/src/main/java/mb/statix/multilang/utils/SolverUtils.java
@@ -8,13 +8,15 @@ import mb.statix.solver.log.IDebugContext;
 import mb.statix.solver.persistent.Solver;
 import mb.statix.solver.persistent.SolverResult;
 import mb.statix.spec.Spec;
+import org.metaborg.util.task.ICancel;
+import org.metaborg.util.task.IProgress;
 
 public class SolverUtils {
 
-    public static SolverResult partialSolve(Spec spec, IState.Immutable state, IConstraint constraint, IDebugContext debug) {
+    public static SolverResult partialSolve(Spec spec, IState.Immutable state, IConstraint constraint, IDebugContext debug, IProgress progress, ICancel cancel) {
         final IsComplete isComplete = (s, l, st) -> !state.scopes().contains(s);
         try {
-            return Solver.solve(spec, state, constraint, isComplete, debug);
+            return Solver.solve(spec, state, constraint, isComplete, debug, progress, cancel);
         } catch(InterruptedException e) {
             throw new MultiLangAnalysisException(e);
         }

--- a/example/mod/mod/build.gradle.kts
+++ b/example/mod/mod/build.gradle.kts
@@ -28,8 +28,7 @@ spoofaxLanguageProject {
       .enableNaBL2(false)
       .enableStatix(true)
       .copyCTree(true)
-      .copyClasses(false)
-      .copyJavaStrategyClasses(false),
+      .copyClasses(false),
     constraintAnalyzer = ConstraintAnalyzerCompiler.LanguageProjectInput.builder()
       .multiFile(true),
 

--- a/example/sdf3/sdf3.spoofax/src/main/java/mb/sdf3/spoofax/task/debug/Sdf3ShowSpecParenthesizer.java
+++ b/example/sdf3/sdf3.spoofax/src/main/java/mb/sdf3/spoofax/task/debug/Sdf3ShowSpecParenthesizer.java
@@ -74,7 +74,7 @@ public class Sdf3ShowSpecParenthesizer extends ProvideOutputShared implements Ta
     @Override public CommandOutput exec(ExecContext context, Args args) throws Exception {
         final Supplier<ParseTable> parseTableSupplier = specToParseTable.createSupplier(new Sdf3SpecToParseTable.Args(
             createSpec.createSupplier(new Sdf3CreateSpec.Input(args.project, args.mainFile)),
-            new ParseTableConfiguration(false, false, true, false, false),
+            new ParseTableConfiguration(false, false, true, false, false, false),
             false
         ));
         final IStrategoTerm ast = context.require(specToParenthesizer, new Sdf3SpecToParenthesizer.Args(parseTableSupplier, "parenthesizer"));

--- a/example/sdf3/sdf3.spoofax/src/main/java/mb/sdf3/spoofax/task/debug/Sdf3ShowSpecParseTable.java
+++ b/example/sdf3/sdf3.spoofax/src/main/java/mb/sdf3/spoofax/task/debug/Sdf3ShowSpecParseTable.java
@@ -62,7 +62,7 @@ public class Sdf3ShowSpecParseTable implements TaskDef<Sdf3ShowSpecParseTable.Ar
     @Override public CommandOutput exec(ExecContext context, Args args) throws Exception {
         final ParseTable parseTable = context.require(specToParseTable, new Sdf3SpecToParseTable.Args(
             createSpec.createSupplier(new Sdf3CreateSpec.Input(args.project, args.mainFile)),
-            new ParseTableConfiguration(false, false, true, false, false),
+            new ParseTableConfiguration(false, false, true, false, false, false),
             false
         ));
         final IStrategoTerm ast = ParseTableIO.generateATerm(parseTable);

--- a/example/sdf3/sdf3.spoofax/src/test/java/mb/sdf3/spoofax/SpecToParenthesizerTest.java
+++ b/example/sdf3/sdf3.spoofax/src/test/java/mb/sdf3/spoofax/SpecToParenthesizerTest.java
@@ -22,7 +22,7 @@ class SpecToParenthesizerTest extends TestBase {
         try(final MixedSession session = newSession()) {
             final Sdf3SpecToParseTable.Args parseTableArgs = new Sdf3SpecToParseTable.Args(
                 specSupplier(desugarSupplier(resource)),
-                new ParseTableConfiguration(false, false, true, false, false),
+                new ParseTableConfiguration(false, false, true, false, false, false),
                 false
             );
             final Sdf3SpecToParenthesizer.Args parenthesizerArgs = new Sdf3SpecToParenthesizer.Args(

--- a/example/sdf3/sdf3.spoofax/src/test/java/mb/sdf3/spoofax/SpecToParseTableTest.java
+++ b/example/sdf3/sdf3.spoofax/src/test/java/mb/sdf3/spoofax/SpecToParseTableTest.java
@@ -33,7 +33,7 @@ class SpecToParseTableTest extends TestBase {
             final Sdf3Parse parse = languageComponent.getParse();
             final Sdf3SpecToParseTable.Args args = new Sdf3SpecToParseTable.Args(
                 specSupplier(desugarSupplier(resourceMain), desugarSupplier(resourceLex), desugarSupplier(resourceA), desugarSupplier(resourceB)),
-                new ParseTableConfiguration(false, false, true, false, false),
+                new ParseTableConfiguration(false, false, true, false, false, false),
                 createCompletionTable
             );
             final ParseTable parseTable = session.require(taskDef.createTask(args));

--- a/example/sdf3/sdf3/build.gradle.kts
+++ b/example/sdf3/sdf3/build.gradle.kts
@@ -42,7 +42,7 @@ spoofaxLanguageProject {
       builder.addAdditionalCopyResources("target/metaborg/EditorService-pretty.pp.af")
       if(gradle.parent != null && gradle.parent!!.rootProject.name == "devenv") {
         // HACK: use org.metaborggggg groupId for SDF3, as that is used to prevent bootstrapping issues.
-        builder.languageSpecificationDependency(GradleDependency.module("org.metaborg:org.metaborg.meta.lang.template:2.6.0-SNAPSHOT"))
+        builder.languageSpecificationDependency(GradleDependency.module("org.metaborggggg:org.metaborg.meta.lang.template:2.6.0-SNAPSHOT"))
       } else {
         // HACK: when building standalone (outside of devenv composite build), use a normal SDF3 dependency.
         builder.languageSpecificationDependency(GradleDependency.module("org.metaborg:org.metaborg.meta.lang.template:2.6.0-SNAPSHOT"))

--- a/example/sdf3/sdf3/build.gradle.kts
+++ b/example/sdf3/sdf3/build.gradle.kts
@@ -30,8 +30,7 @@ spoofaxLanguageProject {
       .enableNaBL2(false)
       .enableStatix(true)
       .copyCTree(true)
-      .copyClasses(false)
-      .copyJavaStrategyClasses(true)
+      .copyClasses(true)
       .classKind(mb.spoofax.compiler.util.ClassKind.Extended)
       .manualFactory("mb.sdf3", "Sdf3ManualStrategoRuntimeBuilderFactory"),
     constraintAnalyzer = ConstraintAnalyzerCompiler.LanguageProjectInput.builder()
@@ -43,10 +42,10 @@ spoofaxLanguageProject {
       builder.addAdditionalCopyResources("target/metaborg/EditorService-pretty.pp.af")
       if(gradle.parent != null && gradle.parent!!.rootProject.name == "devenv") {
         // HACK: use org.metaborggggg groupId for SDF3, as that is used to prevent bootstrapping issues.
-        builder.languageSpecificationDependency(GradleDependency.module("org.metaborggggg:org.metaborg.meta.lang.template:2.6.0-SNAPSHOT"))
+        builder.languageSpecificationDependency(GradleDependency.module("org.metaborg:org.metaborg.meta.lang.template:2.6.0-SNAPSHOT"))
       } else {
         // HACK: when building standalone (outside of devenv composite build), use a normal SDF3 dependency.
-        builder.languageSpecificationDependency(GradleDependency.module("org.metaborg:org.metaborg.meta.lang.template:2.5.9"))
+        builder.languageSpecificationDependency(GradleDependency.module("org.metaborg:org.metaborg.meta.lang.template:2.6.0-SNAPSHOT"))
       }
       builder
     }

--- a/example/sdf3/sdf3/build.gradle.kts
+++ b/example/sdf3/sdf3/build.gradle.kts
@@ -42,10 +42,10 @@ spoofaxLanguageProject {
       builder.addAdditionalCopyResources("target/metaborg/EditorService-pretty.pp.af")
       if(gradle.parent != null && gradle.parent!!.rootProject.name == "devenv") {
         // HACK: use org.metaborggggg groupId for SDF3, as that is used to prevent bootstrapping issues.
-        builder.languageSpecificationDependency(GradleDependency.module("org.metaborggggg:org.metaborg.meta.lang.template:2.6.0-SNAPSHOT"))
+        builder.languageSpecificationDependency(GradleDependency.module("org.metaborggggg:org.metaborg.meta.lang.template:2.5.10"))
       } else {
         // HACK: when building standalone (outside of devenv composite build), use a normal SDF3 dependency.
-        builder.languageSpecificationDependency(GradleDependency.module("org.metaborg:org.metaborg.meta.lang.template:2.6.0-SNAPSHOT"))
+        builder.languageSpecificationDependency(GradleDependency.module("org.metaborg:org.metaborg.meta.lang.template:2.5.10"))
       }
       builder
     }

--- a/example/tiger/generated/tiger/build.gradle.kts
+++ b/example/tiger/generated/tiger/build.gradle.kts
@@ -31,7 +31,7 @@ spoofaxLanguageProject {
       .addInteropRegisterersByReflection("tiger.spoofaxcore.trans.InteropRegisterer", "tiger.spoofaxcore.strategies.InteropRegisterer")
       .enableNaBL2(true)
       .enableStatix(false)
-      .copyJavaStrategyClasses(true),
+      .copyClasses(true),
     constraintAnalyzer = ConstraintAnalyzerCompiler.LanguageProjectInput.builder(),
 
     builder = LanguageProjectCompiler.Input.builder()

--- a/example/tiger/manual/tiger/build.gradle.kts
+++ b/example/tiger/manual/tiger/build.gradle.kts
@@ -39,15 +39,11 @@ fun copySpoofaxLanguageResources(
   dependency: Dependency,
   destinationPackage: String,
   includeStrategoClasses: Boolean,
-  includeStrategoJavastratClasses: Boolean,
   vararg resources: String
 ) {
   val allResources = resources.toMutableList()
   if(includeStrategoClasses) {
     allResources.add("target/metaborg/stratego.jar")
-  }
-  if(includeStrategoJavastratClasses) {
-    allResources.add("target/metaborg/stratego-javastrat.jar")
   }
 
   // Add language dependency.
@@ -71,19 +67,12 @@ fun copySpoofaxLanguageResources(
     from(project.zipTree("$unpackSpoofaxLanguageDir/target/metaborg/stratego.jar"))
     exclude("META-INF")
   }
-  val strategoJavastratCopySpec = copySpec {
-    from(project.zipTree("$unpackSpoofaxLanguageDir/target/metaborg/stratego-javastrat.jar"))
-    exclude("META-INF")
-  }
   val copyMainTask = tasks.register<Copy>("copyMainResources") {
     dependsOn(unpackSpoofaxLanguageTask)
     into(sourceSets.main.get().java.outputDir)
     into(destinationPackage) { with(resourcesCopySpec) }
     if(includeStrategoClasses) {
       into(".") { with(strategoCopySpec) }
-    }
-    if(includeStrategoJavastratClasses) {
-      into(".") { with(strategoJavastratCopySpec) }
     }
   }
   tasks.getByName(JavaPlugin.CLASSES_TASK_NAME).dependsOn(copyMainTask)
@@ -94,16 +83,12 @@ fun copySpoofaxLanguageResources(
     if(includeStrategoClasses) {
       into(".") { with(strategoCopySpec) }
     }
-    if(includeStrategoJavastratClasses) {
-      into(".") { with(strategoJavastratCopySpec) }
-    }
   }
   tasks.getByName(JavaPlugin.TEST_CLASSES_TASK_NAME).dependsOn(copyTestTask)
 }
 copySpoofaxLanguageResources(
   dependencies.create(compositeBuild("tiger.spoofaxcore")),
   "mb/tiger",
-  true,
   true,
   "target/metaborg/editor.esv.af", "target/metaborg/sdf.tbl"
 )

--- a/example/tiger/spoofaxcore/tiger.spoofaxcore/editor/Main.esv
+++ b/example/tiger/spoofaxcore/tiger.spoofaxcore/editor/Main.esv
@@ -11,15 +11,13 @@ language
 
   //provider : target/metaborg/stratego.ctree
   provider : target/metaborg/stratego.jar
-  provider : target/metaborg/stratego-javastrat.jar
-  
+
 menus
 
   menu: "Transform" (openeditor) (realtime)
-  
+
     action: "Desugar"       = editor-desugar (source)
     action: "Desugar AST"   = editor-desugar-ast (source)
     action: "Make Occurrences" = editor-transform-occurrences
     action: "Show SG" = editor-show-analysis-term
     action: "Show analyzed AST" = debug-show-analyzed
-  


### PR DESCRIPTION
This PR migrates Spoofax 3 to support Spoofax 2.5.10.

Depends on:
- metaborg/spoofax.gradle#1
- metaborg/sdf#48
- metaborg/nabl#34