### PR TITLE
Update solver API usage to be compatible with nightly

### DIFF
--- a/core/spoofax.depconstraints/build.gradle.kts
+++ b/core/spoofax.depconstraints/build.gradle.kts
@@ -7,7 +7,7 @@ val logVersion = "0.3.0"
 val slf4jVersion = "1.7.30"
 val resourceVersion = "0.7.3"
 val pieVersion = "0.12.2"
-val spoofax2Version = "2.5.11" // Needs to be kept in sync with metaborgVersion of Spoofax 2 Gradle plugin.
+val spoofax2Version = "2.6.0-SNAPSHOT" // Needs to be kept in sync with metaborgVersion of Spoofax 2 Gradle plugin.
 val picocliVersion = "4.5.0"
 
 val javaxInjectVersion = "1"

--- a/core/statix.multilang/src/main/java/mb/statix/multilang/pie/SmlInstantiateGlobalScope.java
+++ b/core/statix.multilang/src/main/java/mb/statix/multilang/pie/SmlInstantiateGlobalScope.java
@@ -85,7 +85,7 @@ public class SmlInstantiateGlobalScope implements TaskDef<SmlInstantiateGlobalSc
     private Result<GlobalResult, MultiLangAnalysisException> instantiateGlobalScopeForSpec(Input input, Spec spec) {
         ITermVar globalScopeVar = TermVar.of("", "s");
         Set<ITermVar> scopeArgs = Collections.singleton(globalScopeVar);
-        IConstraint globalConstraint = new CExists(scopeArgs, new CNew(new HashSet<>(scopeArgs)));
+        IConstraint globalConstraint = new CExists(scopeArgs, new CNew(globalScopeVar, globalScopeVar));
         IState.Immutable state = State.of(spec);
         IDebugContext debug = TaskUtils.createDebugContext(input.logLevel);
 

--- a/core/statix.multilang/src/main/java/mb/statix/multilang/utils/MessageUtils.java
+++ b/core/statix.multilang/src/main/java/mb/statix/multilang/utils/MessageUtils.java
@@ -105,7 +105,6 @@ public class MessageUtils {
             onNew -> Stream.empty(),
             onResolveQuery -> Stream.empty(),
             onTellEdge -> Stream.empty(),
-            onTellRel -> Stream.empty(),
             onTermId -> Stream.empty(),
             onTermProperty -> Stream.empty(),
             onTrue -> Stream.empty(),

--- a/core/statix.multilang/src/test/java/mb/statix/multilang/metadata/spec/SpecLoaderTest.java
+++ b/core/statix.multilang/src/test/java/mb/statix/multilang/metadata/spec/SpecLoaderTest.java
@@ -37,7 +37,7 @@ public class SpecLoaderTest {
         assertNotNull(spec);
 
         assertEquals(0, spec.edgeLabels().size());
-        assertEquals(1, spec.relationLabels().size()); // Decl()
+        assertEquals(1, spec.dataLabels().size()); // Decl()
         RuleSet rules = spec.rules();
         assertEquals(1, rules.getRules("base!ok").size());
         assertEquals(1, rules.getRules("imported!rule").size());
@@ -57,7 +57,7 @@ public class SpecLoaderTest {
         Spec spec = SpecUtils.mergeSpecs(specFragment1.toSpec(), specFragment2.toSpec()).unwrap();
 
         assertEquals(0, spec.edgeLabels().size());
-        assertEquals(1, spec.relationLabels().size()); // Decl()
+        assertEquals(1, spec.dataLabels().size()); // Decl()
         RuleSet rules = spec.rules();
         assertEquals(1, rules.getRules("root!ok").size());
         assertEquals(2, rules.getRules("imported!rule").size());


### PR DESCRIPTION
This PR updates the the usage of the statix solver API in the `multilang` component.