### PR TITLE
Fix and test multilang analysis compilation

### DIFF
--- a/core/spoofax.compiler.gradle.spoofax2/src/main/kotlin/mb/spoofax/compiler/gradle/spoofax2/plugin/Spoofax2LanguagePlugin.kt
+++ b/core/spoofax.compiler.gradle.spoofax2/src/main/kotlin/mb/spoofax/compiler/gradle/spoofax2/plugin/Spoofax2LanguagePlugin.kt
@@ -60,7 +60,9 @@ open class Spoofax2LanguagePlugin : Plugin<Project> {
     languageProjectExtension.compilerInput { extension.compilerInputFinalized.syncTo(this) }
 
     project.afterEvaluate {
-      configure(project, component, extension.compilerInputFinalized, languageProjectExtension.compilerInputFinalized)
+      project.whenLanguageProjectFinalized {
+        configure(project, component, extension.compilerInputFinalized, languageProjectExtension.compilerInputFinalized)
+      }
     }
   }
 

--- a/core/spoofax.compiler.gradle/src/main/kotlin/mb/spoofax/compiler/gradle/plugin/LanguagePlugin.kt
+++ b/core/spoofax.compiler.gradle/src/main/kotlin/mb/spoofax/compiler/gradle/plugin/LanguagePlugin.kt
@@ -158,8 +158,10 @@ open class LanguagePlugin : Plugin<Project> {
     project.plugins.apply(JavaLibraryPlugin::class.java)
 
     project.afterEvaluate {
-      extension.statixDependenciesFinalized.whenAllLanguageProjectsFinalized {
-        configure(project, extension.component, extension.compilerInputFinalized)
+      project.whenLanguageProjectFinalized {
+        extension.statixDependenciesFinalized.whenAllLanguageProjectsFinalized {
+          configure(project, extension.component, extension.compilerInputFinalized)
+        }
       }
     }
   }

--- a/core/spoofax.compiler.spoofax2/src/main/java/mb/spoofax/compiler/spoofax2/language/Spoofax2MultilangAnalyzerLanguageCompiler.java
+++ b/core/spoofax.compiler.spoofax2/src/main/java/mb/spoofax/compiler/spoofax2/language/Spoofax2MultilangAnalyzerLanguageCompiler.java
@@ -24,18 +24,16 @@ public class Spoofax2MultilangAnalyzerLanguageCompiler implements TaskDef<Spoofa
         return None.instance;
     }
 
-
     public ListView<String> getCopyResources(Input input) {
-        // TODO: requires constraint analyzer compiler with Statix enabled, which already copies Statix specs?
-        return ListView.of();
+        return ListView.of(input.statixSpecificationRelativePath());
     }
-
 
     @Value.Immutable public interface Input extends Serializable {
         class Builder extends Spoofax2MultilangAnalyzerLanguageCompilerData.Input.Builder {}
 
         static Builder builder() { return new Builder(); }
 
+        @Value.Default default String statixSpecificationRelativePath() { return "src-gen/statix/"; }
 
         default void syncTo(MultilangAnalyzerLanguageCompiler.Input.Builder builder) {
             // Nothing to sync right now.

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/LanguageProjectCompilerInputBuilder.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/LanguageProjectCompilerInputBuilder.java
@@ -79,7 +79,7 @@ public class LanguageProjectCompilerInputBuilder {
         final ConstraintAnalyzerLanguageCompiler.@Nullable Input constraintAnalyzer = buildConstraintAnalyzer(shared, languageProject);
         if(constraintAnalyzer != null) project.constraintAnalyzer(constraintAnalyzer);
 
-        final MultilangAnalyzerLanguageCompiler.@Nullable Input multilangAnalyzer = buildMultilangAnalyzer(shared, languageProject);
+        final MultilangAnalyzerLanguageCompiler.@Nullable Input multilangAnalyzer = buildMultilangAnalyzer(shared, languageProject, classloaderResources);
         if(multilangAnalyzer != null) project.multilangAnalyzer(multilangAnalyzer);
 
         final StrategoRuntimeLanguageCompiler.@Nullable Input strategoRuntime = buildStrategoRuntime(shared, languageProject, constraintAnalyzer);
@@ -128,10 +128,11 @@ public class LanguageProjectCompilerInputBuilder {
             .build();
     }
 
-    private MultilangAnalyzerLanguageCompiler.@Nullable Input buildMultilangAnalyzer(Shared shared, LanguageProject languageProject) {
+    private MultilangAnalyzerLanguageCompiler.@Nullable Input buildMultilangAnalyzer(Shared shared, LanguageProject languageProject, ClassloaderResourcesCompiler.Input classloaderResourcesInput) {
         if(!multilangAnalyzerEnabled) return null;
         return multilangAnalyzer
             .shared(shared)
+            .classloaderResources(classloaderResourcesInput.classloaderResources())
             .languageProject(languageProject)
             .build();
     }

--- a/example/multilang/example/arith.msdf
+++ b/example/multilang/example/arith.msdf
@@ -1,0 +1,14 @@
+module arith
+
+sorts
+  Start Expr Fact Term Int
+
+context-free syntax
+
+  Start.Module  = <<Expr>>
+  Expr.Plus 	= <<Expr> + <Term>>
+  Expr.Term		= <<Term>>
+  Term.Times 	= <<Term> * <Fact>>
+  Term.Factor	= <<Fact>>
+  Fact.Bracket	= <(<Expr>)>
+  Fact.Lit 		= <<Int>>

--- a/example/multilang/example/multilang.yaml
+++ b/example/multilang/example/multilang.yaml
@@ -1,0 +1,5 @@
+languageContexts:
+  'mb.minisdf': "debugContext"
+  'mb.ministr': "debugContext"
+logging:
+  debugContext: "debug"

--- a/example/multilang/example/test.mstr
+++ b/example/multilang/example/test.mstr
@@ -1,0 +1,31 @@
+module test
+
+imports
+  arith
+
+rules
+    // Remove unnecesary brackets in Plus terms
+
+rules
+	// Remove unnecessary bracket in Times Terms
+  	remove-bracket-times: Times(a, Bracket(Term(Factor(b)))) -> Times(a, b)
+	// remove-bracket-times: Times(Factor(Bracket(Term(a))), b) -> Times(a, b)
+
+rules
+ 	remove-bracket-plus: Plus(Term(Factor(Bracket(a))), b) -> Plus(a, b)
+	// remove-bracket-plus: Plus(a, Factor(Bracket(Term(b)))) -> Plus(a, b)
+
+rules
+	// Incorrect src pattern
+    // remove-bracket: Plus(Factor(Bracket(a)), b) -> Plus(a, b)
+	// Incorrect var sort
+    // remove-bracket: Plus(Term(Factor(a)), b) -> Plus(a, b)
+    // Incorrect src arity
+ 	// remove-bracket: Plus(Term(Factor(Bracket(a))), b, superfluous) -> Plus(a, b)
+    // Incorrect dst arity
+ 	// remove-bracket: Plus(Term(Factor(Bracket(a))), b) -> Plus(a, b, a)
+
+rules
+
+  bracketize-expr: a -> Factor(Bracket(a))
+  bracketize-term: b -> Bracket(Term(b))

--- a/example/multilang/example/test.mstr
+++ b/example/multilang/example/test.mstr
@@ -5,15 +5,13 @@ imports
 
 rules
     // Remove unnecesary brackets in Plus terms
+ 	remove-bracket-plus: Plus(Term(Factor(Bracket(a))), b) -> Plus(a, b)
+	// remove-bracket-plus: Plus(a, Factor(Bracket(Term(b)))) -> Plus(a, b)
 
 rules
 	// Remove unnecessary bracket in Times Terms
   	remove-bracket-times: Times(a, Bracket(Term(Factor(b)))) -> Times(a, b)
 	// remove-bracket-times: Times(Factor(Bracket(Term(a))), b) -> Times(a, b)
-
-rules
- 	remove-bracket-plus: Plus(Term(Factor(Bracket(a))), b) -> Plus(a, b)
-	// remove-bracket-plus: Plus(a, Factor(Bracket(Term(b)))) -> Plus(a, b)
 
 rules
 	// Incorrect src pattern

--- a/example/multilang/generated/minisdf.cli/build.gradle.kts
+++ b/example/multilang/generated/minisdf.cli/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.cli")
+}
+
+languageCliProject {
+  adapterProject.set(project(":minisdf.spoofax"))
+}

--- a/example/multilang/generated/minisdf.eclipse.externaldeps/build.gradle.kts
+++ b/example/multilang/generated/minisdf.eclipse.externaldeps/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.eclipse.externaldeps")
+}
+
+languageEclipseExternaldepsProject {
+  adapterProject.set(project(":minisdf.spoofax"))
+}

--- a/example/multilang/generated/minisdf.eclipse/build.gradle.kts
+++ b/example/multilang/generated/minisdf.eclipse/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.eclipse")
+}
+
+languageEclipseProject {
+  eclipseExternaldepsProject.set(project(":minisdf.eclipse.externaldeps"))
+  adapterProject.set(project(":minisdf.spoofax"))
+}

--- a/example/multilang/generated/minisdf.spoofax/build.gradle.kts
+++ b/example/multilang/generated/minisdf.spoofax/build.gradle.kts
@@ -1,0 +1,27 @@
+import mb.spoofax.compiler.adapter.*
+import mb.spoofax.compiler.adapter.data.*
+import mb.spoofax.compiler.gradle.plugin.*
+import mb.spoofax.compiler.util.*
+import mb.spoofax.core.language.command.*
+
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.adapter")
+}
+
+languageAdapterProject {
+  languageProject.set(project(":minisdf"))
+  compilerInput {
+    withParser()
+    withStyler()
+    withStrategoRuntime()
+    withMultilangAnalyzer().run {
+      rootModule("mini-sdf/mini-sdf-typing")
+      preAnalysisStrategy("pre-analyze")
+      postAnalysisStrategy("post-analyze")
+      contextId("mini-sdf-str")
+      fileConstraint("mini-sdf/mini-sdf-typing!msdfProgramOK")
+      projectConstraint("mini-sdf/mini-sdf-typing!msdfProjectOK")
+    }
+  }
+}

--- a/example/multilang/generated/minisdf/build.gradle.kts
+++ b/example/multilang/generated/minisdf/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 languageProject {
   shared {
     name("MiniSdf")
+    fileExtensions(listOf("msdf"))
     defaultPackageId("mb.minisdf")
   }
   compilerInput {
@@ -29,6 +30,7 @@ languageProject {
     }
     withStrategoRuntime()
   }
+  statixDependencies.set(listOf(project(":module")))
 }
 
 spoofax2BasedLanguageProject {

--- a/example/multilang/generated/minisdf/build.gradle.kts
+++ b/example/multilang/generated/minisdf/build.gradle.kts
@@ -1,0 +1,46 @@
+import mb.spoofax.compiler.gradle.plugin.*
+import mb.spoofax.compiler.gradle.spoofax2.plugin.*
+import mb.spoofax.compiler.language.*
+import mb.spoofax.compiler.spoofax2.language.*
+import mb.spoofax.compiler.util.*
+
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.gradle.config.junit-testing")
+  id("org.metaborg.spoofax.compiler.gradle.spoofax2.language")
+}
+
+dependencies {
+  api(project(":module"))
+}
+
+languageProject {
+  shared {
+    name("MiniSdf")
+    defaultPackageId("mb.minisdf")
+  }
+  compilerInput {
+    withParser().run {
+      startSymbol("MSDFStart")
+    }
+    withStyler()
+    withMultilangAnalyzer().run {
+      rootModules(listOf("mini-sdf/mini-sdf-typing"))
+    }
+    withStrategoRuntime()
+  }
+}
+
+spoofax2BasedLanguageProject {
+  compilerInput {
+    withParser()
+    withStyler()
+    withStrategoRuntime().run {
+      copyCtree(true)
+      copyClasses(false)
+    }
+    withMultilangAnalyzer()
+    project
+      .languageSpecificationDependency(GradleDependency.project(":minisdf.spoofaxcore"))
+  }
+}

--- a/example/multilang/generated/minisdf/spoofaxc.lock
+++ b/example/multilang/generated/minisdf/spoofaxc.lock
@@ -1,0 +1,5 @@
+defaultGroupId=org.metaborg
+defaultClassPrefix=MiniSdf
+defaultBasePackageId=mb.minisdf
+defaultArtifactId=minisdf
+defaultVersion=0.1.0

--- a/example/multilang/generated/ministr.cli/build.gradle.kts
+++ b/example/multilang/generated/ministr.cli/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.cli")
+}
+
+languageCliProject {
+  adapterProject.set(project(":ministr.spoofax"))
+}

--- a/example/multilang/generated/ministr.eclipse.externaldeps/build.gradle.kts
+++ b/example/multilang/generated/ministr.eclipse.externaldeps/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.eclipse.externaldeps")
+}
+
+languageEclipseExternaldepsProject {
+  adapterProject.set(project(":ministr.spoofax"))
+}

--- a/example/multilang/generated/ministr.eclipse/build.gradle.kts
+++ b/example/multilang/generated/ministr.eclipse/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.eclipse")
+}
+
+languageEclipseProject {
+  eclipseExternaldepsProject.set(project(":ministr.eclipse.externaldeps"))
+  adapterProject.set(project(":ministr.spoofax"))
+}

--- a/example/multilang/generated/ministr.spoofax/build.gradle.kts
+++ b/example/multilang/generated/ministr.spoofax/build.gradle.kts
@@ -1,0 +1,27 @@
+import mb.spoofax.compiler.adapter.*
+import mb.spoofax.compiler.adapter.data.*
+import mb.spoofax.compiler.gradle.plugin.*
+import mb.spoofax.compiler.util.*
+import mb.spoofax.core.language.command.*
+
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.adapter")
+}
+
+languageAdapterProject {
+  languageProject.set(project(":ministr"))
+  compilerInput {
+    withParser()
+    withStyler()
+    withStrategoRuntime()
+    withMultilangAnalyzer().run {
+      rootModule("mini-str/mini-str-typing")
+      preAnalysisStrategy("pre-analyze")
+      postAnalysisStrategy("post-analyze")
+      contextId("mini-sdf-str")
+      fileConstraint("mini-str/mini-str-typing!mstrProgramOK")
+      projectConstraint("mini-str/mini-str-typing!mstrProjectOK")
+    }
+  }
+}

--- a/example/multilang/generated/ministr/build.gradle.kts
+++ b/example/multilang/generated/ministr/build.gradle.kts
@@ -1,0 +1,46 @@
+import mb.spoofax.compiler.gradle.plugin.*
+import mb.spoofax.compiler.gradle.spoofax2.plugin.*
+import mb.spoofax.compiler.language.*
+import mb.spoofax.compiler.spoofax2.language.*
+import mb.spoofax.compiler.util.*
+
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.gradle.config.junit-testing")
+  id("org.metaborg.spoofax.compiler.gradle.spoofax2.language")
+}
+
+dependencies {
+  api(project(":module"))
+}
+
+languageProject {
+  shared {
+    name("MiniStr")
+    defaultPackageId("mb.ministr")
+  }
+  compilerInput {
+    withParser().run {
+      startSymbol("MSTRStart")
+    }
+    withStyler()
+    withMultilangAnalyzer().run {
+      rootModules(listOf("mini-str/mini-str-typing"))
+    }
+    withStrategoRuntime()
+  }
+}
+
+spoofax2BasedLanguageProject {
+  compilerInput {
+    withParser()
+    withStyler()
+    withStrategoRuntime().run {
+      copyCtree(true)
+      copyClasses(false)
+    }
+    withMultilangAnalyzer()
+    project
+      .languageSpecificationDependency(GradleDependency.project(":ministr.spoofaxcore"))
+  }
+}

