### PR TITLE
Fix overwrite cause

### DIFF
--- a/core/jsglr1.common/src/main/java/mb/jsglr1/common/JSGLR1ParseException.java
+++ b/core/jsglr1.common/src/main/java/mb/jsglr1/common/JSGLR1ParseException.java
@@ -18,9 +18,7 @@ public abstract class JSGLR1ParseException extends Exception {
     }
 
     public static JSGLR1ParseException readStringFail(String source, IOException cause) {
-        final JSGLR1ParseException e = JSGLR1ParseExceptions.readStringFail(source, cause);
-        e.initCause(cause);
-        return e;
+        return JSGLR1ParseExceptions.readStringFail(source, cause);
     }
 
     public static JSGLR1ParseException parseFail(Messages messages) {
@@ -48,6 +46,13 @@ public abstract class JSGLR1ParseException extends Exception {
             .readStringFail((source, cause) -> "Parsing failed; cannot get text to parse from '" + source + "'")
             .parseFail((messages) -> "Parsing failed; see error messages")
             .recoveryDisallowedFail((messages) -> "Parsing recovered from failure, but recovery was disallowed; see error messages");
+    }
+
+    @Override public synchronized Throwable getCause() {
+        return caseOf()
+            .readStringFail((source, cause) -> cause)
+            .parseFail((messages) -> null)
+            .recoveryDisallowedFail((messages) -> null);
     }
 
     @Override public abstract int hashCode();

--- a/core/stratego.common/src/main/java/mb/stratego/common/StrategoException.java
+++ b/core/stratego.common/src/main/java/mb/stratego/common/StrategoException.java
@@ -46,9 +46,7 @@ public abstract class StrategoException extends Exception {
     }
 
     public static StrategoException exceptionalFail(String strategyName, IStrategoTerm input, String[] trace, InterpreterException cause) {
-        final StrategoException e = StrategoExceptions.exceptionalFail(strategyName, input, trace, cause);
-        e.initCause(cause);
-        return e;
+        return StrategoExceptions.exceptionalFail(strategyName, input, trace, cause);
     }
 
     public static StrategoException fromInterpreterException(String strategyName, IStrategoTerm input, String[] trace, InterpreterException interpreterException) {
@@ -110,6 +108,16 @@ public abstract class StrategoException extends Exception {
             .strategyUndefined((strategyName, input, trace, undefinedStrategyName) -> createMessage(strategyName, input, trace, "; strategy '" + undefinedStrategyName + "' is undefined"))
             .exceptionalFail((strategyName, input, trace, cause) -> createMessage(strategyName, input, trace, "unexpectedly due to:\n\n" + cause.getMessage()))
             ;
+    }
+
+    @Override public synchronized Throwable getCause() {
+        return caseOf()
+            .strategyFail((strategyName, input, trace) -> (Throwable)null)
+            .fatalFail((strategyName, input, trace) -> null)
+            .fatalFailWithTerm((strategyName, input, trace, term) -> null)
+            .exitFail((strategyName, input, trace, exitCode) -> null)
+            .strategyUndefined((strategyName, input, trace, undefinedStrategyName) -> null)
+            .exceptionalFail((strategyName, input, trace, cause) -> cause);
     }
 
     private String createMessage(String strategyName, IStrategoTerm input, String[] trace, String postfix) {


### PR DESCRIPTION
This PR fixes the error "Can't overwrite cause with Exception" that is thrown when calling `Throwable.initCause(e)` on an exception for which the cause is already set.