--- a/example/multilang/generated/ministr/build.gradle.kts
+++ b/example/multilang/generated/ministr/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 languageProject {
   shared {
     name("MiniStr")
+    fileExtensions(listOf("mstr"))
     defaultPackageId("mb.ministr")
   }
   compilerInput {
@@ -29,6 +30,7 @@ languageProject {
     }
     withStrategoRuntime()
   }
+  statixDependencies.set(listOf(project(":module")))
 }
 
 spoofax2BasedLanguageProject {

--- a/example/multilang/generated/ministr/spoofaxc.lock
+++ b/example/multilang/generated/ministr/spoofaxc.lock
@@ -1,0 +1,5 @@
+defaultGroupId=org.metaborg
+defaultClassPrefix=MiniStr
+defaultBasePackageId=mb.ministr
+defaultArtifactId=ministr
+defaultVersion=0.1.0

--- a/example/multilang/generated/module/build.gradle.kts
+++ b/example/multilang/generated/module/build.gradle.kts
@@ -11,45 +11,26 @@ plugins {
 }
 
 dependencies {
-
+  api(project(":signature"))
 }
 
 languageProject {
   shared {
-    name("Signature")
-    defaultPackageId("mb.signature")
+    name("Module")
+    defaultPackageId("mb.module")
   }
   compilerInput {
-    /* withParser().run {
-      startSymbol("MSDFStart")
-    }
-    withStyler() */
-    /* withConstraintAnalyzer().run {
-      enableNaBL2(false)
-      enableStatix(true)
-      multiFile(true)
-    } */
-    withStrategoRuntime()
     withMultilangAnalyzer().run {
-      rootModules(listOf("cons-type-interface/conflicts/sorts", "cons-type-interface/conflicts/constructors"))
+      rootModules(listOf("module-interface/modules"))
     }
   }
-  statixDependencies.set(listOf())
+  statixDependencies.set(listOf(project(":signature")))
 }
 
 spoofax2BasedLanguageProject {
   compilerInput {
-    /* withParser()
-    withStyler() */
-    /* withConstraintAnalyzer().run {
-      copyStatix(true)
-    } */
-    withStrategoRuntime().run {
-      copyCtree(true)
-      copyClasses(false)
-    }
-    project
-      .languageSpecificationDependency(GradleDependency.project(":signature-interface.spoofaxcore"))
     withMultilangAnalyzer()
+    project
+      .languageSpecificationDependency(GradleDependency.project(":module-interface.spoofaxcore"))
   }
 }

--- a/example/multilang/generated/module/build.gradle.kts
+++ b/example/multilang/generated/module/build.gradle.kts
@@ -1,0 +1,55 @@
+import mb.spoofax.compiler.gradle.plugin.*
+import mb.spoofax.compiler.gradle.spoofax2.plugin.*
+import mb.spoofax.compiler.language.*
+import mb.spoofax.compiler.spoofax2.language.*
+import mb.spoofax.compiler.util.*
+
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.gradle.config.junit-testing")
+  id("org.metaborg.spoofax.compiler.gradle.spoofax2.language")
+}
+
+dependencies {
+
+}
+
+languageProject {
+  shared {
+    name("Signature")
+    defaultPackageId("mb.signature")
+  }
+  compilerInput {
+    /* withParser().run {
+      startSymbol("MSDFStart")
+    }
+    withStyler() */
+    /* withConstraintAnalyzer().run {
+      enableNaBL2(false)
+      enableStatix(true)
+      multiFile(true)
+    } */
+    withStrategoRuntime()
+    withMultilangAnalyzer().run {
+      rootModules(listOf("cons-type-interface/conflicts/sorts", "cons-type-interface/conflicts/constructors"))
+    }
+  }
+  statixDependencies.set(listOf())
+}
+
+spoofax2BasedLanguageProject {
+  compilerInput {
+    /* withParser()
+    withStyler() */
+    /* withConstraintAnalyzer().run {
+      copyStatix(true)
+    } */
+    withStrategoRuntime().run {
+      copyCtree(true)
+      copyClasses(false)
+    }
+    project
+      .languageSpecificationDependency(GradleDependency.project(":signature-interface.spoofaxcore"))
+    withMultilangAnalyzer()
+  }
+}

--- a/example/multilang/generated/module/spoofaxc.lock
+++ b/example/multilang/generated/module/spoofaxc.lock
@@ -1,0 +1,5 @@
+defaultGroupId=org.metaborg
+defaultClassPrefix=Module
+defaultBasePackageId=mb.module
+defaultArtifactId=module
+defaultVersion=0.1.0

--- a/example/multilang/generated/multilang.eclipse/build.gradle.kts
+++ b/example/multilang/generated/multilang.eclipse/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+  id("org.metaborg.coronium.bundle")
+}
+
+fun compositeBuild(name: String) = "$group:$name"
+
+dependencies {
+  api(platform(compositeBuild("spoofax.depconstraints")))
+
+  bundleApi(project(":minisdf.eclipse"))
+  bundleApi(project(":ministr.eclipse"))
+}

--- a/example/multilang/generated/multilang.test/build.gradle.kts
+++ b/example/multilang/generated/multilang.test/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.gradle.config.junit-testing")
+}
+
+dependencies {
+  testCompile("org.metaborg:spoofax.core")
+  testCompile(project(":minisdf.spoofax"))
+  testCompile(project(":ministr.spoofax"))
+
+  testImplementation("org.metaborg:log.backend.slf4j")
+  testImplementation("org.slf4j:slf4j-simple:1.7.30")
+  testImplementation("org.metaborg:pie.runtime")
+  testImplementation("com.google.jimfs:jimfs:1.1")
+  testCompileOnly("org.checkerframework:checker-qual-android")
+}

--- a/example/multilang/generated/multilang.test/src/test/java/mb/multilang/example/MultilangAnalysisTests.java
+++ b/example/multilang/generated/multilang.test/src/test/java/mb/multilang/example/MultilangAnalysisTests.java
@@ -33,8 +33,6 @@ public class MultilangAnalysisTests extends TestBase {
             assertNotNull(msdfMessages);
             assertNotNull(mstrMessages);
 
-            // Because message count and location is not deterministic
-            // We combine the message sets, and assert there are at least some
             assertEquals(0, msdfMessages.size());
             assertEquals(0, mstrMessages.size());
         }

--- a/example/multilang/generated/multilang.test/src/test/java/mb/multilang/example/MultilangAnalysisTests.java
+++ b/example/multilang/generated/multilang.test/src/test/java/mb/multilang/example/MultilangAnalysisTests.java
@@ -1,0 +1,111 @@
+package mb.multilang.example;
+
+import mb.common.message.KeyedMessages;
+import mb.common.result.Result;
+import mb.pie.api.ExecException;
+import mb.pie.api.MixedSession;
+import mb.statix.multilang.ConfigurationException;
+import mb.statix.multilang.metadata.LanguageId;
+import mb.statix.multilang.pie.config.ContextConfig;
+import mb.statix.multilang.pie.config.SmlBuildContextConfiguration;
+import org.junit.jupiter.api.Test;
+import org.metaborg.util.log.Level;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MultilangAnalysisTests extends TestBase {
+
+    @Test public void testMultilangAnalysisSucceeds() throws IOException, ExecException, InterruptedException {
+        createTextFile("module a sorts ID A context-free syntax A.B = <<ID*>>", "a.msdf");
+        createTextFile("module b imports a rules rw: B(lid) -> B([])", "b.mstr");
+
+        try(MixedSession session = newSession()) {
+            KeyedMessages msdfMessages = session.require(miniSdfComponent
+                .getLanguageInstance().createCheckTask(rootDirectory.getKey()));
+
+            KeyedMessages mstrMessages = session.require(miniStrComponent
+                .getLanguageInstance().createCheckTask(rootDirectory.getKey()));
+
+            assertNotNull(msdfMessages);
+            assertNotNull(mstrMessages);
+
+            // Because message count and location is not deterministic
+            // We combine the message sets, and assert there are at least some
+            assertEquals(0, msdfMessages.size());
+            assertEquals(0, mstrMessages.size());
+        }
+    }
+
+    @Test public void testMultilangAnalysisFails() throws IOException, ExecException, InterruptedException {
+        createTextFile("module a sorts ID A context-free syntax A.B = <<ID*>>", "a.msdf");
+        createTextFile("module b imports a rules rw: B(lid) -> B()", "b.mstr");
+
+        try(MixedSession session = newSession()) {
+            KeyedMessages msdfMessages = session.require(miniSdfComponent
+                .getLanguageInstance().createCheckTask(rootDirectory.getKey()));
+
+            KeyedMessages mstrMessages = session.require(miniStrComponent
+                .getLanguageInstance().createCheckTask(rootDirectory.getKey()));
+
+            assertNotNull(msdfMessages);
+            assertNotNull(mstrMessages);
+
+            // Because message count and location is not deterministic
+            // We combine the message sets, and assert there are at least some
+            assertTrue(msdfMessages.size() + mstrMessages.size() > 0);
+        }
+    }
+
+    @Test public void testMultilangAnalysisWithConfigFails() throws IOException, ExecException, InterruptedException {
+        createTextFile("module a sorts ID A context-free syntax A.B = <<ID*>>", "a.msdf");
+        createTextFile("module b imports a rules rw: B(lid) -> B([])", "b.mstr");
+        createTextFile("\n" +
+            "languageContexts:\n" +
+            "  'mb.minisdf': \"mb.minisdf\"\n" +
+            "  'mb.ministr': \"mb.ministr\"", "multilang.yaml");
+
+        try(MixedSession session = newSession()) {
+            KeyedMessages msdfMessages = session.require(miniSdfComponent
+                .getLanguageInstance().createCheckTask(rootDirectory.getKey()));
+
+            KeyedMessages mstrMessages = session.require(miniStrComponent
+                .getLanguageInstance().createCheckTask(rootDirectory.getKey()));
+
+            assertNotNull(msdfMessages);
+            assertNotNull(mstrMessages);
+
+            // Because message count and location is not deterministic
+            // We combine the message sets, and assert there are at least some
+            assertTrue(msdfMessages.size() + mstrMessages.size() > 0);
+        }
+    }
+
+
+    @Test public void readConfig() throws IOException, ExecException, InterruptedException, ConfigurationException {
+        createTextFile("\n" +
+            "languageContexts:\n" +
+            "  'mb.lang1': \"debugContext\"\n" +
+            "  'mb.lang2': \"debugContext\"\n" +
+            "  'mb.lang3': \"lang3\"\n" +
+            "logging:\n" +
+            "  debugContext: debug", "multilang.yaml");
+
+        try(MixedSession session = newSession()) {
+            Result<ContextConfig, ConfigurationException> configResult = session.require(multiLangComponent
+                .getBuildContextConfiguration()
+                .createTask(new SmlBuildContextConfiguration.Input(rootDirectory.getPath(), new LanguageId("mb.lang1"))));
+
+            assertTrue(configResult.isOk());
+            ContextConfig config = configResult.unwrap();
+
+            assertEquals(2, config.languages().size());
+            assertTrue(config.languages().contains(new LanguageId("mb.lang1")));
+            assertTrue(config.languages().contains(new LanguageId("mb.lang2")));
+            assertEquals(Level.Debug, config.parseLevel());
+        }
+    }
+}

--- a/example/multilang/generated/multilang.test/src/test/java/mb/multilang/example/TestBase.java
+++ b/example/multilang/generated/multilang.test/src/test/java/mb/multilang/example/TestBase.java
@@ -1,0 +1,119 @@
+package mb.multilang.example;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import mb.log.api.Logger;
+import mb.log.api.LoggerFactory;
+import mb.log.slf4j.SLF4JLoggerFactory;
+import mb.minisdf.spoofax.DaggerMiniSdfComponent;
+import mb.minisdf.spoofax.MiniSdfComponent;
+import mb.minisdf.spoofax.MiniSdfModule;
+import mb.ministr.spoofax.DaggerMiniStrComponent;
+import mb.ministr.spoofax.MiniStrComponent;
+import mb.ministr.spoofax.MiniStrModule;
+import mb.pie.api.MixedSession;
+import mb.pie.api.Pie;
+import mb.pie.api.ResourceStringSupplier;
+import mb.pie.runtime.PieBuilderImpl;
+import mb.resource.ResourceKey;
+import mb.resource.fs.FSResource;
+import mb.resource.text.TextResourceRegistry;
+import mb.spoofax.core.platform.DaggerPlatformComponent;
+import mb.spoofax.core.platform.LoggerFactoryModule;
+import mb.spoofax.core.platform.PlatformComponent;
+import mb.spoofax.core.platform.PlatformPieModule;
+import mb.statix.multilang.DaggerMultiLangComponent;
+import mb.statix.multilang.MultiLangComponent;
+import mb.statix.multilang.MultiLangModule;
+import mb.statix.multilang.metadata.AnalysisContextService;
+import mb.statix.multilang.metadata.ContextId;
+import mb.statix.multilang.metadata.ImmutableAnalysisContextService;
+import mb.statix.multilang.metadata.LanguageId;
+import mb.statix.multilang.metadata.SpecFragmentId;
+import mb.statix.multilang.metadata.spec.SpecConfig;
+import org.junit.jupiter.api.AfterEach;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.util.HashMap;
+
+public class TestBase {
+
+    public final FileSystem fileSystem = Jimfs.newFileSystem("multilang-test", Configuration.unix());
+    public final FSResource rootDirectory = new FSResource(fileSystem.getPath("/", "virtual-project-dir"));
+
+    public final PlatformComponent platformComponent = DaggerPlatformComponent
+        .builder()
+        .loggerFactoryModule(new LoggerFactoryModule(new SLF4JLoggerFactory()))
+        .platformPieModule(new PlatformPieModule(PieBuilderImpl::new))
+        .build();
+
+    public final LoggerFactory loggerFactory = platformComponent.getLoggerFactory();
+    public final Logger log = loggerFactory.create(TestBase.class);
+    public final TextResourceRegistry textResourceRegistry = platformComponent.getTextResourceRegistry();
+
+    public final MultiLangComponent multiLangComponent = DaggerMultiLangComponent
+        .builder()
+        .platformComponent(platformComponent)
+        .multiLangModule(new MultiLangModule(this::getAnalysisContextService))
+        .build();
+
+    private AnalysisContextService getAnalysisContextService() {
+        HashMap<SpecFragmentId, SpecConfig> specConfigs = new HashMap<>();
+        specConfigs.putAll(miniSdfComponent.getSpecConfigs());
+        specConfigs.putAll(miniStrComponent.getSpecConfigs());
+        return ImmutableAnalysisContextService
+            .builder()
+            .putAllSpecConfigs(specConfigs)
+            .putLanguageMetadataSuppliers(new LanguageId("mb.minisdf"), miniSdfComponent::getLanguageMetadata)
+            .putLanguageMetadataSuppliers(new LanguageId("mb.ministr"), miniStrComponent::getLanguageMetadata)
+            .platformPie(platformComponent.getPie())
+            .putDefaultLanguageContexts(new LanguageId("mb.minisdf"), new ContextId("mb.multilang"))
+            .putDefaultLanguageContexts(new LanguageId("mb.ministr"), new ContextId("mb.multilang"))
+            .build();
+    }
+
+    @SuppressWarnings({"deprecation", "InstantiationOfUtilityClass"})
+    public final MiniSdfComponent miniSdfComponent = DaggerMiniSdfComponent
+        .builder()
+        .platformComponent(platformComponent)
+        .multiLangComponent(multiLangComponent)
+        .miniSdfModule(new MiniSdfModule())
+        .build();
+
+    @SuppressWarnings({"deprecation", "InstantiationOfUtilityClass"})
+    public final MiniStrComponent miniStrComponent = DaggerMiniStrComponent
+        .builder()
+        .platformComponent(platformComponent)
+        .multiLangComponent(multiLangComponent)
+        .miniStrModule(new MiniStrModule())
+        .build();
+
+    public final Pie pie = miniSdfComponent.getPie();
+
+    public FSResource createTextFile(FSResource rootDirectory, String text, String relativePath) throws IOException {
+        final FSResource resource = rootDirectory.appendRelativePath(relativePath);
+        resource.createFile(true);
+        resource.writeString(text, StandardCharsets.UTF_8);
+        return resource;
+    }
+
+    public FSResource createTextFile(String text, String relativePath) throws IOException {
+        return createTextFile(this.rootDirectory, text, relativePath);
+    }
+
+    public ResourceStringSupplier resourceStringSupplier(ResourceKey resourceKey) {
+        return new ResourceStringSupplier(resourceKey);
+    }
+
+    public MixedSession newSession() {
+        return pie.newSession();
+    }
+
+    @AfterEach public void cleanupFs() throws IOException {
+        if(fileSystem != null && fileSystem.isOpen()) {
+            fileSystem.close();
+        }
+    }
+}

--- a/example/multilang/generated/multilang.test/src/test/java/mb/multilang/example/TestBase.java
+++ b/example/multilang/generated/multilang.test/src/test/java/mb/multilang/example/TestBase.java
@@ -59,21 +59,6 @@ public class TestBase {
         .multiLangModule(new MultiLangModule(this::getAnalysisContextService))
         .build();
 
-    private AnalysisContextService getAnalysisContextService() {
-        HashMap<SpecFragmentId, SpecConfig> specConfigs = new HashMap<>();
-        specConfigs.putAll(miniSdfComponent.getSpecConfigs());
-        specConfigs.putAll(miniStrComponent.getSpecConfigs());
-        return ImmutableAnalysisContextService
-            .builder()
-            .putAllSpecConfigs(specConfigs)
-            .putLanguageMetadataSuppliers(new LanguageId("mb.minisdf"), miniSdfComponent::getLanguageMetadata)
-            .putLanguageMetadataSuppliers(new LanguageId("mb.ministr"), miniStrComponent::getLanguageMetadata)
-            .platformPie(platformComponent.getPie())
-            .putDefaultLanguageContexts(new LanguageId("mb.minisdf"), new ContextId("mb.multilang"))
-            .putDefaultLanguageContexts(new LanguageId("mb.ministr"), new ContextId("mb.multilang"))
-            .build();
-    }
-
     @SuppressWarnings({"deprecation", "InstantiationOfUtilityClass"})
     public final MiniSdfComponent miniSdfComponent = DaggerMiniSdfComponent
         .builder()
@@ -109,6 +94,22 @@ public class TestBase {
 
     public MixedSession newSession() {
         return pie.newSession();
+    }
+
+
+    private AnalysisContextService getAnalysisContextService() {
+        HashMap<SpecFragmentId, SpecConfig> specConfigs = new HashMap<>();
+        specConfigs.putAll(miniSdfComponent.getSpecConfigs());
+        specConfigs.putAll(miniStrComponent.getSpecConfigs());
+        return ImmutableAnalysisContextService
+            .builder()
+            .putAllSpecConfigs(specConfigs)
+            .putLanguageMetadataSuppliers(new LanguageId("mb.minisdf"), miniSdfComponent::getLanguageMetadata)
+            .putLanguageMetadataSuppliers(new LanguageId("mb.ministr"), miniStrComponent::getLanguageMetadata)
+            .platformPie(platformComponent.getPie())
+            .putDefaultLanguageContexts(new LanguageId("mb.minisdf"), new ContextId("mb.multilang"))
+            .putDefaultLanguageContexts(new LanguageId("mb.ministr"), new ContextId("mb.multilang"))
+            .build();
     }
 
     @AfterEach public void cleanupFs() throws IOException {

--- a/example/multilang/generated/multilang.test/src/test/java/mb/multilang/package-info.java
+++ b/example/multilang/generated/multilang.test/src/test/java/mb/multilang/package-info.java
@@ -1,0 +1,5 @@
+@DefaultQualifier(NonNull.class)
+package mb.multilang;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;

--- a/example/multilang/generated/signature/build.gradle.kts
+++ b/example/multilang/generated/signature/build.gradle.kts
@@ -1,0 +1,55 @@
+import mb.spoofax.compiler.gradle.plugin.*
+import mb.spoofax.compiler.gradle.spoofax2.plugin.*
+import mb.spoofax.compiler.language.*
+import mb.spoofax.compiler.spoofax2.language.*
+import mb.spoofax.compiler.util.*
+
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.gradle.config.junit-testing")
+  id("org.metaborg.spoofax.compiler.gradle.spoofax2.language")
+}
+
+dependencies {
+
+}
+
+languageProject {
+  shared {
+    name("Signature")
+    defaultPackageId("mb.signature")
+  }
+  compilerInput {
+    /* withParser().run {
+      startSymbol("MSDFStart")
+    }
+    withStyler() */
+    /* withConstraintAnalyzer().run {
+      enableNaBL2(false)
+      enableStatix(true)
+      multiFile(true)
+    } */
+    withStrategoRuntime()
+    withMultilangAnalyzer().run {
+      rootModules(listOf("cons-type-interface/conflicts/sorts", "cons-type-interface/conflicts/constructors"))
+    }
+  }
+  statixDependencies.set(listOf())
+}
+
+spoofax2BasedLanguageProject {
+  compilerInput {
+    /* withParser()
+    withStyler() */
+    /* withConstraintAnalyzer().run {
+      copyStatix(true)
+    } */
+    withStrategoRuntime().run {
+      copyCtree(true)
+      copyClasses(false)
+    }
+    project
+      .languageSpecificationDependency(GradleDependency.project(":signature-interface.spoofaxcore"))
+    withMultilangAnalyzer()
+  }
+}

--- a/example/multilang/generated/signature/build.gradle.kts
+++ b/example/multilang/generated/signature/build.gradle.kts
@@ -10,46 +10,22 @@ plugins {
   id("org.metaborg.spoofax.compiler.gradle.spoofax2.language")
 }
 
-dependencies {
-
-}
-
 languageProject {
   shared {
     name("Signature")
     defaultPackageId("mb.signature")
   }
   compilerInput {
-    /* withParser().run {
-      startSymbol("MSDFStart")
-    }
-    withStyler() */
-    /* withConstraintAnalyzer().run {
-      enableNaBL2(false)
-      enableStatix(true)
-      multiFile(true)
-    } */
-    withStrategoRuntime()
     withMultilangAnalyzer().run {
       rootModules(listOf("cons-type-interface/conflicts/sorts", "cons-type-interface/conflicts/constructors"))
     }
   }
-  statixDependencies.set(listOf())
 }
 
 spoofax2BasedLanguageProject {
   compilerInput {
-    /* withParser()
-    withStyler() */
-    /* withConstraintAnalyzer().run {
-      copyStatix(true)
-    } */
-    withStrategoRuntime().run {
-      copyCtree(true)
-      copyClasses(false)
-    }
+    withMultilangAnalyzer()
     project
       .languageSpecificationDependency(GradleDependency.project(":signature-interface.spoofaxcore"))
-    withMultilangAnalyzer()
   }
 }

--- a/example/multilang/generated/signature/spoofaxc.lock
+++ b/example/multilang/generated/signature/spoofaxc.lock
@@ -1,0 +1,5 @@
+defaultGroupId=org.metaborg
+defaultClassPrefix=Signature
+defaultBasePackageId=mb.signature
+defaultArtifactId=signature
+defaultVersion=0.1.0

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/.gitignore
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/.gitignore
@@ -1,0 +1,11 @@
+/.cache
+/bin
+/src-gen
+/target
+
+/.classpath
+/.project
+/.settings
+/.factorypath
+
+/.polyglot.metaborg.yaml

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/build.gradle.kts
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  id("org.metaborg.spoofax.gradle.langspec")
+  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
+  `maven-publish`
+}
+
+ecj {
+  toolVersion = "3.20.0"
+}
+
+dependencies {
+  sourceLanguage(project(":signature-interface.spoofaxcore"))
+}

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/editor/Analysis.esv
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/editor/Analysis.esv
@@ -1,0 +1,23 @@
+module Analysis
+
+imports
+
+  statix/Menus
+
+language
+
+  // see README.md for details on how to switch to multi-file analysis
+
+  observer : editor-analyze (constraint) (multifile)
+
+references
+
+  reference _ : editor-resolve
+
+  hover _ : editor-hover
+
+menus
+
+  menu: "Analysis"
+  
+  action: "Show scope graph"		= stx--show-scopegraph (openeditor)

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/editor/Main.esv
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/editor/Main.esv
@@ -1,0 +1,12 @@
+module Main
+
+imports
+
+  Syntax
+  Analysis
+
+language
+
+  extensions : msdf
+
+  provider : target/metaborg/stratego.ctree

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/editor/Syntax.esv
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/editor/Syntax.esv
@@ -1,0 +1,27 @@
+module Syntax
+
+imports
+
+  libspoofax/color/default
+  completion/colorer/minisdf-cc-esv
+
+language
+
+  table         : target/metaborg/sdf.tbl
+  start symbols : MSDFStart
+
+  line comment  : "//"
+  block comment : "/*" * "*/"
+  fences        : [ ] ( ) { }
+
+menus
+
+  menu: "Syntax" (openeditor)
+
+    action: "Format"          		= editor-format (source)
+    action: "Show parsed AST" 		= debug-show-aterm (source)
+
+views
+
+  outline view: editor-outline (source)
+    expand to level: 3

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/metaborg.yaml
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/metaborg.yaml
@@ -1,0 +1,47 @@
+---
+id: org.metaborg:lang-minisdf:0.1.0-SNAPSHOT
+name: minisdf
+dependencies:
+  compile:
+  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:statix.lang:${metaborgVersion}
+  - org.metaborg:sdf3.ext.statix:${metaborgVersion}
+  source:
+  - org.metaborg:meta.lib.spoofax:${metaborgVersion}
+  - org.metaborg:statix.runtime:${metaborgVersion}
+pardonedLanguages:
+- EditorService
+- Stratego-Sugar
+- SDF
+debug:
+  typesmart: false
+language:
+  sdf:
+    pretty-print: minisdf
+    sdf2table: java
+    placeholder:
+      prefix: "$"
+  stratego:
+    format: ctree
+    args:
+    - -la
+    - stratego-lib
+    - -la
+    - stratego-sglr
+    - -la
+    - stratego-gpp
+    - -la
+    - stratego-xtc
+    - -la
+    - stratego-aterm
+    - -la
+    - stratego-sdf
+    - -la
+    - strc
+exports:
+- language: ATerm
+  directory: src-gen/statix
+  includes:
+    - signatures/**/*.aterm
+    - mini-sdf/**/*.aterm

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/syntax/mini-sdf/mini-sdf.sdf3
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/syntax/mini-sdf/mini-sdf.sdf3
@@ -1,0 +1,63 @@
+module mini-sdf/mini-sdf
+
+imports
+  minisdf-common
+
+lexical sorts
+  MODNAME KW ID
+
+context-free sorts
+  MSDFStart MSDFSection
+  SortTerm SortRef
+  ProdTerm Production
+
+lexical syntax
+  MODNAME 		= [a-zA-Z0-9\-\/]+
+  KW			= ~[\<\>\ ]+
+  ID			= [a-zA-Z] [a-zA-Z0-9\-]*
+
+  MODNAME = "context-free" 		{reject}
+  MODNAME = "rules" 			{reject}
+  MODNAME = "signatures"	 	{reject}
+  MODNAME = "sorts"				{reject}
+
+lexical restrictions
+  KW	 		-/- ~[\<\>\ \r]
+  MODNAME	 	-/- [a-zA-Z0-9\-\/]
+  ID 			-/- [a-zA-Z0-9\-]
+
+context-free syntax
+
+  MSDFStart.MSDFModule = <
+    module <MODNAME>
+      <{MSDFSection "\n"}*>
+    >
+
+  MSDFSection.ImportSection = <
+  	imports
+    	<{MODNAME "\n"}*>
+    >
+
+  MSDFSection.SortsDecl = <
+  	sorts
+    	<{ID "\n"}*>
+    >
+
+  MSDFSection.ContextFreeSyntax = <
+  	context-free syntax
+    	<{Production "\n"}*>
+    >
+
+  Production.Production = [
+  	[ID].[ID] = <[{ProdTerm " "}*]>
+  ]
+
+  ProdTerm.Terminal = <<KW>>
+  ProdTerm.SortTerm = [<[SortTerm]>]
+
+  SortTerm.Plus 	= <<SortTerm>+> 	{non-assoc}
+  SortTerm.Option	= <<SortTerm>?>		{non-assoc}
+  SortTerm.IterStar	= <<SortTerm>*>		{non-assoc}
+  SortTerm.Ref		= SortRef
+
+  SortRef.SortRef   = <<ID>>

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/syntax/minisdf-common.sdf3
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/syntax/minisdf-common.sdf3
@@ -1,0 +1,28 @@
+module minisdf-common
+
+lexical syntax
+
+  LAYOUT         = [\ \t\n\r]
+  CommentChar    = [\*]
+  LAYOUT         = "/*" InsideComment* "*/"
+  InsideComment  = ~[\*]
+  InsideComment  = CommentChar
+  LAYOUT         = "//" ~[\n\r]* NewLineEOF
+  NewLineEOF     = [\n\r]
+  NewLineEOF     = EOF
+  EOF            =
+
+lexical restrictions
+
+  // Ensure greedy matching for lexicals
+  CommentChar   -/- [\/]
+
+  // EOF may not be followed by any char
+  EOF           -/- ~[]
+
+context-free restrictions
+
+  // Ensure greedy matching for comments
+  LAYOUT? -/- [\ \t\n\r]
+  LAYOUT? -/- [\/].[\/]
+  LAYOUT? -/- [\/].[\*]

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/syntax/minisdf.sdf3
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/syntax/minisdf.sdf3
@@ -1,0 +1,9 @@
+module minisdf
+
+imports
+
+  mini-sdf/mini-sdf
+
+context-free start-symbols
+
+  MSDFStart

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/analysis.str
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/analysis.str
@@ -1,0 +1,37 @@
+module analysis
+
+imports
+
+  statixruntime
+  statix/api
+
+  pp
+
+  injections/-
+
+rules
+
+  // multi-file analysis
+  editor-analyze = stx-editor-analyze(pre-analyze, post-analyze |"mini-sdf/mini-sdf-typing", "msdfProjectOK", "msdfProgramOK")
+  pre-analyze = explicate-injections-minisdf
+  post-analyze = strip-annos; implicate-injections-minisdf
+
+rules // Editor Services
+
+  editor-resolve = stx-editor-resolve
+
+  editor-hover = stx-editor-hover
+
+rules // Debugging
+
+  // Prints the abstract syntax ATerm of a selection.
+  debug-show-aterm: (selected, _, _, path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"aterm")> path
+       ; result   := selected
+
+rules
+
+  // Prints the analyzed annotated abstract syntax ATerm of a selection.
+  debug-show-analyzed: (selected, _, _, path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"analyzed.aterm")> path
+       ; result   := selected

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/conflicts/constructors.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/conflicts/constructors.stx
@@ -1,0 +1,54 @@
+module cons-type-interface/conflicts/constructors
+
+imports
+  module-interface/modules
+  cons-type-interface/constructors
+
+signature
+
+  sorts CTI = (string * int * TAG) // Constructor type info
+
+rules
+
+  conssUnique: scope * scope
+
+  conssUnique(s_imp, s_mod) :- {CM CI}
+    conssInScope(s_mod) == CM, // Constructors in imported module scope
+    importedConss(s_imp) == CI, // Constructors imported in importing module scope
+    conssDisjoint(CM, CI).
+
+rules
+
+  conssInScope : scope -> list(CTI)
+  
+  conssInScope(s) = typeInfosOfConss(C) :-
+    query cons
+      filter resolveMatch[Cons{_}]
+      in s |-> C.
+
+rules
+
+  importedConss : scope -> list(CTI)
+  
+  importedConss(s) = typeInfosOfConss(C) :-
+    query cons
+      filter resolveMatch[Cons{_}] & ~e
+      in s |-> C.
+
+rules
+
+  typeInfosOfConss maps typeInfoOfCons(list(*)) = list(*)
+  typeInfoOfCons: (path * (occurrence * CONS)) -> CTI
+
+  typeInfoOfCons((_, (Cons{n}, CONS(_, _, a, id)))) = (n, a, id).
+
+rules
+  // Double maps to validate each pair
+  conssDisjoint maps consDisjoint(list(*), *)
+  consDisjoint maps consPairDisjoint(*, list(*))
+ 
+  consPairDisjoint: CTI * CTI
+
+  consPairDisjoint((n, a, id1), (n, a, id2)) :-
+    id1 == id2 | error $[Duplicate import of cons [n]/[a]].
+  consPairDisjoint((n1, _, _), (n2, _, _)).

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/conflicts/sorts.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/conflicts/sorts.stx
@@ -1,0 +1,53 @@
+module cons-type-interface/conflicts/sorts
+
+imports
+  module-interface/modules
+  cons-type-interface/sorts
+
+signature
+
+  sorts STI = (string * TAG) // Sort type info
+
+rules
+
+  sortsUnique: scope * scope
+
+  sortsUnique(s_imp, s_mod) :- {SM SI}
+    sortsInScope(s_mod) == SM, // Sorts in imported module scope
+    importedSorts(s_imp) == SI, // Sorts imported in importing module scope
+    sortsDisjoint(SM, SI).
+
+rules
+
+  sortsInScope : scope -> list(STI)
+  
+  sortsInScope(s) = typeInfosOfSorts(S) :-
+    sort of Sort{_} in s |-> S.
+
+rules
+
+  importedSorts : scope -> list(STI)
+  
+  importedSorts(s) = typeInfosOfSorts(S) :-
+    query sort
+      filter resolveMatch[Sort{_}] & ~e
+      in s |-> S.
+
+rules
+
+  typeInfosOfSorts maps typeInfoOfSort(list(*)) = list(*)
+  typeInfoOfSort: (path * (occurrence * TYPE)) -> STI
+
+  typeInfoOfSort((_, (Sort{n}, TSORT(id, _)))) = (n, id).
+
+
+rules
+  // Double maps to validate each pair
+  sortsDisjoint maps sortDisjoint(list(*), *)
+  sortDisjoint maps sortPairDisjoint(*, list(*))
+ 
+  sortPairDisjoint: STI * STI
+
+  sortPairDisjoint((n, id1), (n, id2)) :-
+    id1 == id2 | error $[Duplicate import of sort [n]].
+  sortPairDisjoint((n1, _), (n2, _)).

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/constructors.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/constructors.stx
@@ -1,0 +1,62 @@
+module cons-type-interface/constructors
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+  namespaces
+  
+    Cons : string
+
+  relations
+
+    cons: occurrence * CONS
+
+  name-resolution
+
+    resolve Cons
+      filter P* I* // Transitive imports. If not: sort of imported cons might not be found
+      min $ < P, $ < I, P < I
+
+rules
+
+  declareCons : scope * TYPE * string * list(TYPE)
+
+  declareCons(s, T, n, y) :- {a ctag}
+    new ctag,
+    a == arityOfSig(y),
+    s -> Cons{n} with cons CONS(T, y, a, ctag),
+    // Check for constructors with same name in same scope
+    query cons
+      filter e and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [_] | error $[Duplicate declaration of constructor [n]/[a].],
+    // Check for constructors with same name in imported modules
+    query cons
+      filter resolveMatch[Cons{n}] & ~e and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [] | error $[Shadowing imported constructor [n]/[a].].
+
+rules
+
+  typeOfCons : scope * int * string -> CONS
+
+  typeOfCons(s, a, n) = C :- {res}
+    query cons
+      filter resolveMatch[Cons{n}] and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [(_, (_, C))| _]
+          | error $[Constructor [n]/[a] not declared].
+
+//rules
+//
+//  arityMatch: (occurrence * CONS) * int
+//  arityMatch((Cons{n}, CONS(_, _, a, _)), a).
+
+rules
+
+  arityOfSig : list(TYPE) -> int
+
+  arityOfSig([]) = 0.
+  arityOfSig([_]) = 1.  
+  arityOfSig([h|t]) = res :- {ts}
+    ts == arityOfSig(t),
+    res #= ts + 1.

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/labels.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/labels.stx
@@ -1,0 +1,15 @@
+module cons-type-interface/labels
+
+signature
+  name-resolution
+    labels
+      P // lexical parent
+      I // Module import
+
+rules
+
+  scopesEqual: list(scope)
+
+  scopesEqual([_]).
+  scopesEqual([s, s]).
+  scopesEqual([s, s | tail]) :- scopesEqual([s | tail]).

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/sorts.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/sorts.stx
@@ -1,0 +1,52 @@
+module cons-type-interface/sorts
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+  namespaces
+  
+    Sort : string
+
+  relations
+
+    sort: occurrence -> TYPE // Map sort declaration to its type
+
+  name-resolution
+
+    resolve Sort
+      filter P* I* // Transitive imports. If not: sort of imported cons might not be found
+      min $ < P, $ < I, P < I
+
+rules
+
+  // Rule validating if sorts match (e.g. when adding injections)
+  // signature: expected sort at position * actual sort at position
+  typeEq: TYPE * TYPE
+
+  // Equal sorts match
+  typeEq(a, a).
+
+rules
+
+  declareSort: scope * string
+
+  declareSort(s, n) :- {stag}
+    new stag,
+    s -> Sort{n} with sort TSORT(stag, n),
+    // Check for srts with same name in same scope
+    query sort
+      filter e and { t :- t == Sort{n} }
+      in s |-> [_] | error $[Duplicate declaration of sort [n]],
+    // Check for sorts with same name in imported modules
+    query sort
+      filter resolveMatch[Sort{n}] & ~e and { t :- t == Sort{n} }
+      in s |-> [] | error $[Shadowing imported sort [n]].
+
+rules
+
+  typeOfSort: scope * string -> TYPE
+  typeOfSort(s, n) = T :- {res}
+    sort of Sort{n} in s |-> [(_, (_, T)) | _]
+        | error $[Sort [n] not declared].

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/types.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/cons-type-interface/types.stx
@@ -1,0 +1,14 @@
+module cons-type-interface/types
+
+signature
+
+  sorts TAG = scope
+
+  sorts TYPE constructors
+    TSORT 		: TAG * string -> TYPE
+    TOPT		: TYPE -> TYPE
+    TITER		: TYPE -> TYPE
+    TSTAR		: TYPE -> TYPE
+
+  sorts CONS constructors
+    CONS	: TYPE * list(TYPE) * int * TAG -> CONS // Arity stored explicitly to work around unresolved queries

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/imports/imports.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/imports/imports.stx
@@ -1,0 +1,30 @@
+module mini-sdf/imports/imports
+
+imports
+  module-interface/modules
+  cons-type-interface/sorts
+  signatures/mini-sdf/mini-sdf-sig
+
+  cons-type-interface/conflicts/sorts
+  cons-type-interface/conflicts/constructors
+
+signature
+
+  // Add SDF module type
+  constructors
+    SDFMod : ModuleType
+
+rules
+
+  sdfImportsOk maps sdfImportOk(*, list(*))
+
+  sdfImportOk : scope * MODNAME
+
+  sdfImportOk(s, n) :-
+    import(s, n, SDFMod()).
+
+rules
+
+  itemsOk(_, _, SDFMod(), s_imp, s_mod) :-
+    sortsUnique(s_imp, s_mod),
+    conssUnique(s_imp, s_mod).

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/mini-sdf-typing.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/mini-sdf-typing.stx
@@ -1,0 +1,39 @@
+module mini-sdf/mini-sdf-typing
+
+imports
+  signatures/mini-sdf/mini-sdf-sig
+
+  cons-type-interface/labels
+  module-interface/modules
+
+  mini-sdf/sorts/sorts
+  mini-sdf/productions/productions
+  mini-sdf/imports/imports
+
+rules
+
+  msdfProjectOK : scope
+
+  msdfProjectOK(_).
+
+rules
+
+  msdfProgramOK : scope * MSDFStart
+  msdfProgramOK(s, MSDFModule(n, sec)) :- {s_mod}
+	new s_mod,
+	s_mod -P-> s,
+    declareMod(s, n, s_mod, SDFMod()),
+    sectionsOK(s_mod, sec).
+
+rules
+
+  sectionsOK maps sectionOk(*, list(*))
+
+  sectionOk : scope * MSDFSection
+
+  sectionOk(s, SortsDecl(str)) :-
+    sortsOk(s, str).
+  sectionOk(s, ContextFreeSyntax(prd)) :-
+    prodsOk(s, prd).
+  sectionOk(s, ImportSection(i)) :-
+    sdfImportsOk(s, i).

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/productions/productions.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/productions/productions.stx
@@ -1,0 +1,21 @@
+module mini-sdf/productions/productions
+
+imports
+  cons-type-interface/types
+  cons-type-interface/constructors
+  cons-type-interface/sorts
+
+  signatures/mini-sdf/mini-sdf-sig
+  mini-sdf/sorts/sorts
+  mini-sdf/productions/terms
+
+rules
+
+  prodsOk maps prodOk(*, list(*))
+
+  prodOk: scope * Production
+  prodOk(s, Production(sn, cn, t)) :-
+    {T T1}
+    typeOfSort(s, sn) == T,
+    typeOfTerms(s, prodTerms(t)) == T1,
+    declareCons(s, T, cn, T1).

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/productions/terms.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/productions/terms.stx
@@ -1,0 +1,31 @@
+module mini-sdf/productions/terms
+
+imports
+  signatures/mini-sdf/mini-sdf-sig
+  cons-type-interface/types
+  cons-type-interface/sorts
+
+rules
+
+  // Filter away Terminals, since they do not have a sort
+  // (and hence don't need type-checking, or a position in the constructor signature)
+  prodTerms: list(ProdTerm) -> list(ProdTerm)
+  prodTerms([]) = [].
+  prodTerms([Terminal(_) | tl]) = prodTerms(tl).
+  prodTerms([s@SortTerm(_) | tl]) = [s | prodTerms(tl)].
+
+rules
+
+  typeOfTerms maps typeOfTerm(*, list(*)) = list(*)
+
+  typeOfTerm: scope * ProdTerm -> TYPE
+  typeOfTerm(s_root, SortTerm(t)) = typeOfSortTerm(s_root, t).
+
+rules
+
+  typeOfSortTerm : scope * SortTerm -> TYPE
+
+  typeOfSortTerm(s, Plus(t)) 					= TITER(typeOfSortTerm(s, t)).
+  typeOfSortTerm(s, Option(t)) 					= TOPT(typeOfSortTerm(s, t)).
+  typeOfSortTerm(s, IterStar(t)) 				= TSTAR(typeOfSortTerm(s, t)).
+  typeOfSortTerm(s, Ref(SortRef(n)))	        = typeOfSort(s, n).

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/sorts/sorts.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/mini-sdf/sorts/sorts.stx
@@ -1,0 +1,14 @@
+module mini-sdf/sorts/sorts
+
+imports
+  signatures/mini-sdf/mini-sdf-sig
+  cons-type-interface/types
+  cons-type-interface/sorts
+
+rules
+
+  sortsOk maps sortOk(*, list(*))
+
+  sortOk: scope * ID
+  sortOk(s, n) :-
+    declareSort(s, n).

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/minisdf.str
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/minisdf.str
@@ -1,0 +1,16 @@
+module minisdf
+
+imports
+
+  completion/completion
+  pp
+  outline
+  analysis
+
+rules // Debugging
+
+  debug-show-aterm:
+    (node, _, _, path, project-path) -> (filename, result)
+    with
+      filename := <guarantee-extension(|"aterm")> path
+    ; result   := node

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/module-interface/modules.stx
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/module-interface/modules.stx
@@ -1,0 +1,54 @@
+module module-interface/modules
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+
+  namespaces
+    Module : string
+
+  sorts MODULE constructors
+    MODULE : scope * ModuleType -> MODULE
+
+  sorts ModuleType // Extension point to maintain data for import validating
+  
+  relations
+    modType : occurrence -> MODULE
+
+  name-resolution
+
+    resolve Module filter P*
+
+rules
+
+  modTypesOk: ModuleType * ModuleType
+  modTypesOk(t, t).
+
+  // Rule used for validating unique import of sorts/conss/rules
+  itemsOk: string * ModuleType * ModuleType * scope * scope
+
+rules
+
+  declareMod: scope * string * scope * ModuleType
+
+  declareMod(s, n, s_mod, T) :-
+    s -> Module{n} with modType MODULE(s_mod, T),
+    // Validate module name unique
+    modType of Module{n} in s |-> [_]
+      | error $[Module [n] declared multiple times].
+
+rules
+
+  import: scope * string * ModuleType
+
+  import(s_imp, n, T) :- {s_mod T1}
+    s_imp -I-> s_mod,
+    modType of Module{n} in s_imp |-> [(_, (_, MODULE(s_mod, T1))) | _]
+        | error $[Module [n] could not be found],
+    // Validate module type combination is correct.
+    try { modTypesOk(T, T1) }
+        | error $[Module of type [T] cannot import module of type [T1]],
+    // Validate no comflicts in imported constructs
+    itemsOk(n, T, T1, s_imp, s_mod).

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/outline.str
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/outline.str
@@ -1,0 +1,15 @@
+module outline
+
+imports
+
+  signatures/minisdf-sig
+  libspoofax/editor/outline
+
+rules
+
+  editor-outline:
+    (_, _, ast, path, project-path) -> outline
+    where
+      outline := <simple-label-outline(to-outline-label)> ast
+
+  to-outline-label = fail

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/pp.str
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/trans/pp.str
@@ -1,0 +1,49 @@
+module pp
+
+imports
+
+  libstratego-gpp
+  libspoofax/sdf/pp
+  libspoofax/editor/refactoring/-
+  pp/minisdf-parenthesize
+  pp/minisdf-pp
+
+rules
+
+  editor-format:
+    (node, _, ast, path, project-path) -> (filename, result)
+    with
+      ext      := <get-extension> path
+    ; filename := <guarantee-extension(|$[pp.[ext]])> path
+    ; result   := <pp-debug> node
+
+rules
+
+  pp-minisdf-string =
+    parenthesize-minisdf
+    ; prettyprint-minisdf-start-symbols
+    ; !V([], <id>)
+    ; box2text-string(|120)
+
+  pp-partial-minisdf-string =
+    parenthesize-minisdf
+    ; prettyprint-minisdf
+    ; !V([], <id>)
+    ; box2text-string(|120)
+
+  pp-partial-minisdf-string(|sort) =
+    parenthesize-minisdf
+    ; prettyprint-minisdf(|sort)
+    ; !V([], <id>)
+    ; box2text-string(|120)
+
+  pp-debug :
+    ast -> result
+    with
+       result := <pp-minisdf-string> ast
+    <+ <bottomup(try(not(is-string); not(is-list); not(pp-minisdf-string); debug(!"cannot pp ")))> ast
+    ;  result := ""
+
+rules
+
+  construct-textual-change = construct-textual-change(pp-partial-minisdf-string, parenthesize, override-reconstruction, resugar)

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/.gitignore
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/.gitignore
@@ -1,0 +1,11 @@
+/.cache
+/bin
+/src-gen
+/target
+
+/.classpath
+/.project
+/.settings
+/.factorypath
+
+/.polyglot.metaborg.yaml

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/build.gradle.kts
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  id("org.metaborg.spoofax.gradle.langspec")
+  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
+  `maven-publish`
+}
+
+ecj {
+  toolVersion = "3.20.0"
+}
+
+dependencies {
+  sourceLanguage(project(":signature-interface.spoofaxcore"))
+}

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/editor/Analysis.esv
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/editor/Analysis.esv
@@ -1,0 +1,23 @@
+module Analysis
+
+imports
+
+  statix/Menus
+
+language
+
+  // see README.md for details on how to switch to multi-file analysis
+
+  observer : editor-analyze (constraint) (multifile)
+
+references
+
+  reference _ : editor-resolve
+
+  hover _ : editor-hover
+
+menus
+
+  menu: "Analysis"
+  
+  action: "Show scope graph"		= stx--show-scopegraph (openeditor)

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/editor/Main.esv
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/editor/Main.esv
@@ -1,0 +1,12 @@
+module Main
+
+imports
+
+  Syntax
+  Analysis
+
+language
+
+  extensions : mstr
+
+  provider : target/metaborg/stratego.ctree

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/editor/Syntax.esv
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/editor/Syntax.esv
@@ -1,0 +1,27 @@
+module Syntax
+
+imports
+
+  libspoofax/color/default
+  completion/colorer/ministr-cc-esv
+
+language
+
+  table         : target/metaborg/sdf.tbl
+  start symbols : MSTRStart
+
+  line comment  : "//"
+  block comment : "/*" * "*/"
+  fences        : [ ] ( ) { }
+
+menus
+
+  menu: "Syntax" (openeditor)
+
+    action: "Format"          		= editor-format (source)
+    action: "Show parsed AST" 		= debug-show-aterm (source)
+
+views
+
+  outline view: editor-outline (source)
+    expand to level: 3

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/metaborg.yaml
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/metaborg.yaml
@@ -1,0 +1,47 @@
+---
+id: org.metaborg:lang-ministr:0.1.0-SNAPSHOT
+name: ministr
+dependencies:
+  compile:
+  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:statix.lang:${metaborgVersion}
+  - org.metaborg:sdf3.ext.statix:${metaborgVersion}
+  source:
+  - org.metaborg:meta.lib.spoofax:${metaborgVersion}
+  - org.metaborg:statix.runtime:${metaborgVersion}
+pardonedLanguages:
+- EditorService
+- Stratego-Sugar
+- SDF
+debug:
+  typesmart: false
+language:
+  sdf:
+    pretty-print: ministr
+    sdf2table: java
+    placeholder:
+      prefix: "$"
+  stratego:
+    format: ctree
+    args:
+    - -la
+    - stratego-lib
+    - -la
+    - stratego-sglr
+    - -la
+    - stratego-gpp
+    - -la
+    - stratego-xtc
+    - -la
+    - stratego-aterm
+    - -la
+    - stratego-sdf
+    - -la
+    - strc
+exports:
+- language: ATerm
+  directory: src-gen/statix
+  includes:
+    - signatures/**/*.aterm
+    - mini-str/**/*.aterm

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/syntax/mini-str/mini-str.sdf3
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/syntax/mini-str/mini-str.sdf3
@@ -1,0 +1,89 @@
+module mini-str/mini-str
+
+imports
+  ministr-common
+
+lexical sorts
+  MOD
+  SMBL
+
+context-free sorts
+  MSTRStart MSTRSection SignatureSection
+  ConstructorDef ArgSort
+  RuleDef With Pattern Strategy
+
+lexical syntax
+  MOD 				= [a-zA-Z0-9\-\/]+
+  SMBL				= [a-zA-Z] [a-zA-Z0-9\-]*
+
+  MOD			 	= "rules" 				{reject}
+  MOD 				= "context-free" 		{reject}
+  SMBL				= "rules" 				{reject}
+  SMBL				= "imports" 			{reject}
+  SMBL				= "constructors" 		{reject}
+
+lexical restrictions
+  SMBL	 			-/- [a-zA-Z]
+  MOD				-/- [a-zA-Z0-9\-\/]
+  SMBL				-/- [a-zA-Z0-9\-]
+
+context-free syntax
+
+  MSTRStart.MSTRModule = <
+    module <MOD>
+      <{MSTRSection "\n"}*>
+    >
+
+  MSTRSection.Imports = <
+    imports
+        <{MOD "\n"}*>
+  >
+
+  MSTRSection.Rules = <
+    rules
+        <{RuleDef "\n"}*>
+  >
+
+  MSTRSection.Signatures = <
+    signatures
+        <{SignatureSection "\n"}*>
+  >
+
+  SignatureSection.Sorts = <
+  	sorts
+  		<{SMBL " "}*>
+  >
+
+  SignatureSection.Constructors = <
+  	constructors
+  		<{ConstructorDef "\n"}*>
+  	>
+
+  ConstructorDef.NoArgs = <<SMBL> : <SMBL>>
+  ConstructorDef.WithArgs = [[SMBL] : [{ArgSort "*"}+] -> [SMBL]]
+
+  ArgSort.Sort		= <<SMBL>>
+  ArgSort.Opt 		= <<SMBL>?>
+  ArgSort.Iter 		= <<SMBL>+>
+  ArgSort.Star 		= <<SMBL>*>
+
+  RuleDef.RewriteRuleDef = [
+    [SMBL]: [Pattern] -> [Pattern] [With]
+  ]
+
+  With.NoWith =
+  With.With = <
+    with
+      <Strategy>
+  >
+
+  Pattern.Constr 		= <<SMBL>(<{Pattern ","}*>)>
+  Pattern.Var	 		= <<SMBL>>
+  Pattern.List	 		= <[<{Pattern "|"}*>]>
+  Pattern.RuleCall		= [<[SMBL]> [Pattern]]
+
+  Strategy.Assign		= <<SMBL> := <Pattern>>
+  Strategy.Seq			= <
+  	<Strategy>;
+  	<Strategy>
+  > {right}

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/syntax/ministr-common.sdf3
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/syntax/ministr-common.sdf3
@@ -1,0 +1,28 @@
+module ministr-common
+
+lexical syntax
+
+  LAYOUT         = [\ \t\n\r]
+  CommentChar    = [\*]
+  LAYOUT         = "/*" InsideComment* "*/"
+  InsideComment  = ~[\*]
+  InsideComment  = CommentChar
+  LAYOUT         = "//" ~[\n\r]* NewLineEOF
+  NewLineEOF     = [\n\r]
+  NewLineEOF     = EOF
+  EOF            =
+
+lexical restrictions
+
+  // Ensure greedy matching for lexicals
+  CommentChar   -/- [\/]
+
+  // EOF may not be followed by any char
+  EOF           -/- ~[]
+
+context-free restrictions
+
+  // Ensure greedy matching for comments
+  LAYOUT? -/- [\ \t\n\r]
+  LAYOUT? -/- [\/].[\/]
+  LAYOUT? -/- [\/].[\*]

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/syntax/ministr.sdf3
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/syntax/ministr.sdf3
@@ -1,0 +1,10 @@
+module ministr
+
+imports
+
+  mini-str/mini-str
+
+context-free start-symbols
+
+  MSTRStart
+

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/analysis.str
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/analysis.str
@@ -1,0 +1,37 @@
+module analysis
+
+imports
+
+  statixruntime
+  statix/api
+
+  pp
+
+  injections/-
+
+rules
+
+  // multi-file analysis
+  editor-analyze = stx-editor-analyze(pre-analyze, post-analyze |"mini-str/mini-str-typing", "mstrProjectOK", "mstrProgramOK")
+  pre-analyze = explicate-injections-ministr
+  post-analyze = strip-annos; implicate-injections-ministr
+
+rules // Editor Services
+
+  editor-resolve = stx-editor-resolve
+
+  editor-hover = stx-editor-hover
+
+rules // Debugging
+
+  // Prints the abstract syntax ATerm of a selection.
+  debug-show-aterm: (selected, _, _, path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"aterm")> path
+       ; result   := selected
+
+rules
+
+  // Prints the analyzed annotated abstract syntax ATerm of a selection.
+  debug-show-analyzed: (selected, _, _, path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"analyzed.aterm")> path
+       ; result   := selected

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/conflicts/constructors.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/conflicts/constructors.stx
@@ -1,0 +1,54 @@
+module cons-type-interface/conflicts/constructors
+
+imports
+  module-interface/modules
+  cons-type-interface/constructors
+
+signature
+
+  sorts CTI = (string * int * TAG) // Constructor type info
+
+rules
+
+  conssUnique: scope * scope
+
+  conssUnique(s_imp, s_mod) :- {CM CI}
+    conssInScope(s_mod) == CM, // Constructors in imported module scope
+    importedConss(s_imp) == CI, // Constructors imported in importing module scope
+    conssDisjoint(CM, CI).
+
+rules
+
+  conssInScope : scope -> list(CTI)
+  
+  conssInScope(s) = typeInfosOfConss(C) :-
+    query cons
+      filter resolveMatch[Cons{_}]
+      in s |-> C.
+
+rules
+
+  importedConss : scope -> list(CTI)
+  
+  importedConss(s) = typeInfosOfConss(C) :-
+    query cons
+      filter resolveMatch[Cons{_}] & ~e
+      in s |-> C.
+
+rules
+
+  typeInfosOfConss maps typeInfoOfCons(list(*)) = list(*)
+  typeInfoOfCons: (path * (occurrence * CONS)) -> CTI
+
+  typeInfoOfCons((_, (Cons{n}, CONS(_, _, a, id)))) = (n, a, id).
+
+rules
+  // Double maps to validate each pair
+  conssDisjoint maps consDisjoint(list(*), *)
+  consDisjoint maps consPairDisjoint(*, list(*))
+ 
+  consPairDisjoint: CTI * CTI
+
+  consPairDisjoint((n, a, id1), (n, a, id2)) :-
+    id1 == id2 | error $[Duplicate import of cons [n]/[a]].
+  consPairDisjoint((n1, _, _), (n2, _, _)).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/conflicts/sorts.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/conflicts/sorts.stx
@@ -1,0 +1,53 @@
+module cons-type-interface/conflicts/sorts
+
+imports
+  module-interface/modules
+  cons-type-interface/sorts
+
+signature
+
+  sorts STI = (string * TAG) // Sort type info
+
+rules
+
+  sortsUnique: scope * scope
+
+  sortsUnique(s_imp, s_mod) :- {SM SI}
+    sortsInScope(s_mod) == SM, // Sorts in imported module scope
+    importedSorts(s_imp) == SI, // Sorts imported in importing module scope
+    sortsDisjoint(SM, SI).
+
+rules
+
+  sortsInScope : scope -> list(STI)
+  
+  sortsInScope(s) = typeInfosOfSorts(S) :-
+    sort of Sort{_} in s |-> S.
+
+rules
+
+  importedSorts : scope -> list(STI)
+  
+  importedSorts(s) = typeInfosOfSorts(S) :-
+    query sort
+      filter resolveMatch[Sort{_}] & ~e
+      in s |-> S.
+
+rules
+
+  typeInfosOfSorts maps typeInfoOfSort(list(*)) = list(*)
+  typeInfoOfSort: (path * (occurrence * TYPE)) -> STI
+
+  typeInfoOfSort((_, (Sort{n}, TSORT(id, _)))) = (n, id).
+
+
+rules
+  // Double maps to validate each pair
+  sortsDisjoint maps sortDisjoint(list(*), *)
+  sortDisjoint maps sortPairDisjoint(*, list(*))
+ 
+  sortPairDisjoint: STI * STI
+
+  sortPairDisjoint((n, id1), (n, id2)) :-
+    id1 == id2 | error $[Duplicate import of sort [n]].
+  sortPairDisjoint((n1, _), (n2, _)).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/constructors.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/constructors.stx
@@ -1,0 +1,62 @@
+module cons-type-interface/constructors
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+  namespaces
+  
+    Cons : string
+
+  relations
+
+    cons: occurrence * CONS
+
+  name-resolution
+
+    resolve Cons
+      filter P* I* // Transitive imports. If not: sort of imported cons might not be found
+      min $ < P, $ < I, P < I
+
+rules
+
+  declareCons : scope * TYPE * string * list(TYPE)
+
+  declareCons(s, T, n, y) :- {a ctag}
+    new ctag,
+    a == arityOfSig(y),
+    s -> Cons{n} with cons CONS(T, y, a, ctag),
+    // Check for constructors with same name in same scope
+    query cons
+      filter e and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [_] | error $[Duplicate declaration of constructor [n]/[a].],
+    // Check for constructors with same name in imported modules
+    query cons
+      filter resolveMatch[Cons{n}] & ~e and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [] | error $[Shadowing imported constructor [n]/[a].].
+
+rules
+
+  typeOfCons : scope * int * string -> CONS
+
+  typeOfCons(s, a, n) = C :- {res}
+    query cons
+      filter resolveMatch[Cons{n}] and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [(_, (_, C))| _]
+          | error $[Constructor [n]/[a] not declared].
+
+//rules
+//
+//  arityMatch: (occurrence * CONS) * int
+//  arityMatch((Cons{n}, CONS(_, _, a, _)), a).
+
+rules
+
+  arityOfSig : list(TYPE) -> int
+
+  arityOfSig([]) = 0.
+  arityOfSig([_]) = 1.  
+  arityOfSig([h|t]) = res :- {ts}
+    ts == arityOfSig(t),
+    res #= ts + 1.

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/labels.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/labels.stx
@@ -1,0 +1,15 @@
+module cons-type-interface/labels
+
+signature
+  name-resolution
+    labels
+      P // lexical parent
+      I // Module import
+
+rules
+
+  scopesEqual: list(scope)
+
+  scopesEqual([_]).
+  scopesEqual([s, s]).
+  scopesEqual([s, s | tail]) :- scopesEqual([s | tail]).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/sorts.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/sorts.stx
@@ -1,0 +1,52 @@
+module cons-type-interface/sorts
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+  namespaces
+  
+    Sort : string
+
+  relations
+
+    sort: occurrence -> TYPE // Map sort declaration to its type
+
+  name-resolution
+
+    resolve Sort
+      filter P* I* // Transitive imports. If not: sort of imported cons might not be found
+      min $ < P, $ < I, P < I
+
+rules
+
+  // Rule validating if sorts match (e.g. when adding injections)
+  // signature: expected sort at position * actual sort at position
+  typeEq: TYPE * TYPE
+
+  // Equal sorts match
+  typeEq(a, a).
+
+rules
+
+  declareSort: scope * string
+
+  declareSort(s, n) :- {stag}
+    new stag,
+    s -> Sort{n} with sort TSORT(stag, n),
+    // Check for srts with same name in same scope
+    query sort
+      filter e and { t :- t == Sort{n} }
+      in s |-> [_] | error $[Duplicate declaration of sort [n]],
+    // Check for sorts with same name in imported modules
+    query sort
+      filter resolveMatch[Sort{n}] & ~e and { t :- t == Sort{n} }
+      in s |-> [] | error $[Shadowing imported sort [n]].
+
+rules
+
+  typeOfSort: scope * string -> TYPE
+  typeOfSort(s, n) = T :- {res}
+    sort of Sort{n} in s |-> [(_, (_, T)) | _]
+        | error $[Sort [n] not declared].

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/types.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/cons-type-interface/types.stx
@@ -1,0 +1,14 @@
+module cons-type-interface/types
+
+signature
+
+  sorts TAG = scope
+
+  sorts TYPE constructors
+    TSORT 		: TAG * string -> TYPE
+    TOPT		: TYPE -> TYPE
+    TITER		: TYPE -> TYPE
+    TSTAR		: TYPE -> TYPE
+
+  sorts CONS constructors
+    CONS	: TYPE * list(TYPE) * int * TAG -> CONS // Arity stored explicitly to work around unresolved queries

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/imports/imports.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/imports/imports.stx
@@ -1,0 +1,37 @@
+module mini-str/imports/imports
+
+imports
+  module-interface/modules
+  signatures/mini-str/mini-str-sig
+
+  cons-type-interface/conflicts/sorts
+  cons-type-interface/conflicts/constructors
+
+  mini-str/imports/rules
+
+signature
+
+  // Add STR module type
+  constructors
+    STRMod : ModuleType
+
+rules
+
+  strImportsOk maps strImportOk(*, list(*))
+
+  strImportOk : scope * MOD
+
+  strImportOk(s, n) :-
+    import(s, n, STRMod()).
+
+rules
+
+  itemsOk(n, STRMod(), STRMod(), s_imp, s_mod) :-
+    sortsUnique(s_imp, s_mod),
+    conssUnique(s_imp, s_mod),
+    rulesImpOk(n, s_imp, s_mod).
+
+rules
+
+  // Allow STRMod to import any other module
+  modTypesOk(STRMod(), _).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/imports/rules.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/imports/rules.stx
@@ -1,0 +1,24 @@
+module mini-str/imports/rules
+
+imports
+  mini-str/rules/resolution
+
+rules
+
+  rulesImpOk: string * scope * scope
+
+  rulesImpOk(n, s_imp, s_mod) :- {rds}
+ 	ruleType of Rule{_} in s_mod |-> rds,
+    ruleMergesOk(n, s_imp, namesOfRules(rds)).
+
+rules
+
+  ruleMergesOk maps ruleMergeOk(*, *, list(*))
+
+  ruleMergeOk: string * scope * string
+
+  ruleMergeOk(m, s, rn) :- {rls T1 T2}
+    ruleType of Rule{rn} in s |-> rls,
+    typesOfRules(rls) == (T1, T2),
+    uniqType(T1) == [_],
+    uniqType(T2) == [_].

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/mini-str-typing.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/mini-str-typing.stx
@@ -1,0 +1,42 @@
+module mini-str/mini-str-typing
+
+imports
+  signatures/mini-str/mini-str-sig
+
+  cons-type-interface/labels
+  module-interface/modules
+
+  mini-str/rules/rules
+  mini-str/rules/resolution
+  mini-str/signatures/signatures
+  mini-str/imports/imports
+
+rules
+
+  mstrProjectOK: scope
+  mstrProjectOK(_).
+
+rules
+
+  mstrProgramOK : scope * MSTRStart
+
+  mstrProgramOK(s, MSTRModule(n, sec)) :- {s_mod}
+	new s_mod,
+	s_mod -P-> s,
+    declareMod(s, n, s_mod, STRMod()),
+    declareRules(s_mod),
+    mstrSectionsOk(s_mod, sec).
+
+rules
+
+  mstrSectionsOk maps mstrSectionOk(*, list(*))
+
+  mstrSectionOk: scope * MSTRSection
+  mstrSectionOk(s, Rules(rls)) :-
+    rulesOk(s, rls).
+
+  mstrSectionOk(s, Signatures(sigs)) :-
+    signaturesOk(s, sigs).
+
+  mstrSectionOk(s, Imports(i)) :-
+    strImportsOk(s, i).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/pattern-type.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/pattern-type.stx
@@ -1,0 +1,7 @@
+module mini-str/pattern-type
+
+signature
+
+  sorts PATTERN constructors
+    MATCH	: PATTERN
+    BUILD	: PATTERN

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/list-sorts.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/list-sorts.stx
@@ -1,0 +1,43 @@
+module mini-str/rules/list-sorts
+
+imports
+  cons-type-interface/sorts
+  signatures/mini-str/mini-str-sig
+
+signature
+
+  constructors // Create exact types for list build patterns
+    EMPTY 		: TYPE
+    SINGLETON	: TYPE -> TYPE
+    MULTI		: TYPE -> TYPE
+
+rules
+
+  typeEq(EMPTY(), TSTAR(_)).
+  typeEq(EMPTY(), TOPT(_)).
+
+  typeEq(SINGLETON(T), TOPT(T)).
+  typeEq(SINGLETON(T), TSTAR(T)).
+  typeEq(SINGLETON(T), TITER(T)).
+
+  typeEq(MULTI(T), TSTAR(T)).
+  typeEq(MULTI(T), TITER(T)).
+
+rules
+
+  typeOfList : Pattern -> TYPE
+
+  typeOfList(List([])) = EMPTY().
+  typeOfList(List([_])) = SINGLETON(_).
+  typeOfList(List([_ | _])) = MULTI(_).
+
+rules
+
+  typeOfContent: TYPE -> TYPE
+
+  typeOfContent(TSTAR(T)) 		= T.
+  typeOfContent(TITER(T)) 		= T.
+  typeOfContent(TOPT(T)) 		= T.
+  typeOfContent(SINGLETON(T))	= T.
+  typeOfContent(MULTI(T)) 		= T.
+  typeOfContent(EMPTY()) 		= _.

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/patterns/base.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/patterns/base.stx
@@ -1,0 +1,52 @@
+module mini-str/rules/patterns/base
+
+imports
+  cons-type-interface/types
+  cons-type-interface/sorts
+  cons-type-interface/constructors
+
+  signatures/mini-str/mini-str-sig
+  mini-str/rules/resolution
+  mini-str/rules/list-sorts
+  mini-str/rules/variables
+  mini-str/pattern-type
+
+rules
+
+  arityOfCons : list(Pattern) -> int
+
+  arityOfCons([]) = 0.
+  arityOfCons([_]) = 1.
+  arityOfCons([h | t]) = res :- {ts}
+    ts == arityOfCons(t),
+    res #= ts + 1.
+
+rules
+
+  ptrnsOk maps ptrnOk(*, *, list(*), list(*))
+  lptrnOk maps ptrnOk(*, *, list(*), *)
+
+  ptrnOk : scope * PATTERN * Pattern * TYPE
+
+  ptrnOk(s, pt, Constr(n, p), T) :- {T1 T2}
+    typeOfCons(s, arityOfCons(p), n) == CONS(T1, T2, _, _),
+    ptrnsOk(s, pt, p, T2),
+    typeEq(T, T1)
+        | error $[Expected constructor of sort [T], but was [T1]] @n.
+
+  ptrnOk(s, pt, l@List(i), T) :- {T1}
+    typeOfList(l) == T1,
+    typeEq(T1, T),
+    lptrnOk(s, pt, i, typeOfContent(T)).
+
+  ptrnOk(s, pt, c@RuleCall(n, op), T) :- {T1 T2}
+    resolveRule(s, n) == RULE(T1, T2),
+    ptrnOk(s, pt, op, T1),
+    typeEq(T, T2).
+
+  ptrnOk(s, MATCH(), Var(n), T) :-
+    declareVar(s, n, T).
+
+  ptrnOk(s, BUILD(), Var(n), T) :- {T1}
+    typeOfVar(s, n) == T1,
+    typeEq(T, T1) | error $[Expected variable of sort [T], but was [T1]] @n.

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/patterns/build.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/patterns/build.stx
@@ -1,0 +1,32 @@
+module mini-str/rules/patterns/build
+
+imports
+  cons-type-interface/types
+  cons-type-interface/constructors
+
+  signatures/mini-str/mini-str-sig
+  mini-str/rules/list-sorts
+  mini-str/rules/resolution
+  mini-str/rules/variables
+  mini-str/rules/patterns/base
+  mini-str/pattern-type
+
+rules
+
+  typeOfBuild : scope * Pattern -> TYPE
+
+  typeOfBuild(s, c@Constr(n, p)) = T :-
+    typeOfCons(s, arityOfCons(p), n) == CONS(T, _, _, _),
+    ptrnOk(s, BUILD(), c, T).
+
+  typeOfBuild(s, v@Var(n)) = T :-
+    typeOfVar(s, n) == T,
+    ptrnOk(s, BUILD(), v, T).
+
+  typeOfBuild(s, l@List(_)) = T :-
+    typeOfList(l) == T,
+    ptrnOk(s, BUILD(), l, T).
+
+  typeOfBuild(s, c@RuleCall(n, _)) = T :-
+    resolveRule(s, n) == RULE(_, T),
+    ptrnOk(s, BUILD(), c, T).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/patterns/match.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/patterns/match.stx
@@ -1,0 +1,27 @@
+module mini-str/rules/patterns/match
+
+imports
+  cons-type-interface/types
+  cons-type-interface/constructors
+
+  signatures/mini-str/mini-str-sig
+  mini-str/rules/list-sorts
+  mini-str/rules/variables
+  mini-str/rules/patterns/base
+  mini-str/pattern-type
+
+rules
+
+  typeOfMatch : scope * Pattern -> TYPE
+
+  typeOfMatch(s, c@Constr(n, p)) = T :-
+    typeOfCons(s, arityOfCons(p), n) == CONS(T, _, _, _),
+    ptrnOk(s, MATCH(), c, T).
+
+  typeOfMatch(s, v@Var(n)) = T :-
+    typeOfVar(s, n) == T,
+    ptrnOk(s, MATCH(), v, T).
+
+  typeOfMatch(s, l@List(_)) = T :-
+    typeOfList(l) == T,
+    ptrnOk(s, MATCH(), l, T).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/resolution.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/resolution.stx
@@ -1,0 +1,146 @@
+module mini-str/rules/resolution
+
+imports
+  cons-type-interface/sorts
+  cons-type-interface/labels
+
+signature
+
+  sorts RTYPE constructors
+    // Rule type: input sort -> output sort
+    RULE : TYPE * TYPE -> RTYPE
+
+  namespaces
+    RuleInst : string 	// Declaration of single rewrite rule
+    Rule : string  		// Module-unique declaration of rule
+
+  name-resolution
+    resolve RuleInst
+      filter e // Only find rule instances in same module
+    
+    resolve Rule
+      filter P* I*
+      min $ < P, $ < I, P < I
+
+  relations
+    ruleInstType: occurrence -> RTYPE
+    ruleType: occurrence -> RTYPE
+
+rules
+
+  // Declares a single rule instance in a scope
+  declareRule : scope * string * TYPE * TYPE
+
+  declareRule(s, n, T1, T2) :- {rls rt rts}
+    rt == RULE(T1, T2),
+    s -> RuleInst{n} with ruleInstType rt,
+    query ruleType
+      filter resolveMatch[Rule{n}] & ~e and { t :- t == Rule{n} }
+      in s |-> rts,
+    parentOk(rts, rt).
+
+rules
+
+  parentOk: list((path * (occurrence * RTYPE))) * RTYPE
+
+  // Rule definition is valid when no parent rule specified
+  parentOk([], _).
+
+  // Rule definition is valid when it complies with parent
+  parentOk([(_, (_, RULE(T1, T2))) | _], RULE(T3, T4)) :-
+    T1 == T3 | error $[Input type [T3] does not match with specified type [T1]],
+    T2 == T4 | error $[Output type [T4] does not match with specified type [T2]].
+
+rules
+
+  // Declares a rule definition for a module
+  declareRules : scope
+
+  declareRules(s) :- {rls uns rds uds}
+    // Get names of rule instances declared in this scope
+    query ruleInstType
+      filter e
+      in s |-> rls,
+    unique(namesOfRules(rls)) == uns,
+    // Get visible rule definitions
+    query ruleType
+      filter resolveMatch[Rule{_}] & ~e
+      in s |-> rds,
+    unique(namesOfRules(rds)) == uds,
+    // Create definitions for new rules
+    declareRuleDefs(s, subtract(uds, uns)).
+
+
+rules
+
+  namesOfRules maps nameOfRule(list(*)) = list(*)
+
+  nameOfRule : (path * (occurrence * RTYPE)) -> string
+  nameOfRule((_, (RuleInst{n}, _))) = n.
+  nameOfRule((_, (Rule{n}, _))) = n.
+
+rules
+
+  unique: list(string) -> list(string)
+
+  unique([]) = [].
+  unique([h | t]) = [h | unique(remove(h, t))].
+
+rules
+
+  subtract: list(string) * list(string) -> list(string)
+
+  subtract([], r) = r.
+  subtract([i | t], r) = subtract(t, remove(i, r)).
+
+rules
+
+  remove: string * list(string) -> list(string)
+
+  remove(_, []) = [].
+  remove(s, [s | l]) = remove(s, l).
+  remove(s1, [s2 | l]) = [s2 | remove(s1, l)] :-
+    s1 != s2.
+
+rules
+
+  declareRuleDefs maps declareRuleDef(*, list(*))
+
+  declareRuleDef : scope * string
+  
+  declareRuleDef(s, rn) :- {T1 T2 T3 T4 rls}
+    ruleInstType of RuleInst{rn} in s |-> rls,
+    typesOfRules(rls) == (T3, T4),
+    uniqType(T3) == [T1] | error $[Rule [rn] has different input sorts],
+    uniqType(T4) == [T2] | error $[Rule [rn] has different output sorts],
+    s -> Rule{rn} with ruleType RULE(T1, T2).
+
+rules
+
+  typesOfRules maps typeOfRule(list(*)) = (list(*), list(*))
+
+  typeOfRule: (path * (occurrence * RTYPE)) -> (TYPE * TYPE)
+  typeOfRule((_, (_, RULE(T1, T2)))) = (T1, T2).
+
+rules
+
+  uniqType: list(TYPE) -> list(TYPE)
+
+  uniqType([]) = [].
+  uniqType([h | t]) = [h | uniqType(removeType(h, t))].
+
+rules
+
+  removeType: TYPE * list(TYPE) -> list(TYPE)
+
+  removeType(_, []) = [].
+  removeType(s, [s | l]) = removeType(s, l).
+  removeType(s1, [s2 | l]) = [s2 | removeType(s1, l)] :-
+    s1 != s2.
+
+rules
+
+  resolveRule : scope * string -> RTYPE // TODO: rename resolveRule
+
+  resolveRule(s, n) = rule :-
+    ruleType of Rule{n} in s |-> [(_, (_, rule)) | _].

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/rules.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/rules.stx
@@ -1,0 +1,51 @@
+module mini-str/rules/rules
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+  cons-type-interface/sorts
+
+  signatures/mini-str/mini-str-sig
+  mini-str/rules/variables
+  mini-str/rules/resolution
+  mini-str/rules/patterns/match
+  mini-str/rules/patterns/build
+
+rules
+
+  rulesOk maps ruleOk(*, list(*))
+
+  ruleOk: scope * RuleDef
+  ruleOk(s_root, RewriteRuleDef(n, m, b, w)) :-
+    {s_match s_build s_with T1 T2}
+      new s_match s_build s_with,
+      s_match -P-> s_root,
+      s_build -P-> s_with,
+      withOk(s_match, s_with, w),
+      typeOfMatch(s_match, m) == T1,
+      typeOfBuild(s_build, b) == T2,
+      declareRule(s_root, n, T1, T2).
+
+rules
+
+  withOk: scope * scope * With
+
+  withOk(s_match, s_build, NoWith()) :-
+    s_build -P-> s_match.
+
+  withOk(s_match, s_build, With(str)) :-
+    strategyOk(s_match, s_build, str).
+
+rules
+
+  strategyOk : scope * scope * Strategy
+
+  strategyOk (s_match, s_decl, Assign(n, p)) :- {T}
+    s_decl -P-> s_match,
+    typeOfBuild(s_match, p) == T,
+    declareVar(s_decl, n, T).
+
+  strategyOk(s_match, s_build, Seq(str1, str2)) :- {s_int}
+    new s_int,
+    strategyOk(s_match, s_int, str1),
+    strategyOk(s_int, s_build, str2).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/variables.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/rules/variables.stx
@@ -1,0 +1,37 @@
+module mini-str/rules/variables
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+  signatures/mini-str/mini-str-sig
+
+signature
+
+  namespaces
+
+    Var: string
+
+  name-resolution
+    resolve Var
+      filter P*
+
+  relations
+
+    varType : occurrence -> TYPE
+
+rules
+
+  declareVar : scope * string * TYPE
+
+  declareVar(s, n, T) :-
+    s -> Var{n} with varType T,
+    varType of Var{n} in s |-> [_]
+      | error $[Variable [n] declared multiple times].
+
+rules
+
+  typeOfVar : scope * string -> TYPE
+
+  typeOfVar(s, n) = T :-
+    varType of Var{n} in s |-> [(_, (_, T)) | _]
+      | error $[Variabe [n] not declared] @n.

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/signatures/constructors.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/signatures/constructors.stx
@@ -1,0 +1,35 @@
+module mini-str/signatures/constructors
+
+imports
+  cons-type-interface/types
+  cons-type-interface/sorts
+  cons-type-interface/constructors
+
+  signatures/mini-str/mini-str-sig
+  mini-str/signatures/sorts
+
+rules
+
+  conssOk maps consOk(*, list(*))
+
+  consOk: scope * ConstructorDef
+
+  consOk(s, NoArgs(cn, sn)) :- {T}
+    typeOfSort(s, sn) == T,
+    declareCons(s, T, cn, []).
+
+  consOk(s, WithArgs(cn, p, sn)) :- {T T1}
+    typeOfSort(s, sn) == T,
+    sortsOfParams(s, p) == T1,
+    declareCons(s, T, cn, T1).
+
+rules
+
+  sortsOfParams maps sortOfParam(*, list(*)) = list(*)
+
+  sortOfParam: scope * ArgSort -> TYPE
+
+  sortOfParam(s, Sort(n)) = typeOfSort(s, n).
+  sortOfParam(s, Opt(n))  = TOPT(typeOfSort(s, n)).
+  sortOfParam(s, Iter(n)) = TITER(typeOfSort(s, n)).
+  sortOfParam(s, Star(n)) = TSTAR(typeOfSort(s, n)).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/signatures/signatures.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/signatures/signatures.stx
@@ -1,0 +1,18 @@
+module mini-str/signatures/signatures
+
+imports
+  signatures/mini-str/mini-str-sig
+  mini-str/signatures/sorts
+  mini-str/signatures/constructors
+
+rules
+
+  signaturesOk maps signatureOk(*, list(*))
+
+  signatureOk: scope * SignatureSection
+
+  signatureOk(s_mod, Sorts(s)) :-
+  	sortsOk(s_mod, s).
+
+  signatureOk(s_mod, Constructors(c)) :-
+  	conssOk(s_mod, c).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/signatures/sorts.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/mini-str/signatures/sorts.stx
@@ -1,0 +1,17 @@
+module mini-str/signatures/sorts
+
+imports
+  cons-type-interface/sorts
+  cons-type-interface/types
+
+  signatures/mini-str/mini-str-sig
+
+rules
+
+  sortsOk maps sortOk(*, list(*))
+
+  sortOk: scope * SMBL
+
+  sortOk(s, n) :-
+  	// Declare sort in module root scope
+  	declareSort(s, n).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/ministr.str
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/ministr.str
@@ -1,0 +1,16 @@
+module ministr
+
+imports
+  
+  completion/completion
+  pp
+  outline
+  analysis
+
+rules // Debugging
+  
+  debug-show-aterm:
+    (node, _, _, path, project-path) -> (filename, result)
+    with
+      filename := <guarantee-extension(|"aterm")> path
+    ; result   := node

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/module-interface/modules.stx
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/module-interface/modules.stx
@@ -1,0 +1,54 @@
+module module-interface/modules
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+
+  namespaces
+    Module : string
+
+  sorts MODULE constructors
+    MODULE : scope * ModuleType -> MODULE
+
+  sorts ModuleType // Extension point to maintain data for import validating
+  
+  relations
+    modType : occurrence -> MODULE
+
+  name-resolution
+
+    resolve Module filter P*
+
+rules
+
+  modTypesOk: ModuleType * ModuleType
+  modTypesOk(t, t).
+
+  // Rule used for validating unique import of sorts/conss/rules
+  itemsOk: string * ModuleType * ModuleType * scope * scope
+
+rules
+
+  declareMod: scope * string * scope * ModuleType
+
+  declareMod(s, n, s_mod, T) :-
+    s -> Module{n} with modType MODULE(s_mod, T),
+    // Validate module name unique
+    modType of Module{n} in s |-> [_]
+      | error $[Module [n] declared multiple times].
+
+rules
+
+  import: scope * string * ModuleType
+
+  import(s_imp, n, T) :- {s_mod T1}
+    s_imp -I-> s_mod,
+    modType of Module{n} in s_imp |-> [(_, (_, MODULE(s_mod, T1))) | _]
+        | error $[Module [n] could not be found],
+    // Validate module type combination is correct.
+    try { modTypesOk(T, T1) }
+        | error $[Module of type [T] cannot import module of type [T1]],
+    // Validate no comflicts in imported constructs
+    itemsOk(n, T, T1, s_imp, s_mod).

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/outline.str
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/outline.str
@@ -1,0 +1,15 @@
+module outline
+
+imports
+
+  signatures/ministr-sig
+  libspoofax/editor/outline
+
+rules
+
+  editor-outline:
+    (_, _, ast, path, project-path) -> outline
+    where
+      outline := <simple-label-outline(to-outline-label)> ast
+
+  to-outline-label = fail

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/pp.str
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/trans/pp.str
@@ -1,0 +1,49 @@
+module pp
+
+imports
+
+  libstratego-gpp
+  libspoofax/sdf/pp
+  libspoofax/editor/refactoring/-
+  pp/ministr-parenthesize
+  pp/ministr-pp
+
+rules
+
+  editor-format:
+    (node, _, ast, path, project-path) -> (filename, result)
+    with
+      ext      := <get-extension> path
+    ; filename := <guarantee-extension(|$[pp.[ext]])> path
+    ; result   := <pp-debug> node
+
+rules
+
+  pp-ministr-string =
+    parenthesize-ministr
+    ; prettyprint-ministr-start-symbols
+    ; !V([], <id>)
+    ; box2text-string(|120)
+
+  pp-partial-ministr-string =
+    parenthesize-ministr
+    ; prettyprint-ministr
+    ; !V([], <id>)
+    ; box2text-string(|120)
+
+  pp-partial-ministr-string(|sort) =
+    parenthesize-ministr
+    ; prettyprint-ministr(|sort)
+    ; !V([], <id>)
+    ; box2text-string(|120)
+
+  pp-debug :
+    ast -> result
+    with
+       result := <pp-ministr-string> ast
+    <+ <bottomup(try(not(is-string); not(is-list); not(pp-ministr-string); debug(!"cannot pp ")))> ast
+    ;  result := ""
+
+rules
+
+  construct-textual-change = construct-textual-change(pp-partial-ministr-string, parenthesize, override-reconstruction, resugar)

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/.gitignore
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/.gitignore
@@ -1,0 +1,11 @@
+/.cache
+/bin
+/src-gen
+/target
+
+/.classpath
+/.project
+/.settings
+/.factorypath
+
+/.polyglot.metaborg.yaml

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/build.gradle.kts
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("org.metaborg.spoofax.gradle.langspec")
+  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
+  `maven-publish`
+}
+
+ecj {
+  toolVersion = "3.20.0"
+}

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/metaborg.yaml
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/metaborg.yaml
@@ -1,0 +1,22 @@
+---
+id: org.metaborg:module-interface:0.1.0-SNAPSHOT
+name: module-interface
+dependencies:
+  compile:
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:statix.lang:${metaborgVersion}
+language:
+  sdf:
+    sdf2table: java
+debug:
+  typesmart: false
+exports:
+- language: ATerm
+  directory: src-gen/statix
+  includes: "module-interface/**/*.aterm"
+- language: Statix
+  directory: trans
+  includes: "module-interface/**/*.stx"
+- language: Stratego-Sugar
+  directory: trans
+  includes: "**/*.str"

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/syntax/module-interface.sdf3
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/syntax/module-interface.sdf3
@@ -1,0 +1,1 @@
+module module-interface

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/conflicts/constructors.stx
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/conflicts/constructors.stx
@@ -1,0 +1,54 @@
+module cons-type-interface/conflicts/constructors
+
+imports
+  module-interface/modules
+  cons-type-interface/constructors
+
+signature
+
+  sorts CTI = (string * int * TAG) // Constructor type info
+
+rules
+
+  conssUnique: scope * scope
+
+  conssUnique(s_imp, s_mod) :- {CM CI}
+    conssInScope(s_mod) == CM, // Constructors in imported module scope
+    importedConss(s_imp) == CI, // Constructors imported in importing module scope
+    conssDisjoint(CM, CI).
+
+rules
+
+  conssInScope : scope -> list(CTI)
+  
+  conssInScope(s) = typeInfosOfConss(C) :-
+    query cons
+      filter resolveMatch[Cons{_}]
+      in s |-> C.
+
+rules
+
+  importedConss : scope -> list(CTI)
+  
+  importedConss(s) = typeInfosOfConss(C) :-
+    query cons
+      filter resolveMatch[Cons{_}] & ~e
+      in s |-> C.
+
+rules
+
+  typeInfosOfConss maps typeInfoOfCons(list(*)) = list(*)
+  typeInfoOfCons: (path * (occurrence * CONS)) -> CTI
+
+  typeInfoOfCons((_, (Cons{n}, CONS(_, _, a, id)))) = (n, a, id).
+
+rules
+  // Double maps to validate each pair
+  conssDisjoint maps consDisjoint(list(*), *)
+  consDisjoint maps consPairDisjoint(*, list(*))
+ 
+  consPairDisjoint: CTI * CTI
+
+  consPairDisjoint((n, a, id1), (n, a, id2)) :-
+    id1 == id2 | error $[Duplicate import of cons [n]/[a]].
+  consPairDisjoint((n1, _, _), (n2, _, _)).

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/conflicts/sorts.stx
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/conflicts/sorts.stx
@@ -1,0 +1,53 @@
+module cons-type-interface/conflicts/sorts
+
+imports
+  module-interface/modules
+  cons-type-interface/sorts
+
+signature
+
+  sorts STI = (string * TAG) // Sort type info
+
+rules
+
+  sortsUnique: scope * scope
+
+  sortsUnique(s_imp, s_mod) :- {SM SI}
+    sortsInScope(s_mod) == SM, // Sorts in imported module scope
+    importedSorts(s_imp) == SI, // Sorts imported in importing module scope
+    sortsDisjoint(SM, SI).
+
+rules
+
+  sortsInScope : scope -> list(STI)
+  
+  sortsInScope(s) = typeInfosOfSorts(S) :-
+    sort of Sort{_} in s |-> S.
+
+rules
+
+  importedSorts : scope -> list(STI)
+  
+  importedSorts(s) = typeInfosOfSorts(S) :-
+    query sort
+      filter resolveMatch[Sort{_}] & ~e
+      in s |-> S.
+
+rules
+
+  typeInfosOfSorts maps typeInfoOfSort(list(*)) = list(*)
+  typeInfoOfSort: (path * (occurrence * TYPE)) -> STI
+
+  typeInfoOfSort((_, (Sort{n}, TSORT(id, _)))) = (n, id).
+
+
+rules
+  // Double maps to validate each pair
+  sortsDisjoint maps sortDisjoint(list(*), *)
+  sortDisjoint maps sortPairDisjoint(*, list(*))
+ 
+  sortPairDisjoint: STI * STI
+
+  sortPairDisjoint((n, id1), (n, id2)) :-
+    id1 == id2 | error $[Duplicate import of sort [n]].
+  sortPairDisjoint((n1, _), (n2, _)).

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/constructors.stx
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/constructors.stx
@@ -1,0 +1,62 @@
+module cons-type-interface/constructors
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+  namespaces
+  
+    Cons : string
+
+  relations
+
+    cons: occurrence * CONS
+
+  name-resolution
+
+    resolve Cons
+      filter P* I* // Transitive imports. If not: sort of imported cons might not be found
+      min $ < P, $ < I, P < I
+
+rules
+
+  declareCons : scope * TYPE * string * list(TYPE)
+
+  declareCons(s, T, n, y) :- {a ctag}
+    new ctag,
+    a == arityOfSig(y),
+    s -> Cons{n} with cons CONS(T, y, a, ctag),
+    // Check for constructors with same name in same scope
+    query cons
+      filter e and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [_] | error $[Duplicate declaration of constructor [n]/[a].],
+    // Check for constructors with same name in imported modules
+    query cons
+      filter resolveMatch[Cons{n}] & ~e and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [] | error $[Shadowing imported constructor [n]/[a].].
+
+rules
+
+  typeOfCons : scope * int * string -> CONS
+
+  typeOfCons(s, a, n) = C :- {res}
+    query cons
+      filter resolveMatch[Cons{n}] and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [(_, (_, C))| _]
+          | error $[Constructor [n]/[a] not declared].
+
+//rules
+//
+//  arityMatch: (occurrence * CONS) * int
+//  arityMatch((Cons{n}, CONS(_, _, a, _)), a).
+
+rules
+
+  arityOfSig : list(TYPE) -> int
+
+  arityOfSig([]) = 0.
+  arityOfSig([_]) = 1.  
+  arityOfSig([h|t]) = res :- {ts}
+    ts == arityOfSig(t),
+    res #= ts + 1.

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/labels.stx
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/labels.stx
@@ -1,0 +1,15 @@
+module cons-type-interface/labels
+
+signature
+  name-resolution
+    labels
+      P // lexical parent
+      I // Module import
+
+rules
+
+  scopesEqual: list(scope)
+
+  scopesEqual([_]).
+  scopesEqual([s, s]).
+  scopesEqual([s, s | tail]) :- scopesEqual([s | tail]).

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/sorts.stx
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/sorts.stx
@@ -1,0 +1,52 @@
+module cons-type-interface/sorts
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+  namespaces
+  
+    Sort : string
+
+  relations
+
+    sort: occurrence -> TYPE // Map sort declaration to its type
+
+  name-resolution
+
+    resolve Sort
+      filter P* I* // Transitive imports. If not: sort of imported cons might not be found
+      min $ < P, $ < I, P < I
+
+rules
+
+  // Rule validating if sorts match (e.g. when adding injections)
+  // signature: expected sort at position * actual sort at position
+  typeEq: TYPE * TYPE
+
+  // Equal sorts match
+  typeEq(a, a).
+
+rules
+
+  declareSort: scope * string
+
+  declareSort(s, n) :- {stag}
+    new stag,
+    s -> Sort{n} with sort TSORT(stag, n),
+    // Check for srts with same name in same scope
+    query sort
+      filter e and { t :- t == Sort{n} }
+      in s |-> [_] | error $[Duplicate declaration of sort [n]],
+    // Check for sorts with same name in imported modules
+    query sort
+      filter resolveMatch[Sort{n}] & ~e and { t :- t == Sort{n} }
+      in s |-> [] | error $[Shadowing imported sort [n]].
+
+rules
+
+  typeOfSort: scope * string -> TYPE
+  typeOfSort(s, n) = T :- {res}
+    sort of Sort{n} in s |-> [(_, (_, T)) | _]
+        | error $[Sort [n] not declared].

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/types.stx
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/cons-type-interface/types.stx
@@ -1,0 +1,14 @@
+module cons-type-interface/types
+
+signature
+
+  sorts TAG = scope
+
+  sorts TYPE constructors
+    TSORT 		: TAG * string -> TYPE
+    TOPT		: TYPE -> TYPE
+    TITER		: TYPE -> TYPE
+    TSTAR		: TYPE -> TYPE
+
+  sorts CONS constructors
+    CONS	: TYPE * list(TYPE) * int * TAG -> CONS // Arity stored explicitly to work around unresolved queries

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/module-interface/modules.stx
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/module-interface/modules.stx
@@ -1,0 +1,54 @@
+module module-interface/modules
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+
+  namespaces
+    Module : string
+
+  sorts MODULE constructors
+    MODULE : scope * ModuleType -> MODULE
+
+  sorts ModuleType // Extension point to maintain data for import validating
+  
+  relations
+    modType : occurrence -> MODULE
+
+  name-resolution
+
+    resolve Module filter P*
+
+rules
+
+  modTypesOk: ModuleType * ModuleType
+  modTypesOk(t, t).
+
+  // Rule used for validating unique import of sorts/conss/rules
+  itemsOk: string * ModuleType * ModuleType * scope * scope
+
+rules
+
+  declareMod: scope * string * scope * ModuleType
+
+  declareMod(s, n, s_mod, T) :-
+    s -> Module{n} with modType MODULE(s_mod, T),
+    // Validate module name unique
+    modType of Module{n} in s |-> [_]
+      | error $[Module [n] declared multiple times].
+
+rules
+
+  import: scope * string * ModuleType
+
+  import(s_imp, n, T) :- {s_mod T1}
+    s_imp -I-> s_mod,
+    modType of Module{n} in s_imp |-> [(_, (_, MODULE(s_mod, T1))) | _]
+        | error $[Module [n] could not be found],
+    // Validate module type combination is correct.
+    try { modTypesOk(T, T1) }
+        | error $[Module of type [T] cannot import module of type [T1]],
+    // Validate no comflicts in imported constructs
+    itemsOk(n, T, T1, s_imp, s_mod).

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/module_interface.str
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/trans/module_interface.str
@@ -1,0 +1,5 @@
+module signature_interface
+
+rules
+
+  my-imported-strategy = fail

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/.gitignore
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/.gitignore
@@ -1,0 +1,11 @@
+/.cache
+/bin
+/src-gen
+/target
+
+/.classpath
+/.project
+/.settings
+/.factorypath
+
+/.polyglot.metaborg.yaml

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/build.gradle.kts
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("org.metaborg.spoofax.gradle.langspec")
+  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
+  `maven-publish`
+}
+
+ecj {
+  toolVersion = "3.20.0"
+}

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/metaborg.yaml
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/metaborg.yaml
@@ -1,0 +1,22 @@
+---
+id: org.metaborg:signature-interface:0.1.0-SNAPSHOT
+name: signature-interface
+dependencies:
+  compile:
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:statix.lang:${metaborgVersion}
+language:
+  sdf:
+    sdf2table: java
+debug:
+  typesmart: false
+exports:
+- language: ATerm
+  directory: src-gen/statix
+  includes: "cons-type-interface/**/*.aterm"
+- language: Statix
+  directory: trans
+  includes: "cons-type-interface/**/*.stx"
+- language: Stratego-Sugar
+  directory: trans
+  includes: "**/*.str"

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/syntax/signature-interface.sdf3
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/syntax/signature-interface.sdf3
@@ -1,0 +1,1 @@
+module signature-interface

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/conflicts/constructors.stx
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/conflicts/constructors.stx
@@ -1,0 +1,53 @@
+module cons-type-interface/conflicts/constructors
+
+imports
+  cons-type-interface/constructors
+
+signature
+
+  sorts CTI = (string * int * TAG) // Constructor type info
+
+rules
+
+  conssUnique: scope * scope
+
+  conssUnique(s_imp, s_mod) :- {CM CI}
+    conssInScope(s_mod) == CM, // Constructors in imported module scope
+    importedConss(s_imp) == CI, // Constructors imported in importing module scope
+    conssDisjoint(CM, CI).
+
+rules
+
+  conssInScope : scope -> list(CTI)
+
+  conssInScope(s) = typeInfosOfConss(C) :-
+    query cons
+      filter resolveMatch[Cons{_}]
+      in s |-> C.
+
+rules
+
+  importedConss : scope -> list(CTI)
+
+  importedConss(s) = typeInfosOfConss(C) :-
+    query cons
+      filter resolveMatch[Cons{_}] & ~e
+      in s |-> C.
+
+rules
+
+  typeInfosOfConss maps typeInfoOfCons(list(*)) = list(*)
+  typeInfoOfCons: (path * (occurrence * CONS)) -> CTI
+
+  typeInfoOfCons((_, (Cons{n}, CONS(_, _, a, id)))) = (n, a, id).
+
+rules
+  // Double maps to validate each pair
+  conssDisjoint maps consDisjoint(list(*), *)
+  consDisjoint maps consPairDisjoint(*, list(*))
+
+  consPairDisjoint: CTI * CTI
+
+  consPairDisjoint((n, a, id1), (n, a, id2)) :-
+    id1 == id2 | error $[Duplicate import of cons [n]/[a]].
+  consPairDisjoint((n1, _, _), (n2, _, _)).

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/conflicts/sorts.stx
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/conflicts/sorts.stx
@@ -1,0 +1,52 @@
+module cons-type-interface/conflicts/sorts
+
+imports
+  cons-type-interface/sorts
+
+signature
+
+  sorts STI = (string * TAG) // Sort type info
+
+rules
+
+  sortsUnique: scope * scope
+
+  sortsUnique(s_imp, s_mod) :- {SM SI}
+    sortsInScope(s_mod) == SM, // Sorts in imported module scope
+    importedSorts(s_imp) == SI, // Sorts imported in importing module scope
+    sortsDisjoint(SM, SI).
+
+rules
+
+  sortsInScope : scope -> list(STI)
+
+  sortsInScope(s) = typeInfosOfSorts(S) :-
+    sort of Sort{_} in s |-> S.
+
+rules
+
+  importedSorts : scope -> list(STI)
+
+  importedSorts(s) = typeInfosOfSorts(S) :-
+    query sort
+      filter resolveMatch[Sort{_}] & ~e
+      in s |-> S.
+
+rules
+
+  typeInfosOfSorts maps typeInfoOfSort(list(*)) = list(*)
+  typeInfoOfSort: (path * (occurrence * TYPE)) -> STI
+
+  typeInfoOfSort((_, (Sort{n}, TSORT(id, _)))) = (n, id).
+
+
+rules
+  // Double maps to validate each pair
+  sortsDisjoint maps sortDisjoint(list(*), *)
+  sortDisjoint maps sortPairDisjoint(*, list(*))
+
+  sortPairDisjoint: STI * STI
+
+  sortPairDisjoint((n, id1), (n, id2)) :-
+    id1 == id2 | error $[Duplicate import of sort [n]].
+  sortPairDisjoint((n1, _), (n2, _)).

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/constructors.stx
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/constructors.stx
@@ -1,0 +1,62 @@
+module cons-type-interface/constructors
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+  namespaces
+  
+    Cons : string
+
+  relations
+
+    cons: occurrence * CONS
+
+  name-resolution
+
+    resolve Cons
+      filter P* I* // Transitive imports. If not: sort of imported cons might not be found
+      min $ < P, $ < I, P < I
+
+rules
+
+  declareCons : scope * TYPE * string * list(TYPE)
+
+  declareCons(s, T, n, y) :- {a ctag}
+    new ctag,
+    a == arityOfSig(y),
+    s -> Cons{n} with cons CONS(T, y, a, ctag),
+    // Check for constructors with same name in same scope
+    query cons
+      filter e and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [_] | error $[Duplicate declaration of constructor [n]/[a].],
+    // Check for constructors with same name in imported modules
+    query cons
+      filter resolveMatch[Cons{n}] & ~e and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [] | error $[Shadowing imported constructor [n]/[a].].
+
+rules
+
+  typeOfCons : scope * int * string -> CONS
+
+  typeOfCons(s, a, n) = C :- {res}
+    query cons
+      filter resolveMatch[Cons{n}] and { t :- t == (Cons{n}, CONS(_, _, a, _)) }
+      in s |-> [(_, (_, C))| _]
+          | error $[Constructor [n]/[a] not declared].
+
+//rules
+//
+//  arityMatch: (occurrence * CONS) * int
+//  arityMatch((Cons{n}, CONS(_, _, a, _)), a).
+
+rules
+
+  arityOfSig : list(TYPE) -> int
+
+  arityOfSig([]) = 0.
+  arityOfSig([_]) = 1.  
+  arityOfSig([h|t]) = res :- {ts}
+    ts == arityOfSig(t),
+    res #= ts + 1.

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/labels.stx
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/labels.stx
@@ -1,0 +1,15 @@
+module cons-type-interface/labels
+
+signature
+  name-resolution
+    labels
+      P // lexical parent
+      I // Module import
+
+rules
+
+  scopesEqual: list(scope)
+
+  scopesEqual([_]).
+  scopesEqual([s, s]).
+  scopesEqual([s, s | tail]) :- scopesEqual([s | tail]).

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/sorts.stx
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/sorts.stx
@@ -1,0 +1,52 @@
+module cons-type-interface/sorts
+
+imports
+  cons-type-interface/types
+  cons-type-interface/labels
+
+signature
+  namespaces
+  
+    Sort : string
+
+  relations
+
+    sort: occurrence -> TYPE // Map sort declaration to its type
+
+  name-resolution
+
+    resolve Sort
+      filter P* I* // Transitive imports. If not: sort of imported cons might not be found
+      min $ < P, $ < I, P < I
+
+rules
+
+  // Rule validating if sorts match (e.g. when adding injections)
+  // signature: expected sort at position * actual sort at position
+  typeEq: TYPE * TYPE
+
+  // Equal sorts match
+  typeEq(a, a).
+
+rules
+
+  declareSort: scope * string
+
+  declareSort(s, n) :- {stag}
+    new stag,
+    s -> Sort{n} with sort TSORT(stag, n),
+    // Check for srts with same name in same scope
+    query sort
+      filter e and { t :- t == Sort{n} }
+      in s |-> [_] | error $[Duplicate declaration of sort [n]],
+    // Check for sorts with same name in imported modules
+    query sort
+      filter resolveMatch[Sort{n}] & ~e and { t :- t == Sort{n} }
+      in s |-> [] | error $[Shadowing imported sort [n]].
+
+rules
+
+  typeOfSort: scope * string -> TYPE
+  typeOfSort(s, n) = T :- {res}
+    sort of Sort{n} in s |-> [(_, (_, T)) | _]
+        | error $[Sort [n] not declared].

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/types.stx
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/cons-type-interface/types.stx
@@ -1,0 +1,14 @@
+module cons-type-interface/types
+
+signature
+
+  sorts TAG = scope
+
+  sorts TYPE constructors
+    TSORT 		: TAG * string -> TYPE
+    TOPT		: TYPE -> TYPE
+    TITER		: TYPE -> TYPE
+    TSTAR		: TYPE -> TYPE
+
+  sorts CONS constructors
+    CONS	: TYPE * list(TYPE) * int * TAG -> CONS // Arity stored explicitly to work around unresolved queries

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/signature_interface.str
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/trans/signature_interface.str
@@ -1,0 +1,5 @@
+module signature_interface
+
+rules
+
+  my-imported-strategy = fail

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -61,6 +61,8 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
   includeProject("module")
 
   includeProject("minisdf")
+
+  includeProject("ministr")
 }
 
 

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -61,8 +61,10 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
   includeProject("module")
 
   includeProject("minisdf")
+  includeProject("minisdf.spoofax")
 
   includeProject("ministr")
+  includeProject("ministr.spoofax")
 }
 
 

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -71,6 +71,8 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
   includeProject("ministr.eclipse.externaldeps")
   includeProject("ministr.eclipse")
   includeProject("ministr.cli")
+
+  includeProject("multilang.eclipse")
 }
 
 

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -62,9 +62,15 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
 
   includeProject("minisdf")
   includeProject("minisdf.spoofax")
+  includeProject("minisdf.eclipse.externaldeps")
+  includeProject("minisdf.eclipse")
+  includeProject("minisdf.cli")
 
   includeProject("ministr")
   includeProject("ministr.spoofax")
+  includeProject("ministr.eclipse.externaldeps")
+  includeProject("ministr.eclipse")
+  includeProject("ministr.cli")
 }
 
 

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -73,6 +73,7 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
   includeProject("ministr.cli")
 
   includeProject("multilang.eclipse")
+  includeProject("multilang.test")
 }
 
 

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -59,6 +59,8 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
 "multilang/generated".run {
   includeProject("signature")
   includeProject("module")
+
+  includeProject("minisdf")
 }
 
 

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -56,5 +56,8 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
   includeProject("ministr.spoofaxcore")
 }
 
+"multilang/generated".run {
+  includeProject("signature")
+}
 
 

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -48,3 +48,13 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
   includeProject("calc")
   includeProject("calc.spoofax")
 }
+
+"multilang/spoofaxcore".run {
+  includeProject("signature-interface.spoofaxcore")
+  includeProject("module-interface.spoofaxcore")
+  includeProject("minisdf.spoofaxcore")
+  includeProject("ministr.spoofaxcore")
+}
+
+
+

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -58,6 +58,7 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
 
 "multilang/generated".run {
   includeProject("signature")
+  includeProject("module")
 }
 
 


### PR DESCRIPTION
This PR contains the following fixes and improvements for multilanguage compilation:
- gradle language plugins now wait for the language extension to be finished before finalizing
- spoofax 2 multilang analyzer compiler now enforces statix specs to be included in the language
- classloader resources are properly provided to the multilang compiler

On top of that, an example project with tests has been added. The features that are covered is:
- all aspects of multilang compilation (including transitive module dependencies)
- passing and failing analysis runs, with and without customized configuration

In addition, a small example minisdf + ministr project is included, that can be used to test the eclipse plugins.