### PR TITLE
Simplify/more ergonomic manual class implementation

### DIFF
--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProject.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProject.java
@@ -118,13 +118,10 @@ public interface AdapterProject extends Serializable {
         return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Scope");
     }
 
-    Optional<TypeInfo> manualScope();
+    Optional<TypeInfo> extendedScope();
 
     default TypeInfo scope() {
-        if(classKind().isManual() && manualScope().isPresent()) {
-            return manualScope().get();
-        }
-        return genScope();
+        return extendedScope().orElseGet(this::genScope);
     }
 
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProject.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProject.java
@@ -114,14 +114,14 @@ public interface AdapterProject extends Serializable {
 
     // Dagger Scope
 
-    @Value.Default default TypeInfo genScope() {
+    @Value.Default default TypeInfo baseScope() {
         return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Scope");
     }
 
-    Optional<TypeInfo> extendedScope();
+    Optional<TypeInfo> extendScope();
 
     default TypeInfo scope() {
-        return extendedScope().orElseGet(this::genScope);
+        return extendScope().orElseGet(this::baseScope);
     }
 
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
@@ -404,13 +404,10 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             return TypeInfo.of(adapterProject().packageId(), shared().defaultClassPrefix() + "Qualifier");
         }
 
-        Optional<TypeInfo> manualQualifier();
+        Optional<TypeInfo> extendedQualifier();
 
         default TypeInfo qualifier() {
-            if(classKind().isManual() && manualQualifier().isPresent()) {
-                return manualQualifier().get();
-            }
-            return genQualifier();
+            return extendedQualifier().orElseGet(this::genQualifier);
         }
 
         // Dagger component
@@ -419,13 +416,10 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             return TypeInfo.of(adapterProject().packageId(), shared().defaultClassPrefix() + "Component");
         }
 
-        Optional<TypeInfo> manualComponent();
+        Optional<TypeInfo> extendedComponent();
 
         default TypeInfo component() {
-            if(classKind().isManual() && manualComponent().isPresent()) {
-                return manualComponent().get();
-            }
-            return genComponent();
+            return extendedComponent().orElseGet(this::genComponent);
         }
 
         default TypeInfo daggerComponent() {
@@ -438,13 +432,10 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             return TypeInfo.of(adapterProject().packageId(), shared().defaultClassPrefix() + "Module");
         }
 
-        Optional<TypeInfo> manualModule();
+        Optional<TypeInfo> extendedModule();
 
         default TypeInfo module() {
-            if(classKind().isManual() && manualModule().isPresent()) {
-                return manualModule().get();
-            }
-            return genModule();
+            return extendedModule().orElseGet(this::genModule);
         }
 
         // Language instance
@@ -453,13 +444,10 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             return TypeInfo.of(adapterProject().packageId(), shared().defaultClassPrefix() + "Instance");
         }
 
-        Optional<TypeInfo> manualInstance();
+        Optional<TypeInfo> extendedInstance();
 
         default TypeInfo instance() {
-            if(classKind().isManual() && manualInstance().isPresent()) {
-                return manualInstance().get();
-            }
-            return genInstance();
+            return extendedInstance().orElseGet(this::genInstance);
         }
 
 
@@ -471,13 +459,10 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Check");
         }
 
-        Optional<TypeInfo> manualCheckTaskDef();
+        Optional<TypeInfo> extendedCheckTaskDef();
 
         default TypeInfo checkTaskDef() {
-            if(classKind().isManual() && manualCheckTaskDef().isPresent()) {
-                return manualCheckTaskDef().get();
-            }
-            return genCheckTaskDef();
+            return extendedCheckTaskDef().orElseGet(this::genCheckTaskDef);
         }
 
         // Multi-file check task definition
@@ -486,13 +471,10 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "CheckMulti");
         }
 
-        Optional<TypeInfo> manualCheckMultiTaskDef();
+        Optional<TypeInfo> extendedCheckMultiTaskDef();
 
         default TypeInfo checkMultiTaskDef() {
-            if(classKind().isManual() && manualCheckMultiTaskDef().isPresent()) {
-                return manualCheckMultiTaskDef().get();
-            }
-            return genCheckMultiTaskDef();
+            return extendedCheckMultiTaskDef().orElseGet(this::genCheckMultiTaskDef);
         }
 
         // Single file check results aggregator task definition
@@ -501,13 +483,10 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "CheckAggregator");
         }
 
-        Optional<TypeInfo> manualCheckAggregatorTaskDef();
+        Optional<TypeInfo> extendedCheckAggregatorTaskDef();
 
         default TypeInfo checkAggregatorTaskDef() {
-            if(classKind().isManual() && manualCheckAggregatorTaskDef().isPresent()) {
-                return manualCheckAggregatorTaskDef().get();
-            }
-            return genCheckAggregatorTaskDef();
+            return extendedCheckAggregatorTaskDef().orElseGet(this::genCheckAggregatorTaskDef);
         }
 
         /// Provided files

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
@@ -139,12 +139,12 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             // two package-info.java files in the same package, which is an error.
             packageInfoTemplate.write(context, input.packageInfo().file(generatedJavaSourcesDirectory), input);
         }
-        checkTaskDefTemplate.write(context, input.genCheckTaskDef().file(generatedJavaSourcesDirectory), input);
-        checkMultiTaskDefTemplate.write(context, input.genCheckMultiTaskDef().file(generatedJavaSourcesDirectory), input);
-        checkAggregatorTaskDefTemplate.write(context, input.genCheckAggregatorTaskDef().file(generatedJavaSourcesDirectory), input);
+        checkTaskDefTemplate.write(context, input.baseCheckTaskDef().file(generatedJavaSourcesDirectory), input);
+        checkMultiTaskDefTemplate.write(context, input.baseCheckMultiTaskDef().file(generatedJavaSourcesDirectory), input);
+        checkAggregatorTaskDefTemplate.write(context, input.baseCheckAggregatorTaskDef().file(generatedJavaSourcesDirectory), input);
 
-        scopeTemplate.write(context, input.adapterProject().genScope().file(generatedJavaSourcesDirectory), input);
-        qualifierTemplate.write(context, input.genQualifier().file(generatedJavaSourcesDirectory), input);
+        scopeTemplate.write(context, input.adapterProject().baseScope().file(generatedJavaSourcesDirectory), input);
+        qualifierTemplate.write(context, input.baseQualifier().file(generatedJavaSourcesDirectory), input);
 
         for(CommandDefRepr commandDef : input.commandDefs()) {
             final UniqueNamer uniqueNamer = new UniqueNamer();
@@ -159,7 +159,7 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             final HashMap<String, Object> map = new HashMap<>();
             map.put("providedTaskDefs", allTaskDefs.stream().map(uniqueNamer::makeUnique).collect(Collectors.toList()));
             map.put("providedCommandDefs", input.commandDefs().stream().map(CommandDefRepr::type).map(uniqueNamer::makeUnique).collect(Collectors.toList()));
-            componentTemplate.write(context, input.genComponent().file(generatedJavaSourcesDirectory), input, map);
+            componentTemplate.write(context, input.baseComponent().file(generatedJavaSourcesDirectory), input, map);
         }
 
         { // Module
@@ -170,7 +170,7 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             map.put("providedCommandDefs", input.commandDefs().stream().map(CommandDefRepr::type).map(uniqueNamer::makeUnique).collect(Collectors.toList()));
             uniqueNamer.reset(); // New method scope
             map.put("providedAutoCommandDefs", input.autoCommandDefs().stream().map((c) -> uniqueNamer.makeUnique(c, c.commandDef().asVariableId())).collect(Collectors.toList()));
-            moduleTemplate.write(context, input.genModule().file(generatedJavaSourcesDirectory), input, map);
+            moduleTemplate.write(context, input.baseModule().file(generatedJavaSourcesDirectory), input, map);
         }
 
         { // Instance
@@ -242,7 +242,7 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
                 out.write(name);
             });
 
-            instanceTemplate.write(context, input.genInstance().file(generatedJavaSourcesDirectory), input, map);
+            instanceTemplate.write(context, input.baseInstance().file(generatedJavaSourcesDirectory), input, map);
         }
 
         return Output.builder().build();
@@ -379,7 +379,7 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
 
         // package-info
 
-        @Value.Default default TypeInfo genPackageInfo() {
+        @Value.Default default TypeInfo basePackageInfo() {
             return TypeInfo.of(adapterProject().packageId(), "package-info");
         }
 
@@ -389,37 +389,37 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
             if(classKind().isManual() && manualPackageInfo().isPresent()) {
                 return manualPackageInfo().get();
             }
-            return genPackageInfo();
+            return basePackageInfo();
         }
 
         // Dagger Scope (passthrough from AdapterProject)
 
-        default TypeInfo genScope() { return adapterProject().genScope(); }
+        default TypeInfo baseScope() { return adapterProject().baseScope(); }
 
         default TypeInfo scope() { return adapterProject().scope(); }
 
         // Dagger Qualifier
 
-        @Value.Default default TypeInfo genQualifier() {
+        @Value.Default default TypeInfo baseQualifier() {
             return TypeInfo.of(adapterProject().packageId(), shared().defaultClassPrefix() + "Qualifier");
         }
 
-        Optional<TypeInfo> extendedQualifier();
+        Optional<TypeInfo> extendQualifier();
 
         default TypeInfo qualifier() {
-            return extendedQualifier().orElseGet(this::genQualifier);
+            return extendQualifier().orElseGet(this::baseQualifier);
         }
 
         // Dagger component
 
-        @Value.Default default TypeInfo genComponent() {
+        @Value.Default default TypeInfo baseComponent() {
             return TypeInfo.of(adapterProject().packageId(), shared().defaultClassPrefix() + "Component");
         }
 
-        Optional<TypeInfo> extendedComponent();
+        Optional<TypeInfo> extendComponent();
 
         default TypeInfo component() {
-            return extendedComponent().orElseGet(this::genComponent);
+            return extendComponent().orElseGet(this::baseComponent);
         }
 
         default TypeInfo daggerComponent() {
@@ -428,26 +428,26 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
 
         // Dagger module
 
-        @Value.Default default TypeInfo genModule() {
+        @Value.Default default TypeInfo baseModule() {
             return TypeInfo.of(adapterProject().packageId(), shared().defaultClassPrefix() + "Module");
         }
 
-        Optional<TypeInfo> extendedModule();
+        Optional<TypeInfo> extendModule();
 
         default TypeInfo module() {
-            return extendedModule().orElseGet(this::genModule);
+            return extendModule().orElseGet(this::baseModule);
         }
 
         // Language instance
 
-        @Value.Default default TypeInfo genInstance() {
+        @Value.Default default TypeInfo baseInstance() {
             return TypeInfo.of(adapterProject().packageId(), shared().defaultClassPrefix() + "Instance");
         }
 
-        Optional<TypeInfo> extendedInstance();
+        Optional<TypeInfo> extendInstance();
 
         default TypeInfo instance() {
-            return extendedInstance().orElseGet(this::genInstance);
+            return extendInstance().orElseGet(this::baseInstance);
         }
 
 
@@ -455,38 +455,38 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
 
         // Check task definition
 
-        @Value.Default default TypeInfo genCheckTaskDef() {
+        @Value.Default default TypeInfo baseCheckTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Check");
         }
 
-        Optional<TypeInfo> extendedCheckTaskDef();
+        Optional<TypeInfo> extendCheckTaskDef();
 
         default TypeInfo checkTaskDef() {
-            return extendedCheckTaskDef().orElseGet(this::genCheckTaskDef);
+            return extendCheckTaskDef().orElseGet(this::baseCheckTaskDef);
         }
 
         // Multi-file check task definition
 
-        @Value.Default default TypeInfo genCheckMultiTaskDef() {
+        @Value.Default default TypeInfo baseCheckMultiTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "CheckMulti");
         }
 
-        Optional<TypeInfo> extendedCheckMultiTaskDef();
+        Optional<TypeInfo> extendCheckMultiTaskDef();
 
         default TypeInfo checkMultiTaskDef() {
-            return extendedCheckMultiTaskDef().orElseGet(this::genCheckMultiTaskDef);
+            return extendCheckMultiTaskDef().orElseGet(this::baseCheckMultiTaskDef);
         }
 
         // Single file check results aggregator task definition
 
-        @Value.Default default TypeInfo genCheckAggregatorTaskDef() {
+        @Value.Default default TypeInfo baseCheckAggregatorTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "CheckAggregator");
         }
 
-        Optional<TypeInfo> extendedCheckAggregatorTaskDef();
+        Optional<TypeInfo> extendCheckAggregatorTaskDef();
 
         default TypeInfo checkAggregatorTaskDef() {
-            return extendedCheckAggregatorTaskDef().orElseGet(this::genCheckAggregatorTaskDef);
+            return extendCheckAggregatorTaskDef().orElseGet(this::baseCheckAggregatorTaskDef);
         }
 
         /// Provided files
@@ -498,13 +498,13 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
                 if(languageProjectDependency().isSome()) {
                     // Only generate package-info.java if the language project is a separate project. Otherwise we will have
                     // two package-info.java files in the same package, which is an error.
-                    generatedFiles.add(genPackageInfo().file(classesGenDirectory));
+                    generatedFiles.add(basePackageInfo().file(classesGenDirectory));
                 }
-                generatedFiles.add(genComponent().file(classesGenDirectory));
-                generatedFiles.add(genModule().file(classesGenDirectory));
-                generatedFiles.add(genInstance().file(classesGenDirectory));
-                generatedFiles.add(genCheckTaskDef().file(classesGenDirectory));
-                generatedFiles.add(genCheckMultiTaskDef().file(classesGenDirectory));
+                generatedFiles.add(baseComponent().file(classesGenDirectory));
+                generatedFiles.add(baseModule().file(classesGenDirectory));
+                generatedFiles.add(baseInstance().file(classesGenDirectory));
+                generatedFiles.add(baseCheckTaskDef().file(classesGenDirectory));
+                generatedFiles.add(baseCheckMultiTaskDef().file(classesGenDirectory));
             }
             parser().ifPresent((i) -> i.generatedFiles().addAllTo(generatedFiles));
             styler().ifPresent((i) -> i.generatedFiles().addAllTo(generatedFiles));

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
@@ -521,21 +521,7 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManualOnly();
-            if(!manual) return;
-            if(!manualComponent().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualComponent' has not been set");
-            }
-            if(!manualModule().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualModule' has not been set");
-            }
-            if(!manualInstance().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualInstance' has not been set");
-            }
-            if(!manualCheckTaskDef().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualCheckTaskDef' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/CompleterAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/CompleterAdapterCompiler.java
@@ -91,12 +91,7 @@ public class CompleterAdapterCompiler implements TaskDef<CompleterAdapterCompile
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManualOnly();
-            if(!manual) return;
-            if(!manualCompleteTaskDef().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualCompleteTaskDef' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/CompleterAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/CompleterAdapterCompiler.java
@@ -33,7 +33,7 @@ public class CompleterAdapterCompiler implements TaskDef<CompleterAdapterCompile
 
     @Override public Output exec(ExecContext context, Input input) throws IOException {
         final Output.Builder outputBuilder = Output.builder();
-        if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
+        if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         completeTaskDefTemplate.write(context, input.genCompleteTaskDef().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/CompleterAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/CompleterAdapterCompiler.java
@@ -63,19 +63,16 @@ public class CompleterAdapterCompiler implements TaskDef<CompleterAdapterCompile
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "CompleteTaskDef");
         }
 
-        Optional<TypeInfo> manualCompleteTaskDef();
+        Optional<TypeInfo> extendedCompleteTaskDef();
 
         default TypeInfo completeTaskDef() {
-            if(classKind().isManual() && manualCompleteTaskDef().isPresent()) {
-                return manualCompleteTaskDef().get();
-            }
-            return genCompleteTaskDef();
+            return extendedCompleteTaskDef().orElseGet(this::genCompleteTaskDef);
         }
 
         // List of all generated files
 
         default ListView<ResourcePath> generatedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/CompleterAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/CompleterAdapterCompiler.java
@@ -35,7 +35,7 @@ public class CompleterAdapterCompiler implements TaskDef<CompleterAdapterCompile
         final Output.Builder outputBuilder = Output.builder();
         if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        completeTaskDefTemplate.write(context, input.genCompleteTaskDef().file(generatedJavaSourcesDirectory), input);
+        completeTaskDefTemplate.write(context, input.baseCompleteTaskDef().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
     }
 
@@ -59,14 +59,14 @@ public class CompleterAdapterCompiler implements TaskDef<CompleterAdapterCompile
 
         // Complete task definition
 
-        @Value.Default default TypeInfo genCompleteTaskDef() {
+        @Value.Default default TypeInfo baseCompleteTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "CompleteTaskDef");
         }
 
-        Optional<TypeInfo> extendedCompleteTaskDef();
+        Optional<TypeInfo> extendCompleteTaskDef();
 
         default TypeInfo completeTaskDef() {
-            return extendedCompleteTaskDef().orElseGet(this::genCompleteTaskDef);
+            return extendCompleteTaskDef().orElseGet(this::baseCompleteTaskDef);
         }
 
         // List of all generated files
@@ -76,7 +76,7 @@ public class CompleterAdapterCompiler implements TaskDef<CompleterAdapterCompile
                 return ListView.of();
             }
             return ListView.of(
-                genCompleteTaskDef().file(generatedJavaSourcesDirectory())
+                baseCompleteTaskDef().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
@@ -113,12 +113,7 @@ public class ConstraintAnalyzerAdapterCompiler implements TaskDef<ConstraintAnal
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManualOnly();
-            if(!manual) return;
-            if(!manualAnalyzeTaskDef().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualAnalyzeTaskDef' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
@@ -35,7 +35,7 @@ public class ConstraintAnalyzerAdapterCompiler implements TaskDef<ConstraintAnal
 
     @Override public Output exec(ExecContext context, Input input) throws Exception {
         final Output.Builder outputBuilder = Output.builder();
-        if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
+        if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         analyzeTaskDefTemplate.write(context, input.genAnalyzeTaskDef().file(generatedJavaSourcesDirectory), input);
         analyzeMultiTaskDefTemplate.write(context, input.genAnalyzeMultiTaskDef().file(generatedJavaSourcesDirectory), input);

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
@@ -71,13 +71,10 @@ public class ConstraintAnalyzerAdapterCompiler implements TaskDef<ConstraintAnal
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Analyze");
         }
 
-        Optional<TypeInfo> manualAnalyzeTaskDef();
+        Optional<TypeInfo> extendedAnalyzeTaskDef();
 
         default TypeInfo analyzeTaskDef() {
-            if(classKind().isManual() && manualAnalyzeTaskDef().isPresent()) {
-                return manualAnalyzeTaskDef().get();
-            }
-            return genAnalyzeTaskDef();
+            return extendedAnalyzeTaskDef().orElseGet(this::genAnalyzeTaskDef);
         }
 
         // Multi-file analyze
@@ -86,20 +83,17 @@ public class ConstraintAnalyzerAdapterCompiler implements TaskDef<ConstraintAnal
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "AnalyzeMulti");
         }
 
-        Optional<TypeInfo> manualAnalyzeMultiTaskDef();
+        Optional<TypeInfo> extendedAnalyzeMultiTaskDef();
 
         default TypeInfo analyzeMultiTaskDef() {
-            if(classKind().isManual() && manualAnalyzeMultiTaskDef().isPresent()) {
-                return manualAnalyzeMultiTaskDef().get();
-            }
-            return genAnalyzeMultiTaskDef();
+            return extendedAnalyzeMultiTaskDef().orElseGet(this::genAnalyzeMultiTaskDef);
         }
 
 
         // List of all generated files
 
         default ListView<ResourcePath> generatedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
@@ -37,8 +37,8 @@ public class ConstraintAnalyzerAdapterCompiler implements TaskDef<ConstraintAnal
         final Output.Builder outputBuilder = Output.builder();
         if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        analyzeTaskDefTemplate.write(context, input.genAnalyzeTaskDef().file(generatedJavaSourcesDirectory), input);
-        analyzeMultiTaskDefTemplate.write(context, input.genAnalyzeMultiTaskDef().file(generatedJavaSourcesDirectory), input);
+        analyzeTaskDefTemplate.write(context, input.baseAnalyzeTaskDef().file(generatedJavaSourcesDirectory), input);
+        analyzeMultiTaskDefTemplate.write(context, input.baseAnalyzeMultiTaskDef().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
     }
 
@@ -67,26 +67,26 @@ public class ConstraintAnalyzerAdapterCompiler implements TaskDef<ConstraintAnal
 
         // Analyze
 
-        @Value.Default default TypeInfo genAnalyzeTaskDef() {
+        @Value.Default default TypeInfo baseAnalyzeTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Analyze");
         }
 
-        Optional<TypeInfo> extendedAnalyzeTaskDef();
+        Optional<TypeInfo> extendAnalyzeTaskDef();
 
         default TypeInfo analyzeTaskDef() {
-            return extendedAnalyzeTaskDef().orElseGet(this::genAnalyzeTaskDef);
+            return extendAnalyzeTaskDef().orElseGet(this::baseAnalyzeTaskDef);
         }
 
         // Multi-file analyze
 
-        @Value.Default default TypeInfo genAnalyzeMultiTaskDef() {
+        @Value.Default default TypeInfo baseAnalyzeMultiTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "AnalyzeMulti");
         }
 
-        Optional<TypeInfo> extendedAnalyzeMultiTaskDef();
+        Optional<TypeInfo> extendAnalyzeMultiTaskDef();
 
         default TypeInfo analyzeMultiTaskDef() {
-            return extendedAnalyzeMultiTaskDef().orElseGet(this::genAnalyzeMultiTaskDef);
+            return extendAnalyzeMultiTaskDef().orElseGet(this::baseAnalyzeMultiTaskDef);
         }
 
 
@@ -97,8 +97,8 @@ public class ConstraintAnalyzerAdapterCompiler implements TaskDef<ConstraintAnal
                 return ListView.of();
             }
             return ListView.of(
-                genAnalyzeTaskDef().file(generatedJavaSourcesDirectory()),
-                genAnalyzeMultiTaskDef().file(generatedJavaSourcesDirectory())
+                baseAnalyzeTaskDef().file(generatedJavaSourcesDirectory()),
+                baseAnalyzeMultiTaskDef().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/MultilangAnalyzerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/MultilangAnalyzerAdapterCompiler.java
@@ -43,7 +43,7 @@ public class MultilangAnalyzerAdapterCompiler implements TaskDef<MultilangAnalyz
 
     @Override public Output exec(ExecContext context, Input input) throws IOException {
         final Output.Builder outputBuilder = Output.builder();
-        if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
+        if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         analyzeProjectTemplate.write(context, input.genAnalyzeTaskDef().file(generatedJavaSourcesDirectory), input);
         indexAstTaskDefTemplate.write(context, input.genIndexAstTaskDef().file(generatedJavaSourcesDirectory), input);
@@ -163,7 +163,7 @@ public class MultilangAnalyzerAdapterCompiler implements TaskDef<MultilangAnalyz
         // List of all generated files
 
         default ListView<ResourcePath> generatedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/MultilangAnalyzerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/MultilangAnalyzerAdapterCompiler.java
@@ -45,11 +45,11 @@ public class MultilangAnalyzerAdapterCompiler implements TaskDef<MultilangAnalyz
         final Output.Builder outputBuilder = Output.builder();
         if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        analyzeProjectTemplate.write(context, input.genAnalyzeTaskDef().file(generatedJavaSourcesDirectory), input);
-        indexAstTaskDefTemplate.write(context, input.genIndexAstTaskDef().file(generatedJavaSourcesDirectory), input);
-        preStatixTaskDefTemplate.write(context, input.genPreStatixTaskDef().file(generatedJavaSourcesDirectory), input);
-        postStatixTaskDefTemplate.write(context, input.genPostStatixTaskDef().file(generatedJavaSourcesDirectory), input);
-        checkTaskDefTemplate.write(context, input.genCheckTaskDef().file(generatedJavaSourcesDirectory), input);
+        analyzeProjectTemplate.write(context, input.baseAnalyzeTaskDef().file(generatedJavaSourcesDirectory), input);
+        indexAstTaskDefTemplate.write(context, input.baseIndexAstTaskDef().file(generatedJavaSourcesDirectory), input);
+        preStatixTaskDefTemplate.write(context, input.basePreStatixTaskDef().file(generatedJavaSourcesDirectory), input);
+        postStatixTaskDefTemplate.write(context, input.basePostStatixTaskDef().file(generatedJavaSourcesDirectory), input);
+        checkTaskDefTemplate.write(context, input.baseCheckTaskDef().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
     }
 
@@ -73,56 +73,56 @@ public class MultilangAnalyzerAdapterCompiler implements TaskDef<MultilangAnalyz
 
         // Analyze
 
-        @Value.Default default TypeInfo genAnalyzeTaskDef() {
+        @Value.Default default TypeInfo baseAnalyzeTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "AnalyzeProject");
         }
 
-        Optional<TypeInfo> extendedAnalyzeTaskDef();
+        Optional<TypeInfo> extendAnalyzeTaskDef();
 
         default TypeInfo analyzeTaskDef() {
-            return extendedAnalyzeTaskDef().orElseGet(this::genAnalyzeTaskDef);
+            return extendAnalyzeTaskDef().orElseGet(this::baseAnalyzeTaskDef);
         }
 
         // Transformation tasks
 
-        @Value.Default default TypeInfo genIndexAstTaskDef() {
+        @Value.Default default TypeInfo baseIndexAstTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "IndexAst");
         }
 
-        Optional<TypeInfo> extendedIndexAstTaskDef();
+        Optional<TypeInfo> extendIndexAstTaskDef();
 
         default TypeInfo indexAstTaskDef() {
-            return extendedIndexAstTaskDef().orElseGet(this::genIndexAstTaskDef);
+            return extendIndexAstTaskDef().orElseGet(this::baseIndexAstTaskDef);
         }
 
-        @Value.Default default TypeInfo genPreStatixTaskDef() {
+        @Value.Default default TypeInfo basePreStatixTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "PreStatix");
         }
 
-        Optional<TypeInfo> extendedPreStatixTaskDef();
+        Optional<TypeInfo> extendPreStatixTaskDef();
 
         default TypeInfo preStatixTaskDef() {
-            return extendedPreStatixTaskDef().orElseGet(this::genPreStatixTaskDef);
+            return extendPreStatixTaskDef().orElseGet(this::basePreStatixTaskDef);
         }
 
-        @Value.Default default TypeInfo genPostStatixTaskDef() {
+        @Value.Default default TypeInfo basePostStatixTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "PostStatix");
         }
 
-        Optional<TypeInfo> extendedPostStatixTaskDef();
+        Optional<TypeInfo> extendPostStatixTaskDef();
 
         default TypeInfo postStatixTaskDef() {
-            return extendedPostStatixTaskDef().orElseGet(this::genPostStatixTaskDef);
+            return extendPostStatixTaskDef().orElseGet(this::basePostStatixTaskDef);
         }
 
-        @Value.Default default TypeInfo genCheckTaskDef() {
+        @Value.Default default TypeInfo baseCheckTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "SmlCheck");
         }
 
-        Optional<TypeInfo> extendedCheckTaskDef();
+        Optional<TypeInfo> extendCheckTaskDef();
 
         default TypeInfo checkTaskDef() {
-            return extendedCheckTaskDef().orElseGet(this::genCheckTaskDef);
+            return extendCheckTaskDef().orElseGet(this::baseCheckTaskDef);
         }
 
         // Transformation settings
@@ -167,11 +167,11 @@ public class MultilangAnalyzerAdapterCompiler implements TaskDef<MultilangAnalyz
                 return ListView.of();
             }
             return ListView.of(
-                genAnalyzeTaskDef().file(generatedJavaSourcesDirectory()),
-                genIndexAstTaskDef().file(generatedJavaSourcesDirectory()),
-                genPreStatixTaskDef().file(generatedJavaSourcesDirectory()),
-                genPostStatixTaskDef().file(generatedJavaSourcesDirectory()),
-                genCheckTaskDef().file(generatedJavaSourcesDirectory())
+                baseAnalyzeTaskDef().file(generatedJavaSourcesDirectory()),
+                baseIndexAstTaskDef().file(generatedJavaSourcesDirectory()),
+                basePreStatixTaskDef().file(generatedJavaSourcesDirectory()),
+                basePostStatixTaskDef().file(generatedJavaSourcesDirectory()),
+                baseCheckTaskDef().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/MultilangAnalyzerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/MultilangAnalyzerAdapterCompiler.java
@@ -77,13 +77,10 @@ public class MultilangAnalyzerAdapterCompiler implements TaskDef<MultilangAnalyz
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "AnalyzeProject");
         }
 
-        Optional<TypeInfo> manualAnalyzeTaskDef();
+        Optional<TypeInfo> extendedAnalyzeTaskDef();
 
         default TypeInfo analyzeTaskDef() {
-            if(classKind().isManual() && manualAnalyzeTaskDef().isPresent()) {
-                return manualAnalyzeTaskDef().get();
-            }
-            return genAnalyzeTaskDef();
+            return extendedAnalyzeTaskDef().orElseGet(this::genAnalyzeTaskDef);
         }
 
         // Transformation tasks
@@ -92,52 +89,40 @@ public class MultilangAnalyzerAdapterCompiler implements TaskDef<MultilangAnalyz
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "IndexAst");
         }
 
-        Optional<TypeInfo> manualIndexAstTaskDef();
+        Optional<TypeInfo> extendedIndexAstTaskDef();
 
         default TypeInfo indexAstTaskDef() {
-            if(classKind().isManual() && manualIndexAstTaskDef().isPresent()) {
-                return manualIndexAstTaskDef().get();
-            }
-            return genIndexAstTaskDef();
+            return extendedIndexAstTaskDef().orElseGet(this::genIndexAstTaskDef);
         }
 
         @Value.Default default TypeInfo genPreStatixTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "PreStatix");
         }
 
-        Optional<TypeInfo> manualPreStatixTaskDef();
+        Optional<TypeInfo> extendedPreStatixTaskDef();
 
         default TypeInfo preStatixTaskDef() {
-            if(classKind().isManual() && manualPreStatixTaskDef().isPresent()) {
-                return manualPreStatixTaskDef().get();
-            }
-            return genPreStatixTaskDef();
+            return extendedPreStatixTaskDef().orElseGet(this::genPreStatixTaskDef);
         }
 
         @Value.Default default TypeInfo genPostStatixTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "PostStatix");
         }
 
-        Optional<TypeInfo> manualPostStatixTaskDef();
+        Optional<TypeInfo> extendedPostStatixTaskDef();
 
         default TypeInfo postStatixTaskDef() {
-            if(classKind().isManual() && manualPostStatixTaskDef().isPresent()) {
-                return manualPostStatixTaskDef().get();
-            }
-            return genPostStatixTaskDef();
+            return extendedPostStatixTaskDef().orElseGet(this::genPostStatixTaskDef);
         }
 
         @Value.Default default TypeInfo genCheckTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "SmlCheck");
         }
 
-        Optional<TypeInfo> manualCheckTaskDef();
+        Optional<TypeInfo> extendedCheckTaskDef();
 
         default TypeInfo checkTaskDef() {
-            if(classKind().isManual() && manualCheckTaskDef().isPresent()) {
-                return manualCheckTaskDef().get();
-            }
-            return genCheckTaskDef();
+            return extendedCheckTaskDef().orElseGet(this::genCheckTaskDef);
         }
 
         // Transformation settings

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ParserAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ParserAdapterCompiler.java
@@ -36,7 +36,7 @@ public class ParserAdapterCompiler implements TaskDef<ParserAdapterCompiler.Inpu
 
     @Override public Output exec(ExecContext context, Input input) throws IOException {
         final Output.Builder outputBuilder = Output.builder();
-        if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
+        if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         parseTaskDefTemplate.write(context, input.genParseTaskDef().file(generatedJavaSourcesDirectory), input);
         tokenizeTaskDefTemplate.write(context, input.genTokenizeTaskDef().file(generatedJavaSourcesDirectory), input);

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ParserAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ParserAdapterCompiler.java
@@ -76,13 +76,10 @@ public class ParserAdapterCompiler implements TaskDef<ParserAdapterCompiler.Inpu
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Parse");
         }
 
-        Optional<TypeInfo> manualParseTaskDef();
+        Optional<TypeInfo> extendedParseTaskDef();
 
         default TypeInfo parseTaskDef() {
-            if(classKind().isManual() && manualParseTaskDef().isPresent()) {
-                return manualParseTaskDef().get();
-            }
-            return genParseTaskDef();
+            return extendedParseTaskDef().orElseGet(this::genParseTaskDef);
         }
 
         // Tokenize task definition
@@ -91,20 +88,17 @@ public class ParserAdapterCompiler implements TaskDef<ParserAdapterCompiler.Inpu
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Tokenize");
         }
 
-        Optional<TypeInfo> manualTokenizeTaskDef();
+        Optional<TypeInfo> extendedTokenizeTaskDef();
 
         default TypeInfo tokenizeTaskDef() {
-            if(classKind().isManual() && manualTokenizeTaskDef().isPresent()) {
-                return manualTokenizeTaskDef().get();
-            }
-            return genTokenizeTaskDef();
+            return extendedTokenizeTaskDef().orElseGet(this::genTokenizeTaskDef);
         }
 
 
         // List of all generated files
 
         default ListView<ResourcePath> generatedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ParserAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ParserAdapterCompiler.java
@@ -38,8 +38,8 @@ public class ParserAdapterCompiler implements TaskDef<ParserAdapterCompiler.Inpu
         final Output.Builder outputBuilder = Output.builder();
         if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        parseTaskDefTemplate.write(context, input.genParseTaskDef().file(generatedJavaSourcesDirectory), input);
-        tokenizeTaskDefTemplate.write(context, input.genTokenizeTaskDef().file(generatedJavaSourcesDirectory), input);
+        parseTaskDefTemplate.write(context, input.baseParseTaskDef().file(generatedJavaSourcesDirectory), input);
+        tokenizeTaskDefTemplate.write(context, input.baseTokenizeTaskDef().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
     }
 
@@ -72,26 +72,26 @@ public class ParserAdapterCompiler implements TaskDef<ParserAdapterCompiler.Inpu
 
         // Parse task definition
 
-        @Value.Default default TypeInfo genParseTaskDef() {
+        @Value.Default default TypeInfo baseParseTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Parse");
         }
 
-        Optional<TypeInfo> extendedParseTaskDef();
+        Optional<TypeInfo> extendParseTaskDef();
 
         default TypeInfo parseTaskDef() {
-            return extendedParseTaskDef().orElseGet(this::genParseTaskDef);
+            return extendParseTaskDef().orElseGet(this::baseParseTaskDef);
         }
 
         // Tokenize task definition
 
-        @Value.Default default TypeInfo genTokenizeTaskDef() {
+        @Value.Default default TypeInfo baseTokenizeTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Tokenize");
         }
 
-        Optional<TypeInfo> extendedTokenizeTaskDef();
+        Optional<TypeInfo> extendTokenizeTaskDef();
 
         default TypeInfo tokenizeTaskDef() {
-            return extendedTokenizeTaskDef().orElseGet(this::genTokenizeTaskDef);
+            return extendTokenizeTaskDef().orElseGet(this::baseTokenizeTaskDef);
         }
 
 
@@ -102,8 +102,8 @@ public class ParserAdapterCompiler implements TaskDef<ParserAdapterCompiler.Inpu
                 return ListView.of();
             }
             return ListView.of(
-                genParseTaskDef().file(generatedJavaSourcesDirectory()),
-                genTokenizeTaskDef().file(generatedJavaSourcesDirectory())
+                baseParseTaskDef().file(generatedJavaSourcesDirectory()),
+                baseTokenizeTaskDef().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ParserAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ParserAdapterCompiler.java
@@ -118,15 +118,7 @@ public class ParserAdapterCompiler implements TaskDef<ParserAdapterCompiler.Inpu
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManualOnly();
-            if(!manual) return;
-            if(!manualParseTaskDef().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualParseTaskDef' has not been set");
-            }
-            if(!manualTokenizeTaskDef().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualTokenizeTaskDef' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/StylerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/StylerAdapterCompiler.java
@@ -35,7 +35,7 @@ public class StylerAdapterCompiler implements TaskDef<StylerAdapterCompiler.Inpu
         final Output.Builder outputBuilder = Output.builder();
         if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        styleTaskDefTemplate.write(context, input.genStyleTaskDef().file(generatedJavaSourcesDirectory), input);
+        styleTaskDefTemplate.write(context, input.baseStyleTaskDef().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
     }
 
@@ -60,14 +60,14 @@ public class StylerAdapterCompiler implements TaskDef<StylerAdapterCompiler.Inpu
 
         // Style task definition
 
-        @Value.Default default TypeInfo genStyleTaskDef() {
+        @Value.Default default TypeInfo baseStyleTaskDef() {
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Style");
         }
 
-        Optional<TypeInfo> extendedStyleTaskDef();
+        Optional<TypeInfo> extendStyleTaskDef();
 
         default TypeInfo styleTaskDef() {
-            return extendedStyleTaskDef().orElseGet(this::genStyleTaskDef);
+            return extendStyleTaskDef().orElseGet(this::baseStyleTaskDef);
         }
 
 
@@ -78,7 +78,7 @@ public class StylerAdapterCompiler implements TaskDef<StylerAdapterCompiler.Inpu
                 return ListView.of();
             }
             return ListView.of(
-                genStyleTaskDef().file(generatedJavaSourcesDirectory())
+                baseStyleTaskDef().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/StylerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/StylerAdapterCompiler.java
@@ -33,7 +33,7 @@ public class StylerAdapterCompiler implements TaskDef<StylerAdapterCompiler.Inpu
 
     @Override public Output exec(ExecContext context, Input input) throws IOException {
         final Output.Builder outputBuilder = Output.builder();
-        if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
+        if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         styleTaskDefTemplate.write(context, input.genStyleTaskDef().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/StylerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/StylerAdapterCompiler.java
@@ -64,20 +64,17 @@ public class StylerAdapterCompiler implements TaskDef<StylerAdapterCompiler.Inpu
             return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Style");
         }
 
-        Optional<TypeInfo> manualStyleTaskDef();
+        Optional<TypeInfo> extendedStyleTaskDef();
 
         default TypeInfo styleTaskDef() {
-            if(classKind().isManual() && manualStyleTaskDef().isPresent()) {
-                return manualStyleTaskDef().get();
-            }
-            return genStyleTaskDef();
+            return extendedStyleTaskDef().orElseGet(this::genStyleTaskDef);
         }
 
 
         /// List of all generated files
 
         default ListView<ResourcePath> generatedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/StylerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/StylerAdapterCompiler.java
@@ -93,12 +93,7 @@ public class StylerAdapterCompiler implements TaskDef<StylerAdapterCompiler.Inpu
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManualOnly();
-            if(!manual) return;
-            if(!manualStyleTaskDef().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualStyleTaskDef' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ClassloaderResourcesCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ClassloaderResourcesCompiler.java
@@ -92,12 +92,7 @@ public class ClassloaderResourcesCompiler implements TaskDef<ClassloaderResource
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManual();
-            if(!manual) return;
-            if(!manualClassloaderResources().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualClassloaderResources' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ClassloaderResourcesCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ClassloaderResourcesCompiler.java
@@ -34,7 +34,7 @@ public class ClassloaderResourcesCompiler implements TaskDef<ClassloaderResource
         final Output.Builder outputBuilder = Output.builder();
         if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        classloaderResourcesTemplate.write(context, input.genClassloaderResources().file(generatedJavaSourcesDirectory), input);
+        classloaderResourcesTemplate.write(context, input.baseClassloaderResources().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
     }
 
@@ -58,14 +58,14 @@ public class ClassloaderResourcesCompiler implements TaskDef<ClassloaderResource
 
         // Classloader resources
 
-        @Value.Default default TypeInfo genClassloaderResources() {
+        @Value.Default default TypeInfo baseClassloaderResources() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "ClassloaderResources");
         }
 
-        Optional<TypeInfo> extendedClassloaderResources();
+        Optional<TypeInfo> extendClassloaderResources();
 
         default TypeInfo classloaderResources() {
-            return extendedClassloaderResources().orElseGet(this::genClassloaderResources);
+            return extendClassloaderResources().orElseGet(this::baseClassloaderResources);
         }
 
         @Value.Default default String qualifier() {
@@ -79,7 +79,7 @@ public class ClassloaderResourcesCompiler implements TaskDef<ClassloaderResource
                 return ListView.of();
             }
             return ListView.of(
-                genClassloaderResources().file(generatedJavaSourcesDirectory())
+                baseClassloaderResources().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ClassloaderResourcesCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ClassloaderResourcesCompiler.java
@@ -32,7 +32,7 @@ public class ClassloaderResourcesCompiler implements TaskDef<ClassloaderResource
 
     @Override public Output exec(ExecContext context, Input input) throws IOException {
         final Output.Builder outputBuilder = Output.builder();
-        if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
+        if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         classloaderResourcesTemplate.write(context, input.genClassloaderResources().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
@@ -75,7 +75,7 @@ public class ClassloaderResourcesCompiler implements TaskDef<ClassloaderResource
         /// List of all provided files
 
         default ListView<ResourcePath> providedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ClassloaderResourcesCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ClassloaderResourcesCompiler.java
@@ -62,13 +62,10 @@ public class ClassloaderResourcesCompiler implements TaskDef<ClassloaderResource
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "ClassloaderResources");
         }
 
-        Optional<TypeInfo> manualClassloaderResources();
+        Optional<TypeInfo> extendedClassloaderResources();
 
         default TypeInfo classloaderResources() {
-            if(classKind().isManual() && manualClassloaderResources().isPresent()) {
-                return manualClassloaderResources().get();
-            }
-            return genClassloaderResources();
+            return extendedClassloaderResources().orElseGet(this::genClassloaderResources);
         }
 
         @Value.Default default String qualifier() {

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/CompleterLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/CompleterLanguageCompiler.java
@@ -93,12 +93,7 @@ public class CompleterLanguageCompiler implements TaskDef<CompleterLanguageCompi
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManual();
-            if(!manual) return;
-            if(!manualCompleter().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualCompleter' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/CompleterLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/CompleterLanguageCompiler.java
@@ -26,7 +26,7 @@ public class CompleterLanguageCompiler implements TaskDef<CompleterLanguageCompi
 
     @Override public Output exec(ExecContext context, Input input) throws IOException {
         final Output.Builder outputBuilder = Output.builder();
-        if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
+        if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         return outputBuilder.build();
     }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/CompleterLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/CompleterLanguageCompiler.java
@@ -62,14 +62,14 @@ public class CompleterLanguageCompiler implements TaskDef<CompleterLanguageCompi
 
         // Completer
 
-        @Value.Default default TypeInfo genCompleter() {
+        @Value.Default default TypeInfo baseCompleter() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "Completer");
         }
 
-        Optional<TypeInfo> extendedCompleter();
+        Optional<TypeInfo> extendCompleter();
 
         default TypeInfo completer() {
-            return extendedCompleter().orElseGet(this::genCompleter);
+            return extendCompleter().orElseGet(this::baseCompleter);
         }
 
 
@@ -80,7 +80,7 @@ public class CompleterLanguageCompiler implements TaskDef<CompleterLanguageCompi
                 return ListView.of();
             }
             return ListView.of(
-                genCompleter().file(generatedJavaSourcesDirectory())
+                baseCompleter().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/CompleterLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/CompleterLanguageCompiler.java
@@ -66,20 +66,17 @@ public class CompleterLanguageCompiler implements TaskDef<CompleterLanguageCompi
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "Completer");
         }
 
-        Optional<TypeInfo> manualCompleter();
+        Optional<TypeInfo> extendedCompleter();
 
         default TypeInfo completer() {
-            if(classKind().isManual() && manualCompleter().isPresent()) {
-                return manualCompleter().get();
-            }
-            return genCompleter();
+            return extendedCompleter().orElseGet(this::genCompleter);
         }
 
 
         /// List of all provided files
 
         default ListView<ResourcePath> providedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ConstraintAnalyzerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ConstraintAnalyzerLanguageCompiler.java
@@ -37,7 +37,7 @@ public class ConstraintAnalyzerLanguageCompiler implements TaskDef<ConstraintAna
         if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         constraintAnalyzerTemplate.write(context, input.genConstraintAnalyzer().file(generatedJavaSourcesDirectory), input);
-        factoryTemplate.write(context, input.genFactory().file(generatedJavaSourcesDirectory), input);
+        factoryTemplate.write(context, input.genConstraintAnalyzerFactory().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
     }
 
@@ -81,40 +81,34 @@ public class ConstraintAnalyzerLanguageCompiler implements TaskDef<ConstraintAna
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "ConstraintAnalyzer");
         }
 
-        Optional<TypeInfo> manualConstraintAnalyzer();
+        Optional<TypeInfo> extendedConstraintAnalyzer();
 
         default TypeInfo constraintAnalyzer() {
-            if(classKind().isManual() && manualConstraintAnalyzer().isPresent()) {
-                return manualConstraintAnalyzer().get();
-            }
-            return genConstraintAnalyzer();
+            return extendedConstraintAnalyzer().orElseGet(this::genConstraintAnalyzer);
         }
 
         // Constraint analyzer factory
 
-        @Value.Default default TypeInfo genFactory() {
+        @Value.Default default TypeInfo genConstraintAnalyzerFactory() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "ConstraintAnalyzerFactory");
         }
 
-        Optional<TypeInfo> manualFactory();
+        Optional<TypeInfo> extendedConstraintAnalyzerFactory();
 
-        default TypeInfo factory() {
-            if(classKind().isManual() && manualFactory().isPresent()) {
-                return manualFactory().get();
-            }
-            return genFactory();
+        default TypeInfo constraintAnalyzerFactory() {
+            return extendedConstraintAnalyzerFactory().orElseGet(this::genConstraintAnalyzerFactory);
         }
 
 
         // List of all provided files
 
         default ListView<ResourcePath> providedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(
                 genConstraintAnalyzer().file(generatedJavaSourcesDirectory()),
-                genFactory().file(generatedJavaSourcesDirectory())
+                genConstraintAnalyzerFactory().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ConstraintAnalyzerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ConstraintAnalyzerLanguageCompiler.java
@@ -132,15 +132,7 @@ public class ConstraintAnalyzerLanguageCompiler implements TaskDef<ConstraintAna
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManual();
-            if(!manual) return;
-            if(!manualConstraintAnalyzer().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualConstraintAnalyzer' has not been set");
-            }
-            if(!manualFactory().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualFactory' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ConstraintAnalyzerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ConstraintAnalyzerLanguageCompiler.java
@@ -36,8 +36,8 @@ public class ConstraintAnalyzerLanguageCompiler implements TaskDef<ConstraintAna
         final Output.Builder outputBuilder = Output.builder();
         if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        constraintAnalyzerTemplate.write(context, input.genConstraintAnalyzer().file(generatedJavaSourcesDirectory), input);
-        factoryTemplate.write(context, input.genConstraintAnalyzerFactory().file(generatedJavaSourcesDirectory), input);
+        constraintAnalyzerTemplate.write(context, input.baseConstraintAnalyzer().file(generatedJavaSourcesDirectory), input);
+        factoryTemplate.write(context, input.baseConstraintAnalyzerFactory().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
     }
 
@@ -77,26 +77,26 @@ public class ConstraintAnalyzerLanguageCompiler implements TaskDef<ConstraintAna
 
         // Constraint analyzer
 
-        @Value.Default default TypeInfo genConstraintAnalyzer() {
+        @Value.Default default TypeInfo baseConstraintAnalyzer() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "ConstraintAnalyzer");
         }
 
-        Optional<TypeInfo> extendedConstraintAnalyzer();
+        Optional<TypeInfo> extendConstraintAnalyzer();
 
         default TypeInfo constraintAnalyzer() {
-            return extendedConstraintAnalyzer().orElseGet(this::genConstraintAnalyzer);
+            return extendConstraintAnalyzer().orElseGet(this::baseConstraintAnalyzer);
         }
 
         // Constraint analyzer factory
 
-        @Value.Default default TypeInfo genConstraintAnalyzerFactory() {
+        @Value.Default default TypeInfo baseConstraintAnalyzerFactory() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "ConstraintAnalyzerFactory");
         }
 
-        Optional<TypeInfo> extendedConstraintAnalyzerFactory();
+        Optional<TypeInfo> extendConstraintAnalyzerFactory();
 
         default TypeInfo constraintAnalyzerFactory() {
-            return extendedConstraintAnalyzerFactory().orElseGet(this::genConstraintAnalyzerFactory);
+            return extendConstraintAnalyzerFactory().orElseGet(this::baseConstraintAnalyzerFactory);
         }
 
 
@@ -107,8 +107,8 @@ public class ConstraintAnalyzerLanguageCompiler implements TaskDef<ConstraintAna
                 return ListView.of();
             }
             return ListView.of(
-                genConstraintAnalyzer().file(generatedJavaSourcesDirectory()),
-                genConstraintAnalyzerFactory().file(generatedJavaSourcesDirectory())
+                baseConstraintAnalyzer().file(generatedJavaSourcesDirectory()),
+                baseConstraintAnalyzerFactory().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ConstraintAnalyzerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ConstraintAnalyzerLanguageCompiler.java
@@ -34,7 +34,7 @@ public class ConstraintAnalyzerLanguageCompiler implements TaskDef<ConstraintAna
 
     @Override public Output exec(ExecContext context, Input input) throws Exception {
         final Output.Builder outputBuilder = Output.builder();
-        if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
+        if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         constraintAnalyzerTemplate.write(context, input.genConstraintAnalyzer().file(generatedJavaSourcesDirectory), input);
         factoryTemplate.write(context, input.genConstraintAnalyzerFactory().file(generatedJavaSourcesDirectory), input);

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ExportsLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ExportsLanguageCompiler.java
@@ -50,7 +50,7 @@ public class ExportsLanguageCompiler implements TaskDef<ExportsLanguageCompiler.
             final UniqueNamer uniqueNamer = new UniqueNamer();
             final HashMap<String, Object> map = new HashMap<>();
             map.put("combinedExports", combinedExports.values());
-            exportsTemplate.write(context, input.genExports().file(generatedJavaSourcesDirectory), input, map);
+            exportsTemplate.write(context, input.baseExports().file(generatedJavaSourcesDirectory), input, map);
         }
         return None.instance;
     }
@@ -91,14 +91,14 @@ public class ExportsLanguageCompiler implements TaskDef<ExportsLanguageCompiler.
 
         // Completer
 
-        @Value.Default default TypeInfo genExports() {
+        @Value.Default default TypeInfo baseExports() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "Exports");
         }
 
-        Optional<TypeInfo> extendedExports();
+        Optional<TypeInfo> extendExports();
 
         default TypeInfo exportsClass() {
-            return extendedExports().orElseGet(this::genExports);
+            return extendExports().orElseGet(this::baseExports);
         }
 
 
@@ -109,7 +109,7 @@ public class ExportsLanguageCompiler implements TaskDef<ExportsLanguageCompiler.
                 return ListView.of();
             }
             return ListView.of(
-                genExports().file(generatedJavaSourcesDirectory())
+                baseExports().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ExportsLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ExportsLanguageCompiler.java
@@ -39,7 +39,7 @@ public class ExportsLanguageCompiler implements TaskDef<ExportsLanguageCompiler.
     }
 
     @Override public None exec(ExecContext context, Input input) throws IOException {
-        if(input.classKind().isManualOnly()) return None.instance; // Nothing to generate: return.
+        if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         { // Exports
             final HashMap<String, CombinedExport> combinedExports = new HashMap<>();
@@ -50,7 +50,7 @@ public class ExportsLanguageCompiler implements TaskDef<ExportsLanguageCompiler.
             final UniqueNamer uniqueNamer = new UniqueNamer();
             final HashMap<String, Object> map = new HashMap<>();
             map.put("combinedExports", combinedExports.values());
-            exportsTemplate.write(context, input.genExportsClass().file(generatedJavaSourcesDirectory), input, map);
+            exportsTemplate.write(context, input.genExports().file(generatedJavaSourcesDirectory), input, map);
         }
         return None.instance;
     }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ExportsLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ExportsLanguageCompiler.java
@@ -122,12 +122,7 @@ public class ExportsLanguageCompiler implements TaskDef<ExportsLanguageCompiler.
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManualOnly();
-            if(!manual) return;
-            if(!manualExportsClass().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualExportsClass' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ExportsLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ExportsLanguageCompiler.java
@@ -91,28 +91,25 @@ public class ExportsLanguageCompiler implements TaskDef<ExportsLanguageCompiler.
 
         // Completer
 
-        @Value.Default default TypeInfo genExportsClass() {
+        @Value.Default default TypeInfo genExports() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "Exports");
         }
 
-        Optional<TypeInfo> manualExportsClass();
+        Optional<TypeInfo> extendedExports();
 
         default TypeInfo exportsClass() {
-            if(classKind().isManual() && manualExportsClass().isPresent()) {
-                return manualExportsClass().get();
-            }
-            return genExportsClass();
+            return extendedExports().orElseGet(this::genExports);
         }
 
 
         /// List of all provided files
 
         default ListView<ResourcePath> providedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(
-                genExportsClass().file(generatedJavaSourcesDirectory())
+                genExports().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/LanguageProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/LanguageProjectCompiler.java
@@ -64,7 +64,7 @@ public class LanguageProjectCompiler implements TaskDef<LanguageProjectCompiler.
 
         // Class files.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        packageInfoTemplate.write(context, input.genPackageInfo().file(generatedJavaSourcesDirectory), input);
+        packageInfoTemplate.write(context, input.basePackageInfo().file(generatedJavaSourcesDirectory), input);
 
         // Files from other compilers.
         context.require(classloaderResourcesCompiler, input.classloaderResources());
@@ -152,7 +152,7 @@ public class LanguageProjectCompiler implements TaskDef<LanguageProjectCompiler.
 
         // package-info
 
-        @Value.Default default TypeInfo genPackageInfo() {
+        @Value.Default default TypeInfo basePackageInfo() {
             return TypeInfo.of(languageProject().packageId(), "package-info");
         }
 
@@ -162,7 +162,7 @@ public class LanguageProjectCompiler implements TaskDef<LanguageProjectCompiler.
             if(classKind().isManual() && manualPackageInfo().isPresent()) {
                 return manualPackageInfo().get();
             }
-            return genPackageInfo();
+            return basePackageInfo();
         }
 
 
@@ -171,7 +171,7 @@ public class LanguageProjectCompiler implements TaskDef<LanguageProjectCompiler.
         default ArrayList<ResourcePath> providedFiles() {
             final ArrayList<ResourcePath> providedFiles = new ArrayList<>();
             if(classKind().isGenerating()) {
-                providedFiles.add(genPackageInfo().file(generatedJavaSourcesDirectory()));
+                providedFiles.add(basePackageInfo().file(generatedJavaSourcesDirectory()));
             }
             parser().ifPresent((i) -> i.providedFiles().addAllTo(providedFiles));
             styler().ifPresent((i) -> i.providedFiles().addAllTo(providedFiles));

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/MultilangAnalyzerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/MultilangAnalyzerLanguageCompiler.java
@@ -37,7 +37,7 @@ public class MultilangAnalyzerLanguageCompiler implements TaskDef<MultilangAnaly
         final Output.Builder outputBuilder = Output.builder();
         if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        specConfigFactoryTemplate.write(context, input.genSpecConfigFactory().file(generatedJavaSourcesDirectory), input);
+        specConfigFactoryTemplate.write(context, input.baseSpecConfigFactory().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
     }
 
@@ -64,14 +64,14 @@ public class MultilangAnalyzerLanguageCompiler implements TaskDef<MultilangAnaly
 
         // Spec factory
 
-        @Value.Default default TypeInfo genSpecConfigFactory() {
+        @Value.Default default TypeInfo baseSpecConfigFactory() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "SpecConfigFactory");
         }
 
-        Optional<TypeInfo> extendedSpecConfigFactory();
+        Optional<TypeInfo> extendSpecConfigFactory();
 
         default TypeInfo specConfigFactory() {
-            return extendedSpecConfigFactory().orElseGet(this::genSpecConfigFactory);
+            return extendSpecConfigFactory().orElseGet(this::baseSpecConfigFactory);
         }
 
         @Value.Default default String languageId() { return shared().defaultPackageId(); }
@@ -88,7 +88,7 @@ public class MultilangAnalyzerLanguageCompiler implements TaskDef<MultilangAnaly
                 return ListView.of();
             }
             return ListView.of(
-                genSpecConfigFactory().file(generatedJavaSourcesDirectory())
+                baseSpecConfigFactory().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/MultilangAnalyzerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/MultilangAnalyzerLanguageCompiler.java
@@ -68,13 +68,10 @@ public class MultilangAnalyzerLanguageCompiler implements TaskDef<MultilangAnaly
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "SpecConfigFactory");
         }
 
-        Optional<TypeInfo> manualSpecConfigFactory();
+        Optional<TypeInfo> extendedSpecConfigFactory();
 
         default TypeInfo specConfigFactory() {
-            if(classKind().isManual() && manualSpecConfigFactory().isPresent()) {
-                return manualSpecConfigFactory().get();
-            }
-            return genSpecConfigFactory();
+            return extendedSpecConfigFactory().orElseGet(this::genSpecConfigFactory);
         }
 
         @Value.Default default String languageId() { return shared().defaultPackageId(); }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/MultilangAnalyzerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/MultilangAnalyzerLanguageCompiler.java
@@ -35,7 +35,7 @@ public class MultilangAnalyzerLanguageCompiler implements TaskDef<MultilangAnaly
 
     @Override public Output exec(ExecContext context, Input input) throws IOException {
         final Output.Builder outputBuilder = Output.builder();
-        if(input.classKind().isManualOnly()) return outputBuilder.build(); // Nothing to generate: return.
+        if(input.classKind().isManual()) return outputBuilder.build(); // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         specConfigFactoryTemplate.write(context, input.genSpecConfigFactory().file(generatedJavaSourcesDirectory), input);
         return outputBuilder.build();
@@ -84,7 +84,7 @@ public class MultilangAnalyzerLanguageCompiler implements TaskDef<MultilangAnaly
         // List of all provided files
 
         default ListView<ResourcePath> providedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ParserLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ParserLanguageCompiler.java
@@ -37,7 +37,7 @@ public class ParserLanguageCompiler implements TaskDef<ParserLanguageCompiler.In
     }
 
     @Override public None exec(ExecContext context, Input input) throws IOException {
-        if(input.classKind().isManualOnly()) return None.instance; // Nothing to generate: return.
+        if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         tableTemplate.write(context, input.genTable().file(generatedJavaSourcesDirectory), input);
         parserTemplate.write(context, input.genParser().file(generatedJavaSourcesDirectory), input);

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ParserLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ParserLanguageCompiler.java
@@ -138,15 +138,7 @@ public class ParserLanguageCompiler implements TaskDef<ParserLanguageCompiler.In
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManual();
-            if(!manual) return;
-            if(!manualParser().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualParser' has not been set");
-            }
-            if(!manualFactory().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualFactory' has not been set");
-            }
+
         }
     }
 }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ParserLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ParserLanguageCompiler.java
@@ -41,7 +41,7 @@ public class ParserLanguageCompiler implements TaskDef<ParserLanguageCompiler.In
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         tableTemplate.write(context, input.genTable().file(generatedJavaSourcesDirectory), input);
         parserTemplate.write(context, input.genParser().file(generatedJavaSourcesDirectory), input);
-        factoryTemplate.write(context, input.genFactory().file(generatedJavaSourcesDirectory), input);
+        factoryTemplate.write(context, input.genParserFactory().file(generatedJavaSourcesDirectory), input);
         return None.instance;
     }
 
@@ -97,41 +97,35 @@ public class ParserLanguageCompiler implements TaskDef<ParserLanguageCompiler.In
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "Parser");
         }
 
-        Optional<TypeInfo> manualParser();
+        Optional<TypeInfo> extendedParser();
 
         default TypeInfo parser() {
-            if(classKind().isManual() && manualParser().isPresent()) {
-                return manualParser().get();
-            }
-            return genParser();
+            return extendedParser().orElseGet(this::genParser);
         }
 
         // Parser factory
 
-        @Value.Default default TypeInfo genFactory() {
+        @Value.Default default TypeInfo genParserFactory() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "ParserFactory");
         }
 
-        Optional<TypeInfo> manualFactory();
+        Optional<TypeInfo> extendedParserFactory();
 
-        default TypeInfo factory() {
-            if(classKind().isManual() && manualFactory().isPresent()) {
-                return manualFactory().get();
-            }
-            return genFactory();
+        default TypeInfo parserFactory() {
+            return extendedParserFactory().orElseGet(this::genParserFactory);
         }
 
 
         /// List of all provided files
 
         default ListView<ResourcePath> providedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(
                 genTable().file(generatedJavaSourcesDirectory()),
                 genParser().file(generatedJavaSourcesDirectory()),
-                genFactory().file(generatedJavaSourcesDirectory())
+                genParserFactory().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ParserLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/ParserLanguageCompiler.java
@@ -39,9 +39,9 @@ public class ParserLanguageCompiler implements TaskDef<ParserLanguageCompiler.In
     @Override public None exec(ExecContext context, Input input) throws IOException {
         if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        tableTemplate.write(context, input.genTable().file(generatedJavaSourcesDirectory), input);
-        parserTemplate.write(context, input.genParser().file(generatedJavaSourcesDirectory), input);
-        factoryTemplate.write(context, input.genParserFactory().file(generatedJavaSourcesDirectory), input);
+        tableTemplate.write(context, input.baseParseTable().file(generatedJavaSourcesDirectory), input);
+        parserTemplate.write(context, input.baseParser().file(generatedJavaSourcesDirectory), input);
+        factoryTemplate.write(context, input.baseParserFactory().file(generatedJavaSourcesDirectory), input);
         return None.instance;
     }
 
@@ -87,32 +87,38 @@ public class ParserLanguageCompiler implements TaskDef<ParserLanguageCompiler.In
 
         // Parse table
 
-        @Value.Default default TypeInfo genTable() {
+        @Value.Default default TypeInfo baseParseTable() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "ParseTable");
+        }
+
+        Optional<TypeInfo> extendParseTable();
+
+        default TypeInfo parseTable() {
+            return extendParseTable().orElseGet(this::baseParseTable);
         }
 
         // Parser
 
-        @Value.Default default TypeInfo genParser() {
+        @Value.Default default TypeInfo baseParser() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "Parser");
         }
 
-        Optional<TypeInfo> extendedParser();
+        Optional<TypeInfo> extendParser();
 
         default TypeInfo parser() {
-            return extendedParser().orElseGet(this::genParser);
+            return extendParser().orElseGet(this::baseParser);
         }
 
         // Parser factory
 
-        @Value.Default default TypeInfo genParserFactory() {
+        @Value.Default default TypeInfo baseParserFactory() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "ParserFactory");
         }
 
-        Optional<TypeInfo> extendedParserFactory();
+        Optional<TypeInfo> extendParserFactory();
 
         default TypeInfo parserFactory() {
-            return extendedParserFactory().orElseGet(this::genParserFactory);
+            return extendParserFactory().orElseGet(this::baseParserFactory);
         }
 
 
@@ -123,9 +129,9 @@ public class ParserLanguageCompiler implements TaskDef<ParserLanguageCompiler.In
                 return ListView.of();
             }
             return ListView.of(
-                genTable().file(generatedJavaSourcesDirectory()),
-                genParser().file(generatedJavaSourcesDirectory()),
-                genParserFactory().file(generatedJavaSourcesDirectory())
+                baseParseTable().file(generatedJavaSourcesDirectory()),
+                baseParser().file(generatedJavaSourcesDirectory()),
+                baseParserFactory().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StrategoRuntimeLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StrategoRuntimeLanguageCompiler.java
@@ -37,7 +37,7 @@ public class StrategoRuntimeLanguageCompiler implements TaskDef<StrategoRuntimeL
     @Override public None exec(ExecContext context, Input input) throws IOException {
         if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        factoryTemplate.write(context, input.genStrategoRuntimeBuilderFactory().file(generatedJavaSourcesDirectory), input);
+        factoryTemplate.write(context, input.baseStrategoRuntimeBuilderFactory().file(generatedJavaSourcesDirectory), input);
         return None.instance;
     }
 
@@ -104,14 +104,14 @@ public class StrategoRuntimeLanguageCompiler implements TaskDef<StrategoRuntimeL
 
         // Stratego runtime builder factory
 
-        @Value.Default default TypeInfo genStrategoRuntimeBuilderFactory() {
+        @Value.Default default TypeInfo baseStrategoRuntimeBuilderFactory() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "StrategoRuntimeBuilderFactory");
         }
 
-        Optional<TypeInfo> extendedStrategoRuntimeBuilderFactory();
+        Optional<TypeInfo> extendStrategoRuntimeBuilderFactory();
 
         default TypeInfo strategoRuntimeBuilderFactory() {
-            return extendedStrategoRuntimeBuilderFactory().orElseGet(this::genStrategoRuntimeBuilderFactory);
+            return extendStrategoRuntimeBuilderFactory().orElseGet(this::baseStrategoRuntimeBuilderFactory);
         }
 
 
@@ -122,7 +122,7 @@ public class StrategoRuntimeLanguageCompiler implements TaskDef<StrategoRuntimeL
                 return ListView.of();
             }
             return ListView.of(
-                genStrategoRuntimeBuilderFactory().file(generatedJavaSourcesDirectory())
+                baseStrategoRuntimeBuilderFactory().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StrategoRuntimeLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StrategoRuntimeLanguageCompiler.java
@@ -135,12 +135,7 @@ public class StrategoRuntimeLanguageCompiler implements TaskDef<StrategoRuntimeL
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManualOnly();
-            if(!manual) return;
-            if(!manualFactory().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualFactory' has not been set");
-            }
+
         }
     }
 }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StrategoRuntimeLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StrategoRuntimeLanguageCompiler.java
@@ -35,7 +35,7 @@ public class StrategoRuntimeLanguageCompiler implements TaskDef<StrategoRuntimeL
     }
 
     @Override public None exec(ExecContext context, Input input) throws IOException {
-        if(input.classKind().isManualOnly()) return None.instance; // Nothing to generate: return.
+        if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         factoryTemplate.write(context, input.genStrategoRuntimeBuilderFactory().file(generatedJavaSourcesDirectory), input);
         return None.instance;

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StrategoRuntimeLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StrategoRuntimeLanguageCompiler.java
@@ -37,7 +37,7 @@ public class StrategoRuntimeLanguageCompiler implements TaskDef<StrategoRuntimeL
     @Override public None exec(ExecContext context, Input input) throws IOException {
         if(input.classKind().isManualOnly()) return None.instance; // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        factoryTemplate.write(context, input.genFactory().file(generatedJavaSourcesDirectory), input);
+        factoryTemplate.write(context, input.genStrategoRuntimeBuilderFactory().file(generatedJavaSourcesDirectory), input);
         return None.instance;
     }
 
@@ -104,28 +104,25 @@ public class StrategoRuntimeLanguageCompiler implements TaskDef<StrategoRuntimeL
 
         // Stratego runtime builder factory
 
-        @Value.Default default TypeInfo genFactory() {
+        @Value.Default default TypeInfo genStrategoRuntimeBuilderFactory() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "StrategoRuntimeBuilderFactory");
         }
 
-        Optional<TypeInfo> manualFactory();
+        Optional<TypeInfo> extendedStrategoRuntimeBuilderFactory();
 
-        default TypeInfo factory() {
-            if(classKind().isManual() && manualFactory().isPresent()) {
-                return manualFactory().get();
-            }
-            return genFactory();
+        default TypeInfo strategoRuntimeBuilderFactory() {
+            return extendedStrategoRuntimeBuilderFactory().orElseGet(this::genStrategoRuntimeBuilderFactory);
         }
 
 
         // List of all provided files
 
         default ListView<ResourcePath> providedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(
-                genFactory().file(generatedJavaSourcesDirectory())
+                genStrategoRuntimeBuilderFactory().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StylerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StylerLanguageCompiler.java
@@ -130,15 +130,7 @@ public class StylerLanguageCompiler implements TaskDef<StylerLanguageCompiler.In
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManual();
-            if(!manual) return;
-            if(!manualStyler().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualStyler' has not been set");
-            }
-            if(!manualFactory().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualFactory' has not been set");
-            }
+
         }
     }
 }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StylerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StylerLanguageCompiler.java
@@ -41,7 +41,7 @@ public class StylerLanguageCompiler implements TaskDef<StylerLanguageCompiler.In
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         rulesTemplate.write(context, input.genRules().file(generatedJavaSourcesDirectory), input);
         stylerTemplate.write(context, input.genStyler().file(generatedJavaSourcesDirectory), input);
-        factoryTemplate.write(context, input.genFactory().file(generatedJavaSourcesDirectory), input);
+        factoryTemplate.write(context, input.genStylerFactory().file(generatedJavaSourcesDirectory), input);
         return None.instance;
     }
 
@@ -89,41 +89,35 @@ public class StylerLanguageCompiler implements TaskDef<StylerLanguageCompiler.In
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "Styler");
         }
 
-        Optional<TypeInfo> manualStyler();
+        Optional<TypeInfo> extendedStyler();
 
         default TypeInfo styler() {
-            if(classKind().isManual() && manualStyler().isPresent()) {
-                return manualStyler().get();
-            }
-            return genStyler();
+            return extendedStyler().orElseGet(this::genStyler);
         }
 
         // Styler factory
 
-        @Value.Default default TypeInfo genFactory() {
+        @Value.Default default TypeInfo genStylerFactory() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "StylerFactory");
         }
 
-        Optional<TypeInfo> manualFactory();
+        Optional<TypeInfo> extendedStylerFactory();
 
-        default TypeInfo factory() {
-            if(classKind().isManual() && manualFactory().isPresent()) {
-                return manualFactory().get();
-            }
-            return genFactory();
+        default TypeInfo stylerFactory() {
+            return extendedStylerFactory().orElseGet(this::genStylerFactory);
         }
 
 
         /// List of all provided files
 
         default ListView<ResourcePath> providedFiles() {
-            if(classKind().isManualOnly()) {
+            if(classKind().isManual()) {
                 return ListView.of();
             }
             return ListView.of(
                 genRules().file(generatedJavaSourcesDirectory()),
                 genStyler().file(generatedJavaSourcesDirectory()),
-                genFactory().file(generatedJavaSourcesDirectory())
+                genStylerFactory().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StylerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StylerLanguageCompiler.java
@@ -37,7 +37,7 @@ public class StylerLanguageCompiler implements TaskDef<StylerLanguageCompiler.In
     }
 
     @Override public None exec(ExecContext context, Input input) throws IOException {
-        if(input.classKind().isManualOnly()) return None.instance; // Nothing to generate: return.
+        if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
         rulesTemplate.write(context, input.genRules().file(generatedJavaSourcesDirectory), input);
         stylerTemplate.write(context, input.genStyler().file(generatedJavaSourcesDirectory), input);

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StylerLanguageCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/language/StylerLanguageCompiler.java
@@ -39,9 +39,9 @@ public class StylerLanguageCompiler implements TaskDef<StylerLanguageCompiler.In
     @Override public None exec(ExecContext context, Input input) throws IOException {
         if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        rulesTemplate.write(context, input.genRules().file(generatedJavaSourcesDirectory), input);
-        stylerTemplate.write(context, input.genStyler().file(generatedJavaSourcesDirectory), input);
-        factoryTemplate.write(context, input.genStylerFactory().file(generatedJavaSourcesDirectory), input);
+        rulesTemplate.write(context, input.baseStylingRules().file(generatedJavaSourcesDirectory), input);
+        stylerTemplate.write(context, input.baseStyler().file(generatedJavaSourcesDirectory), input);
+        factoryTemplate.write(context, input.baseStylerFactory().file(generatedJavaSourcesDirectory), input);
         return None.instance;
     }
 
@@ -79,32 +79,38 @@ public class StylerLanguageCompiler implements TaskDef<StylerLanguageCompiler.In
 
         // Styling rules
 
-        @Value.Default default TypeInfo genRules() {
+        @Value.Default default TypeInfo baseStylingRules() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "StylingRules");
+        }
+
+        Optional<TypeInfo> extendStylingRules();
+
+        default TypeInfo stylingRules() {
+            return extendStylingRules().orElseGet(this::baseStylingRules);
         }
 
         // Styler
 
-        @Value.Default default TypeInfo genStyler() {
+        @Value.Default default TypeInfo baseStyler() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "Styler");
         }
 
-        Optional<TypeInfo> extendedStyler();
+        Optional<TypeInfo> extendStyler();
 
         default TypeInfo styler() {
-            return extendedStyler().orElseGet(this::genStyler);
+            return extendStyler().orElseGet(this::baseStyler);
         }
 
         // Styler factory
 
-        @Value.Default default TypeInfo genStylerFactory() {
+        @Value.Default default TypeInfo baseStylerFactory() {
             return TypeInfo.of(languageProject().packageId(), shared().defaultClassPrefix() + "StylerFactory");
         }
 
-        Optional<TypeInfo> extendedStylerFactory();
+        Optional<TypeInfo> extendStylerFactory();
 
         default TypeInfo stylerFactory() {
-            return extendedStylerFactory().orElseGet(this::genStylerFactory);
+            return extendStylerFactory().orElseGet(this::baseStylerFactory);
         }
 
 
@@ -115,9 +121,9 @@ public class StylerLanguageCompiler implements TaskDef<StylerLanguageCompiler.In
                 return ListView.of();
             }
             return ListView.of(
-                genRules().file(generatedJavaSourcesDirectory()),
-                genStyler().file(generatedJavaSourcesDirectory()),
-                genStylerFactory().file(generatedJavaSourcesDirectory())
+                baseStylingRules().file(generatedJavaSourcesDirectory()),
+                baseStyler().file(generatedJavaSourcesDirectory()),
+                baseStylerFactory().file(generatedJavaSourcesDirectory())
             );
         }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/CliProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/CliProjectCompiler.java
@@ -40,8 +40,8 @@ public class CliProjectCompiler implements TaskDef<CliProjectCompiler.Input, Cli
         final Shared shared = input.shared();
 
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
-        packageInfoTemplate.write(context, input.genPackageInfo().file(generatedJavaSourcesDirectory), input);
-        mainTemplate.write(context, input.genMain().file(generatedJavaSourcesDirectory), input);
+        packageInfoTemplate.write(context, input.basePackageInfo().file(generatedJavaSourcesDirectory), input);
+        mainTemplate.write(context, input.baseMain().file(generatedJavaSourcesDirectory), input);
 
         return Output.builder().build();
     }
@@ -124,7 +124,7 @@ public class CliProjectCompiler implements TaskDef<CliProjectCompiler.Input, Cli
 
         // package-info
 
-        @Value.Default default TypeInfo genPackageInfo() {
+        @Value.Default default TypeInfo basePackageInfo() {
             return TypeInfo.of(packageId(), "package-info");
         }
 
@@ -134,19 +134,19 @@ public class CliProjectCompiler implements TaskDef<CliProjectCompiler.Input, Cli
             if(classKind().isManual() && manualPackageInfo().isPresent()) {
                 return manualPackageInfo().get();
             }
-            return genPackageInfo();
+            return basePackageInfo();
         }
 
         // Main
 
-        @Value.Default default TypeInfo genMain() {
+        @Value.Default default TypeInfo baseMain() {
             return TypeInfo.of(packageId(), "Main");
         }
 
-        Optional<TypeInfo> extendedMain();
+        Optional<TypeInfo> extendMain();
 
         default TypeInfo main() {
-            return extendedMain().orElseGet(this::genMain);
+            return extendMain().orElseGet(this::baseMain);
         }
 
 
@@ -155,8 +155,8 @@ public class CliProjectCompiler implements TaskDef<CliProjectCompiler.Input, Cli
         default ArrayList<ResourcePath> providedFiles() {
             final ArrayList<ResourcePath> generatedFiles = new ArrayList<>();
             if(classKind().isGenerating()) {
-                generatedFiles.add(genPackageInfo().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genMain().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(basePackageInfo().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseMain().file(generatedJavaSourcesDirectory()));
             }
             return generatedFiles;
         }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/CliProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/CliProjectCompiler.java
@@ -170,12 +170,7 @@ public class CliProjectCompiler implements TaskDef<CliProjectCompiler.Input, Cli
 
 
         @Value.Check default void check() {
-            final ClassKind kind = classKind();
-            final boolean manual = kind.isManualOnly();
-            if(!manual) return;
-            if(!manualMain().isPresent()) {
-                throw new IllegalArgumentException("Kind '" + kind + "' indicates that a manual class will be used, but 'manualMain' has not been set");
-            }
+
         }
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/CliProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/CliProjectCompiler.java
@@ -143,13 +143,10 @@ public class CliProjectCompiler implements TaskDef<CliProjectCompiler.Input, Cli
             return TypeInfo.of(packageId(), "Main");
         }
 
-        Optional<TypeInfo> manualMain();
+        Optional<TypeInfo> extendedMain();
 
         default TypeInfo main() {
-            if(classKind().isManual() && manualMain().isPresent()) {
-                return manualMain().get();
-            }
-            return genMain();
+            return extendedMain().orElseGet(this::genMain);
         }
 
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/EclipseProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/EclipseProjectCompiler.java
@@ -85,26 +85,26 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
 
         // Class files
         final ResourcePath classesGenDirectory = input.generatedJavaSourcesDirectory();
-        packageInfoTemplate.write(context, input.genPackageInfo().file(classesGenDirectory), input);
-        pluginTemplate.write(context, input.genPlugin().file(classesGenDirectory), input);
-        moduleTemplate.write(context, input.genEclipseModule().file(classesGenDirectory), input);
-        componentTemplate.write(context, input.genEclipseComponent().file(classesGenDirectory), input);
-        identifiersTemplate.write(context, input.genEclipseIdentifiers().file(classesGenDirectory), input);
-        documentProviderTemplate.write(context, input.genDocumentProvider().file(classesGenDirectory), input);
-        editorTemplate.write(context, input.genEditor().file(classesGenDirectory), input);
-        editorTrackerTemplate.write(context, input.genEditorTracker().file(classesGenDirectory), input);
-        natureTemplate.write(context, input.genNature().file(classesGenDirectory), input);
+        packageInfoTemplate.write(context, input.basePackageInfo().file(classesGenDirectory), input);
+        pluginTemplate.write(context, input.basePlugin().file(classesGenDirectory), input);
+        moduleTemplate.write(context, input.baseEclipseModule().file(classesGenDirectory), input);
+        componentTemplate.write(context, input.baseEclipseComponent().file(classesGenDirectory), input);
+        identifiersTemplate.write(context, input.baseEclipseIdentifiers().file(classesGenDirectory), input);
+        documentProviderTemplate.write(context, input.baseDocumentProvider().file(classesGenDirectory), input);
+        editorTemplate.write(context, input.baseEditor().file(classesGenDirectory), input);
+        editorTrackerTemplate.write(context, input.baseEditorTracker().file(classesGenDirectory), input);
+        natureTemplate.write(context, input.baseNature().file(classesGenDirectory), input);
         addNatureHandlerTemplate.write(context, input.addNatureHandler().file(classesGenDirectory), input);
         removeNatureHandlerTemplate.write(context, input.removeNatureHandler().file(classesGenDirectory), input);
-        projectBuilderTemplate.write(context, input.genProjectBuilder().file(classesGenDirectory), input);
-        mainMenuTemplate.write(context, input.genMainMenu().file(classesGenDirectory), input);
-        editorContextMenuTemplate.write(context, input.genEditorContextMenu().file(classesGenDirectory), input);
-        resourceContextMenuTemplate.write(context, input.genResourceContextMenu().file(classesGenDirectory), input);
-        runCommandHandlerTemplate.write(context, input.genRunCommandHandler().file(classesGenDirectory), input);
-        observeHandlerTemplate.write(context, input.genObserveHandler().file(classesGenDirectory), input);
-        unobserveHandlerTemplate.write(context, input.genUnobserveHandler().file(classesGenDirectory), input);
+        projectBuilderTemplate.write(context, input.baseProjectBuilder().file(classesGenDirectory), input);
+        mainMenuTemplate.write(context, input.baseMainMenu().file(classesGenDirectory), input);
+        editorContextMenuTemplate.write(context, input.baseEditorContextMenu().file(classesGenDirectory), input);
+        resourceContextMenuTemplate.write(context, input.baseResourceContextMenu().file(classesGenDirectory), input);
+        runCommandHandlerTemplate.write(context, input.baseRunCommandHandler().file(classesGenDirectory), input);
+        observeHandlerTemplate.write(context, input.baseObserveHandler().file(classesGenDirectory), input);
+        unobserveHandlerTemplate.write(context, input.baseUnobserveHandler().file(classesGenDirectory), input);
         if(input.adapterProjectCompilerInput().multilangAnalyzer().isPresent()) {
-            metadataProviderTemplate.write(context, input.genMetadataProvider().file(classesGenDirectory), input);
+            metadataProviderTemplate.write(context, input.baseMetadataProvider().file(classesGenDirectory), input);
         }
 
         return Output.builder().build();
@@ -269,7 +269,7 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
 
         // package-info
 
-        @Value.Default default TypeInfo genPackageInfo() { return TypeInfo.of(packageId(), "package-info"); }
+        @Value.Default default TypeInfo basePackageInfo() { return TypeInfo.of(packageId(), "package-info"); }
 
         Optional<TypeInfo> manualPackageInfo();
 
@@ -277,31 +277,31 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             if(classKind().isManual() && manualPackageInfo().isPresent()) {
                 return manualPackageInfo().get();
             }
-            return genPackageInfo();
+            return basePackageInfo();
         }
 
         // Plugin
 
-        @Value.Default default TypeInfo genPlugin() {
+        @Value.Default default TypeInfo basePlugin() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Plugin");
         }
 
-        Optional<TypeInfo> extendedPlugin();
+        Optional<TypeInfo> extendPlugin();
 
         default TypeInfo plugin() {
-            return extendedPlugin().orElseGet(this::genPlugin);
+            return extendPlugin().orElseGet(this::basePlugin);
         }
 
         // Dagger component
 
-        @Value.Default default TypeInfo genEclipseComponent() {
+        @Value.Default default TypeInfo baseEclipseComponent() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EclipseComponent");
         }
 
-        Optional<TypeInfo> extendedEclipseComponent();
+        Optional<TypeInfo> extendEclipseComponent();
 
         default TypeInfo eclipseComponent() {
-            return extendedEclipseComponent().orElseGet(this::genEclipseComponent);
+            return extendEclipseComponent().orElseGet(this::baseEclipseComponent);
         }
 
         default TypeInfo daggerEclipseComponent() {
@@ -310,194 +310,194 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
 
         // Dagger module
 
-        @Value.Default default TypeInfo genEclipseModule() {
+        @Value.Default default TypeInfo baseEclipseModule() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EclipseModule");
         }
 
-        Optional<TypeInfo> extendedEclipseModule();
+        Optional<TypeInfo> extendEclipseModule();
 
         default TypeInfo eclipseModule() {
-            return extendedEclipseModule().orElseGet(this::genEclipseModule);
+            return extendEclipseModule().orElseGet(this::baseEclipseModule);
         }
 
         // Eclipse Identifiers
 
-        @Value.Default default TypeInfo genEclipseIdentifiers() {
+        @Value.Default default TypeInfo baseEclipseIdentifiers() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EclipseIdentifiers");
         }
 
-        Optional<TypeInfo> extendedEclipseIdentifiers();
+        Optional<TypeInfo> extendEclipseIdentifiers();
 
         default TypeInfo eclipseIdentifiers() {
-            return extendedEclipseIdentifiers().orElseGet(this::genEclipseIdentifiers);
+            return extendEclipseIdentifiers().orElseGet(this::baseEclipseIdentifiers);
         }
 
         // Document provider
 
-        @Value.Default default TypeInfo genDocumentProvider() {
+        @Value.Default default TypeInfo baseDocumentProvider() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "DocumentProvider");
         }
 
-        Optional<TypeInfo> extendedDocumentProvider();
+        Optional<TypeInfo> extendDocumentProvider();
 
         default TypeInfo documentProvider() {
-            return extendedDocumentProvider().orElseGet(this::genDocumentProvider);
+            return extendDocumentProvider().orElseGet(this::baseDocumentProvider);
         }
 
         // Editor
 
-        @Value.Default default TypeInfo genEditor() {
+        @Value.Default default TypeInfo baseEditor() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Editor");
         }
 
-        Optional<TypeInfo> extendedEditor();
+        Optional<TypeInfo> extendEditor();
 
         default TypeInfo editor() {
-            return extendedEditor().orElseGet(this::genEditor);
+            return extendEditor().orElseGet(this::baseEditor);
         }
 
         // Editor Tracker
 
-        @Value.Default default TypeInfo genEditorTracker() {
+        @Value.Default default TypeInfo baseEditorTracker() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EditorTracker");
         }
 
-        Optional<TypeInfo> extendedEditorTracker();
+        Optional<TypeInfo> extendEditorTracker();
 
         default TypeInfo editorTracker() {
-            return extendedEditorTracker().orElseGet(this::genEditorTracker);
+            return extendEditorTracker().orElseGet(this::baseEditorTracker);
         }
 
         // Project nature
 
-        @Value.Default default TypeInfo genNature() {
+        @Value.Default default TypeInfo baseNature() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Nature");
         }
 
-        Optional<TypeInfo> extendedNature();
+        Optional<TypeInfo> extendNature();
 
         default TypeInfo nature() {
-            return extendedNature().orElseGet(this::genNature);
+            return extendNature().orElseGet(this::baseNature);
         }
 
         // Add nature handler
 
-        @Value.Default default TypeInfo genAddNatureHandler() {
+        @Value.Default default TypeInfo baseAddNatureHandler() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "AddNatureHandler");
         }
 
-        Optional<TypeInfo> extendedAddNatureHandler();
+        Optional<TypeInfo> extendAddNatureHandler();
 
         default TypeInfo addNatureHandler() {
-            return extendedAddNatureHandler().orElseGet(this::genAddNatureHandler);
+            return extendAddNatureHandler().orElseGet(this::baseAddNatureHandler);
         }
 
         // Remove nature handler
 
-        @Value.Default default TypeInfo genRemoveNatureHandler() {
+        @Value.Default default TypeInfo baseRemoveNatureHandler() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "RemoveNatureHandler");
         }
 
-        Optional<TypeInfo> extendedRemoveNatureHandler();
+        Optional<TypeInfo> extendRemoveNatureHandler();
 
         default TypeInfo removeNatureHandler() {
-            return extendedRemoveNatureHandler().orElseGet(this::genRemoveNatureHandler);
+            return extendRemoveNatureHandler().orElseGet(this::baseRemoveNatureHandler);
         }
 
         // Project builder
 
-        @Value.Default default TypeInfo genProjectBuilder() {
+        @Value.Default default TypeInfo baseProjectBuilder() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "ProjectBuilder");
         }
 
-        Optional<TypeInfo> extendedProjectBuilder();
+        Optional<TypeInfo> extendProjectBuilder();
 
         default TypeInfo projectBuilder() {
-            return extendedProjectBuilder().orElseGet(this::genProjectBuilder);
+            return extendProjectBuilder().orElseGet(this::baseProjectBuilder);
         }
 
         // Main menu
 
-        @Value.Default default TypeInfo genMainMenu() {
+        @Value.Default default TypeInfo baseMainMenu() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "MainMenu");
         }
 
-        Optional<TypeInfo> extendedMainMenu();
+        Optional<TypeInfo> extendMainMenu();
 
         default TypeInfo mainMenu() {
-            return extendedMainMenu().orElseGet(this::genMainMenu);
+            return extendMainMenu().orElseGet(this::baseMainMenu);
         }
 
         // Editor context menu
 
-        @Value.Default default TypeInfo genEditorContextMenu() {
+        @Value.Default default TypeInfo baseEditorContextMenu() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EditorContextMenu");
         }
 
-        Optional<TypeInfo> extendedEditorContextMenu();
+        Optional<TypeInfo> extendEditorContextMenu();
 
         default TypeInfo editorContextMenu() {
-            return extendedEditorContextMenu().orElseGet(this::genEditorContextMenu);
+            return extendEditorContextMenu().orElseGet(this::baseEditorContextMenu);
         }
 
         // Resource context menu
 
-        @Value.Default default TypeInfo genResourceContextMenu() {
+        @Value.Default default TypeInfo baseResourceContextMenu() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "ResourceContextMenu");
         }
 
-        Optional<TypeInfo> extendedResourceContextMenu();
+        Optional<TypeInfo> extendResourceContextMenu();
 
         default TypeInfo resourceContextMenu() {
-            return extendedResourceContextMenu().orElseGet(this::genResourceContextMenu);
+            return extendResourceContextMenu().orElseGet(this::baseResourceContextMenu);
         }
 
         // Command handler
 
-        @Value.Default default TypeInfo genRunCommandHandler() {
+        @Value.Default default TypeInfo baseRunCommandHandler() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "RunCommandHandler");
         }
 
-        Optional<TypeInfo> extendedRunCommandHandler();
+        Optional<TypeInfo> extendRunCommandHandler();
 
         default TypeInfo runCommandHandler() {
-            return extendedRunCommandHandler().orElseGet(this::genRunCommandHandler);
+            return extendRunCommandHandler().orElseGet(this::baseRunCommandHandler);
         }
 
         // Observe handler
 
-        @Value.Default default TypeInfo genObserveHandler() {
+        @Value.Default default TypeInfo baseObserveHandler() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "ObserveHandler");
         }
 
-        Optional<TypeInfo> extendedObserveHandler();
+        Optional<TypeInfo> extendObserveHandler();
 
         default TypeInfo observeHandler() {
-            return extendedObserveHandler().orElseGet(this::genObserveHandler);
+            return extendObserveHandler().orElseGet(this::baseObserveHandler);
         }
 
         // Unobserve handler
 
-        @Value.Default default TypeInfo genUnobserveHandler() {
+        @Value.Default default TypeInfo baseUnobserveHandler() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "UnobserveHandler");
         }
 
-        Optional<TypeInfo> extendedUnobserveHandler();
+        Optional<TypeInfo> extendUnobserveHandler();
 
         default TypeInfo unobserveHandler() {
-            return extendedUnobserveHandler().orElseGet(this::genUnobserveHandler);
+            return extendUnobserveHandler().orElseGet(this::baseUnobserveHandler);
         }
 
         // Language Metadata Provider
 
-        @Value.Default default TypeInfo genMetadataProvider() {
+        @Value.Default default TypeInfo baseMetadataProvider() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "MetadataProvider");
         }
 
-        Optional<TypeInfo> extendedMetadataProvider();
+        Optional<TypeInfo> extendMetadataProvider();
 
         default TypeInfo metadataProvider() {
-            return extendedMetadataProvider().orElseGet(this::genMetadataProvider);
+            return extendMetadataProvider().orElseGet(this::baseMetadataProvider);
         }
 
 
@@ -508,26 +508,26 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             generatedFiles.add(pluginXmlFile());
             generatedFiles.add(manifestMfFile());
             if(classKind().isGenerating()) {
-                generatedFiles.add(genPackageInfo().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genPlugin().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genEclipseComponent().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genEclipseModule().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genEclipseIdentifiers().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genDocumentProvider().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genEditor().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genEditorTracker().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genNature().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genAddNatureHandler().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genRemoveNatureHandler().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genProjectBuilder().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genMainMenu().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genEditorContextMenu().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genResourceContextMenu().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genRunCommandHandler().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genObserveHandler().file(this.generatedJavaSourcesDirectory()));
-                generatedFiles.add(genUnobserveHandler().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(basePackageInfo().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(basePlugin().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseEclipseComponent().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseEclipseModule().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseEclipseIdentifiers().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseDocumentProvider().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseEditor().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseEditorTracker().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseNature().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseAddNatureHandler().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseRemoveNatureHandler().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseProjectBuilder().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseMainMenu().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseEditorContextMenu().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseResourceContextMenu().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseRunCommandHandler().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseObserveHandler().file(this.generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseUnobserveHandler().file(this.generatedJavaSourcesDirectory()));
                 if(adapterProjectCompilerInput().multilangAnalyzer().isPresent()) {
-                    generatedFiles.add(genMetadataProvider().file(this.generatedJavaSourcesDirectory()));
+                    generatedFiles.add(baseMetadataProvider().file(this.generatedJavaSourcesDirectory()));
                 }
             }
             return generatedFiles;

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/EclipseProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/EclipseProjectCompiler.java
@@ -286,13 +286,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Plugin");
         }
 
-        Optional<TypeInfo> manualPlugin();
+        Optional<TypeInfo> extendedPlugin();
 
         default TypeInfo plugin() {
-            if(classKind().isManual() && manualPlugin().isPresent()) {
-                return manualPlugin().get();
-            }
-            return genPlugin();
+            return extendedPlugin().orElseGet(this::genPlugin);
         }
 
         // Dagger component
@@ -301,13 +298,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EclipseComponent");
         }
 
-        Optional<TypeInfo> manualEclipseComponent();
+        Optional<TypeInfo> extendedEclipseComponent();
 
         default TypeInfo eclipseComponent() {
-            if(classKind().isManual() && manualEclipseComponent().isPresent()) {
-                return manualEclipseComponent().get();
-            }
-            return genEclipseComponent();
+            return extendedEclipseComponent().orElseGet(this::genEclipseComponent);
         }
 
         default TypeInfo daggerEclipseComponent() {
@@ -320,13 +314,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EclipseModule");
         }
 
-        Optional<TypeInfo> manualEclipseModule();
+        Optional<TypeInfo> extendedEclipseModule();
 
         default TypeInfo eclipseModule() {
-            if(classKind().isManual() && manualEclipseModule().isPresent()) {
-                return manualEclipseModule().get();
-            }
-            return genEclipseModule();
+            return extendedEclipseModule().orElseGet(this::genEclipseModule);
         }
 
         // Eclipse Identifiers
@@ -335,13 +326,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EclipseIdentifiers");
         }
 
-        Optional<TypeInfo> manualEclipseIdentifiers();
+        Optional<TypeInfo> extendedEclipseIdentifiers();
 
         default TypeInfo eclipseIdentifiers() {
-            if(classKind().isManual() && manualEclipseIdentifiers().isPresent()) {
-                return manualEclipseIdentifiers().get();
-            }
-            return genEclipseIdentifiers();
+            return extendedEclipseIdentifiers().orElseGet(this::genEclipseIdentifiers);
         }
 
         // Document provider
@@ -350,13 +338,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "DocumentProvider");
         }
 
-        Optional<TypeInfo> manualDocumentProvider();
+        Optional<TypeInfo> extendedDocumentProvider();
 
         default TypeInfo documentProvider() {
-            if(classKind().isManual() && manualDocumentProvider().isPresent()) {
-                return manualDocumentProvider().get();
-            }
-            return genDocumentProvider();
+            return extendedDocumentProvider().orElseGet(this::genDocumentProvider);
         }
 
         // Editor
@@ -365,13 +350,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Editor");
         }
 
-        Optional<TypeInfo> manualEditor();
+        Optional<TypeInfo> extendedEditor();
 
         default TypeInfo editor() {
-            if(classKind().isManual() && manualEditor().isPresent()) {
-                return manualEditor().get();
-            }
-            return genEditor();
+            return extendedEditor().orElseGet(this::genEditor);
         }
 
         // Editor Tracker
@@ -380,13 +362,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EditorTracker");
         }
 
-        Optional<TypeInfo> manualEditorTracker();
+        Optional<TypeInfo> extendedEditorTracker();
 
         default TypeInfo editorTracker() {
-            if(classKind().isManual() && manualEditorTracker().isPresent()) {
-                return manualEditorTracker().get();
-            }
-            return genEditorTracker();
+            return extendedEditorTracker().orElseGet(this::genEditorTracker);
         }
 
         // Project nature
@@ -395,13 +374,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Nature");
         }
 
-        Optional<TypeInfo> manualNature();
+        Optional<TypeInfo> extendedNature();
 
         default TypeInfo nature() {
-            if(classKind().isManual() && manualNature().isPresent()) {
-                return manualNature().get();
-            }
-            return genNature();
+            return extendedNature().orElseGet(this::genNature);
         }
 
         // Add nature handler
@@ -410,13 +386,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "AddNatureHandler");
         }
 
-        Optional<TypeInfo> manualAddNatureHandler();
+        Optional<TypeInfo> extendedAddNatureHandler();
 
         default TypeInfo addNatureHandler() {
-            if(classKind().isManual() && manualAddNatureHandler().isPresent()) {
-                return manualAddNatureHandler().get();
-            }
-            return genAddNatureHandler();
+            return extendedAddNatureHandler().orElseGet(this::genAddNatureHandler);
         }
 
         // Remove nature handler
@@ -425,13 +398,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "RemoveNatureHandler");
         }
 
-        Optional<TypeInfo> manualRemoveNatureHandler();
+        Optional<TypeInfo> extendedRemoveNatureHandler();
 
         default TypeInfo removeNatureHandler() {
-            if(classKind().isManual() && manualRemoveNatureHandler().isPresent()) {
-                return manualRemoveNatureHandler().get();
-            }
-            return genRemoveNatureHandler();
+            return extendedRemoveNatureHandler().orElseGet(this::genRemoveNatureHandler);
         }
 
         // Project builder
@@ -440,13 +410,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "ProjectBuilder");
         }
 
-        Optional<TypeInfo> manualProjectBuilder();
+        Optional<TypeInfo> extendedProjectBuilder();
 
         default TypeInfo projectBuilder() {
-            if(classKind().isManual() && manualProjectBuilder().isPresent()) {
-                return manualProjectBuilder().get();
-            }
-            return genProjectBuilder();
+            return extendedProjectBuilder().orElseGet(this::genProjectBuilder);
         }
 
         // Main menu
@@ -455,13 +422,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "MainMenu");
         }
 
-        Optional<TypeInfo> manualMainMenu();
+        Optional<TypeInfo> extendedMainMenu();
 
         default TypeInfo mainMenu() {
-            if(classKind().isManual() && manualMainMenu().isPresent()) {
-                return manualMainMenu().get();
-            }
-            return genMainMenu();
+            return extendedMainMenu().orElseGet(this::genMainMenu);
         }
 
         // Editor context menu
@@ -470,13 +434,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "EditorContextMenu");
         }
 
-        Optional<TypeInfo> manualEditorContextMenu();
+        Optional<TypeInfo> extendedEditorContextMenu();
 
         default TypeInfo editorContextMenu() {
-            if(classKind().isManual() && manualEditorContextMenu().isPresent()) {
-                return manualEditorContextMenu().get();
-            }
-            return genEditorContextMenu();
+            return extendedEditorContextMenu().orElseGet(this::genEditorContextMenu);
         }
 
         // Resource context menu
@@ -485,13 +446,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "ResourceContextMenu");
         }
 
-        Optional<TypeInfo> manualResourceContextMenu();
+        Optional<TypeInfo> extendedResourceContextMenu();
 
         default TypeInfo resourceContextMenu() {
-            if(classKind().isManual() && manualResourceContextMenu().isPresent()) {
-                return manualResourceContextMenu().get();
-            }
-            return genResourceContextMenu();
+            return extendedResourceContextMenu().orElseGet(this::genResourceContextMenu);
         }
 
         // Command handler
@@ -500,13 +458,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "RunCommandHandler");
         }
 
-        Optional<TypeInfo> manualRunCommandHandler();
+        Optional<TypeInfo> extendedRunCommandHandler();
 
         default TypeInfo runCommandHandler() {
-            if(classKind().isManual() && manualRunCommandHandler().isPresent()) {
-                return manualRunCommandHandler().get();
-            }
-            return genRunCommandHandler();
+            return extendedRunCommandHandler().orElseGet(this::genRunCommandHandler);
         }
 
         // Observe handler
@@ -515,13 +470,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "ObserveHandler");
         }
 
-        Optional<TypeInfo> manualObserveHandler();
+        Optional<TypeInfo> extendedObserveHandler();
 
         default TypeInfo observeHandler() {
-            if(classKind().isManual() && manualObserveHandler().isPresent()) {
-                return manualObserveHandler().get();
-            }
-            return genObserveHandler();
+            return extendedObserveHandler().orElseGet(this::genObserveHandler);
         }
 
         // Unobserve handler
@@ -530,13 +482,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "UnobserveHandler");
         }
 
-        Optional<TypeInfo> manualUnobserveHandler();
+        Optional<TypeInfo> extendedUnobserveHandler();
 
         default TypeInfo unobserveHandler() {
-            if(classKind().isManual() && manualUnobserveHandler().isPresent()) {
-                return manualUnobserveHandler().get();
-            }
-            return genUnobserveHandler();
+            return extendedUnobserveHandler().orElseGet(this::genUnobserveHandler);
         }
 
         // Language Metadata Provider
@@ -545,13 +494,10 @@ public class EclipseProjectCompiler implements TaskDef<EclipseProjectCompiler.In
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "MetadataProvider");
         }
 
-        Optional<TypeInfo> manualMetadataProvider();
+        Optional<TypeInfo> extendedMetadataProvider();
 
         default TypeInfo metadataProvider() {
-            if(classKind().isManual() && manualMetadataProvider().isPresent()) {
-                return manualMetadataProvider().get();
-            }
-            return genMetadataProvider();
+            return extendedMetadataProvider().orElseGet(this::genMetadataProvider);
         }
 
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/IntellijProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/IntellijProjectCompiler.java
@@ -189,13 +189,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "IntellijModule");
         }
 
-        Optional<TypeInfo> manualModule();
+        Optional<TypeInfo> extendedModule();
 
         default TypeInfo module() {
-            if(classKind().isManual() && manualModule().isPresent()) {
-                return manualModule().get();
-            }
-            return genModule();
+            return extendedModule().orElseGet(this::genModule);
         }
 
         // IntelliJ component
@@ -204,13 +201,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "IntellijComponent");
         }
 
-        Optional<TypeInfo> manualComponent();
+        Optional<TypeInfo> extendedComponent();
 
         default TypeInfo component() {
-            if(classKind().isManual() && manualComponent().isPresent()) {
-                return manualComponent().get();
-            }
-            return genComponent();
+            return extendedComponent().orElseGet(this::genComponent);
         }
 
         default TypeInfo daggerComponent() {
@@ -223,13 +217,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Plugin");
         }
 
-        Optional<TypeInfo> manualPlugin();
+        Optional<TypeInfo> extendedPlugin();
 
         default TypeInfo plugin() {
-            if(classKind().isManual() && manualPlugin().isPresent()) {
-                return manualPlugin().get();
-            }
-            return genPlugin();
+            return extendedPlugin().orElseGet(this::genPlugin);
         }
 
         // Loader
@@ -238,13 +229,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Loader");
         }
 
-        Optional<TypeInfo> manualLoader();
+        Optional<TypeInfo> extendedLoader();
 
         default TypeInfo loader() {
-            if(classKind().isManual() && manualLoader().isPresent()) {
-                return manualLoader().get();
-            }
-            return genLoader();
+            return extendedLoader().orElseGet(this::genLoader);
         }
 
         // Language
@@ -253,13 +241,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Language");
         }
 
-        Optional<TypeInfo> manualLanguage();
+        Optional<TypeInfo> extendedLanguage();
 
         default TypeInfo language() {
-            if(classKind().isManual() && manualLanguage().isPresent()) {
-                return manualLanguage().get();
-            }
-            return genLanguage();
+            return extendedLanguage().orElseGet(this::genLanguage);
         }
 
         // File type
@@ -268,13 +253,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "FileType");
         }
 
-        Optional<TypeInfo> manualFileType();
+        Optional<TypeInfo> extendedFileType();
 
         default TypeInfo fileType() {
-            if(classKind().isManual() && manualFileType().isPresent()) {
-                return manualFileType().get();
-            }
-            return genFileType();
+            return extendedFileType().orElseGet(this::genFileType);
         }
 
         // File type
@@ -283,13 +265,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "FileElementType");
         }
 
-        Optional<TypeInfo> manualFileElementType();
+        Optional<TypeInfo> extendedFileElementType();
 
         default TypeInfo fileElementType() {
-            if(classKind().isManual() && manualFileElementType().isPresent()) {
-                return manualFileElementType().get();
-            }
-            return genFileElementType();
+            return extendedFileElementType().orElseGet(this::genFileElementType);
         }
 
         // File type factory
@@ -298,13 +277,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "FileTypeFactory");
         }
 
-        Optional<TypeInfo> manualFileTypeFactory();
+        Optional<TypeInfo> extendedFileTypeFactory();
 
         default TypeInfo fileTypeFactory() {
-            if(classKind().isManual() && manualFileTypeFactory().isPresent()) {
-                return manualFileTypeFactory().get();
-            }
-            return genFileTypeFactory();
+            return extendedFileTypeFactory().orElseGet(this::genFileTypeFactory);
         }
 
         // Syntax highlighter factory
@@ -313,13 +289,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "SyntaxHighlighterFactory");
         }
 
-        Optional<TypeInfo> manualSyntaxHighlighterFactory();
+        Optional<TypeInfo> extendedSyntaxHighlighterFactory();
 
         default TypeInfo syntaxHighlighterFactory() {
-            if(classKind().isManual() && manualSyntaxHighlighterFactory().isPresent()) {
-                return manualSyntaxHighlighterFactory().get();
-            }
-            return genSyntaxHighlighterFactory();
+            return extendedSyntaxHighlighterFactory().orElseGet(this::genSyntaxHighlighterFactory);
         }
 
         // Parser definition
@@ -328,13 +301,10 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "ParserDefinition");
         }
 
-        Optional<TypeInfo> manualParserDefinition();
+        Optional<TypeInfo> extendedParserDefinition();
 
         default TypeInfo parserDefinition() {
-            if(classKind().isManual() && manualParserDefinition().isPresent()) {
-                return manualParserDefinition().get();
-            }
-            return genParserDefinition();
+            return extendedParserDefinition().orElseGet(this::genParserDefinition);
         }
 
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/IntellijProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/platform/IntellijProjectCompiler.java
@@ -64,15 +64,15 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
 
         // Class files
         final ResourcePath classesGenDirectory = input.generatedJavaSourcesDirectory();
-        packageInfoTemplate.write(context, input.genPackageInfo().file(classesGenDirectory), input);
-        moduleTemplate.write(context, input.genModule().file(classesGenDirectory), input);
-        componentTemplate.write(context, input.genComponent().file(classesGenDirectory), input);
-        pluginTemplate.write(context, input.genPlugin().file(classesGenDirectory), input);
-        loaderTemplate.write(context, input.genLoader().file(classesGenDirectory), input);
-        languageTemplate.write(context, input.genLanguage().file(classesGenDirectory), input);
-        fileTypeTemplate.write(context, input.genFileType().file(classesGenDirectory), input);
-        fileElementTypeTemplate.write(context, input.genFileElementType().file(classesGenDirectory), input);
-        fileTypeFactoryTemplate.write(context, input.genFileTypeFactory().file(classesGenDirectory), input);
+        packageInfoTemplate.write(context, input.basePackageInfo().file(classesGenDirectory), input);
+        moduleTemplate.write(context, input.baseModule().file(classesGenDirectory), input);
+        componentTemplate.write(context, input.baseComponent().file(classesGenDirectory), input);
+        pluginTemplate.write(context, input.basePlugin().file(classesGenDirectory), input);
+        loaderTemplate.write(context, input.baseLoader().file(classesGenDirectory), input);
+        languageTemplate.write(context, input.baseLanguage().file(classesGenDirectory), input);
+        fileTypeTemplate.write(context, input.baseFileType().file(classesGenDirectory), input);
+        fileElementTypeTemplate.write(context, input.baseFileElementType().file(classesGenDirectory), input);
+        fileTypeFactoryTemplate.write(context, input.baseFileTypeFactory().file(classesGenDirectory), input);
         syntaxHighlighterFactoryTemplate.write(context, input.syntaxHighlighterFactory().file(classesGenDirectory), input);
         parserDefinitionTemplate.write(context, input.parserDefinition().file(classesGenDirectory), input);
 
@@ -170,7 +170,7 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
 
         // package-info
 
-        @Value.Default default TypeInfo genPackageInfo() {
+        @Value.Default default TypeInfo basePackageInfo() {
             return TypeInfo.of(packageId(), "package-info");
         }
 
@@ -180,31 +180,31 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             if(classKind().isManual() && manualPackageInfo().isPresent()) {
                 return manualPackageInfo().get();
             }
-            return genPackageInfo();
+            return basePackageInfo();
         }
 
         // IntelliJ module
 
-        @Value.Default default TypeInfo genModule() {
+        @Value.Default default TypeInfo baseModule() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "IntellijModule");
         }
 
-        Optional<TypeInfo> extendedModule();
+        Optional<TypeInfo> extendModule();
 
         default TypeInfo module() {
-            return extendedModule().orElseGet(this::genModule);
+            return extendModule().orElseGet(this::baseModule);
         }
 
         // IntelliJ component
 
-        @Value.Default default TypeInfo genComponent() {
+        @Value.Default default TypeInfo baseComponent() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "IntellijComponent");
         }
 
-        Optional<TypeInfo> extendedComponent();
+        Optional<TypeInfo> extendComponent();
 
         default TypeInfo component() {
-            return extendedComponent().orElseGet(this::genComponent);
+            return extendComponent().orElseGet(this::baseComponent);
         }
 
         default TypeInfo daggerComponent() {
@@ -213,98 +213,98 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
 
         // Plugin
 
-        @Value.Default default TypeInfo genPlugin() {
+        @Value.Default default TypeInfo basePlugin() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Plugin");
         }
 
-        Optional<TypeInfo> extendedPlugin();
+        Optional<TypeInfo> extendPlugin();
 
         default TypeInfo plugin() {
-            return extendedPlugin().orElseGet(this::genPlugin);
+            return extendPlugin().orElseGet(this::basePlugin);
         }
 
         // Loader
 
-        @Value.Default default TypeInfo genLoader() {
+        @Value.Default default TypeInfo baseLoader() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Loader");
         }
 
-        Optional<TypeInfo> extendedLoader();
+        Optional<TypeInfo> extendLoader();
 
         default TypeInfo loader() {
-            return extendedLoader().orElseGet(this::genLoader);
+            return extendLoader().orElseGet(this::baseLoader);
         }
 
         // Language
 
-        @Value.Default default TypeInfo genLanguage() {
+        @Value.Default default TypeInfo baseLanguage() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "Language");
         }
 
-        Optional<TypeInfo> extendedLanguage();
+        Optional<TypeInfo> extendLanguage();
 
         default TypeInfo language() {
-            return extendedLanguage().orElseGet(this::genLanguage);
+            return extendLanguage().orElseGet(this::baseLanguage);
         }
 
         // File type
 
-        @Value.Default default TypeInfo genFileType() {
+        @Value.Default default TypeInfo baseFileType() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "FileType");
         }
 
-        Optional<TypeInfo> extendedFileType();
+        Optional<TypeInfo> extendFileType();
 
         default TypeInfo fileType() {
-            return extendedFileType().orElseGet(this::genFileType);
+            return extendFileType().orElseGet(this::baseFileType);
         }
 
         // File type
 
-        @Value.Default default TypeInfo genFileElementType() {
+        @Value.Default default TypeInfo baseFileElementType() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "FileElementType");
         }
 
-        Optional<TypeInfo> extendedFileElementType();
+        Optional<TypeInfo> extendFileElementType();
 
         default TypeInfo fileElementType() {
-            return extendedFileElementType().orElseGet(this::genFileElementType);
+            return extendFileElementType().orElseGet(this::baseFileElementType);
         }
 
         // File type factory
 
-        @Value.Default default TypeInfo genFileTypeFactory() {
+        @Value.Default default TypeInfo baseFileTypeFactory() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "FileTypeFactory");
         }
 
-        Optional<TypeInfo> extendedFileTypeFactory();
+        Optional<TypeInfo> extendFileTypeFactory();
 
         default TypeInfo fileTypeFactory() {
-            return extendedFileTypeFactory().orElseGet(this::genFileTypeFactory);
+            return extendFileTypeFactory().orElseGet(this::baseFileTypeFactory);
         }
 
         // Syntax highlighter factory
 
-        @Value.Default default TypeInfo genSyntaxHighlighterFactory() {
+        @Value.Default default TypeInfo baseSyntaxHighlighterFactory() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "SyntaxHighlighterFactory");
         }
 
-        Optional<TypeInfo> extendedSyntaxHighlighterFactory();
+        Optional<TypeInfo> extendSyntaxHighlighterFactory();
 
         default TypeInfo syntaxHighlighterFactory() {
-            return extendedSyntaxHighlighterFactory().orElseGet(this::genSyntaxHighlighterFactory);
+            return extendSyntaxHighlighterFactory().orElseGet(this::baseSyntaxHighlighterFactory);
         }
 
         // Parser definition
 
-        @Value.Default default TypeInfo genParserDefinition() {
+        @Value.Default default TypeInfo baseParserDefinition() {
             return TypeInfo.of(packageId(), shared().defaultClassPrefix() + "ParserDefinition");
         }
 
-        Optional<TypeInfo> extendedParserDefinition();
+        Optional<TypeInfo> extendParserDefinition();
 
         default TypeInfo parserDefinition() {
-            return extendedParserDefinition().orElseGet(this::genParserDefinition);
+            return extendParserDefinition().orElseGet(this::baseParserDefinition);
         }
 
 
@@ -314,16 +314,16 @@ public class IntellijProjectCompiler implements TaskDef<IntellijProjectCompiler.
             final ArrayList<ResourcePath> generatedFiles = new ArrayList<>();
             generatedFiles.add(pluginXmlFile());
             if(classKind().isGenerating()) {
-                generatedFiles.add(genPackageInfo().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genModule().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genComponent().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genPlugin().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genLoader().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genFileType().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genFileElementType().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genFileTypeFactory().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genSyntaxHighlighterFactory().file(generatedJavaSourcesDirectory()));
-                generatedFiles.add(genParserDefinition().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(basePackageInfo().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseModule().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseComponent().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(basePlugin().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseLoader().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseFileType().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseFileElementType().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseFileTypeFactory().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseSyntaxHighlighterFactory().file(generatedJavaSourcesDirectory()));
+                generatedFiles.add(baseParserDefinition().file(generatedJavaSourcesDirectory()));
             }
             return generatedFiles;
         }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/util/ClassKind.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/util/ClassKind.java
@@ -13,32 +13,11 @@ public enum ClassKind implements Serializable {
     Manual;
 
     public boolean isGenerating() {
-        switch(this) {
-            case Generated:
-            case Extended:
-                return true;
-            case Manual:
-                return false;
-        }
-        return false;
-    }
-
-    public boolean isGeneratingOnly() {
         return this == Generated;
     }
 
     public boolean isManual() {
-        switch(this) {
-            case Generated:
-                return false;
-            case Extended:
-            case Manual:
-                return true;
-        }
-        return false;
-    }
-
-    public boolean isManualOnly() {
         return this == Manual;
     }
+
 }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/util/ClassKind.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/util/ClassKind.java
@@ -8,10 +8,6 @@ public enum ClassKind implements Serializable {
      */
     Generated,
     /**
-     * Manually implemented class that may extend generated class.
-     */
-    Extended,
-    /**
      * Manually implemented class.
      */
     Manual;

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckAggregatorTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckAggregatorTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genCheckAggregatorTaskDef.packageId}};
+package {{baseCheckAggregatorTaskDef.packageId}};
 
 import mb.common.message.KeyedMessages;
 import mb.common.message.Messages;
@@ -19,7 +19,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 @{{scope.qualifiedId}}
-public class {{genCheckAggregatorTaskDef.id}} implements TaskDef<{{genCheckAggregatorTaskDef.id}}.Input, @Nullable KeyedMessages> {
+public class {{baseCheckAggregatorTaskDef.id}} implements TaskDef<{{baseCheckAggregatorTaskDef.id}}.Input, @Nullable KeyedMessages> {
     public static class Input implements Serializable {
         public final ResourcePath root;
         public final ResourceWalker walker;
@@ -57,14 +57,14 @@ public class {{genCheckAggregatorTaskDef.id}} implements TaskDef<{{genCheckAggre
         }
     }
 
-    private final {{genCheckTaskDef.id}} check;
+    private final {{baseCheckTaskDef.id}} check;
 
-    @Inject public {{genCheckAggregatorTaskDef.id}}({{genCheckTaskDef.id}} check){
+    @Inject public {{baseCheckAggregatorTaskDef.id}}({{baseCheckTaskDef.id}} check){
         this.check = check;
     }
 
     @Override public String getId() {
-        return "{{genCheckAggregatorTaskDef.qualifiedId}}";
+        return "{{baseCheckAggregatorTaskDef.qualifiedId}}";
     }
 
     @Override public @Nullable KeyedMessages exec(ExecContext context, Input input) throws Exception {

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckAggregatorTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckAggregatorTaskDef.java.mustache
@@ -57,9 +57,9 @@ public class {{baseCheckAggregatorTaskDef.id}} implements TaskDef<{{baseCheckAgg
         }
     }
 
-    private final {{baseCheckTaskDef.id}} check;
+    private final {{checkTaskDef.qualifiedId}} check;
 
-    @Inject public {{baseCheckAggregatorTaskDef.id}}({{baseCheckTaskDef.id}} check){
+    @Inject public {{baseCheckAggregatorTaskDef.id}}({{checkTaskDef.qualifiedId}} check){
         this.check = check;
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckMultiTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckMultiTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genCheckMultiTaskDef.packageId}};
+package {{baseCheckMultiTaskDef.packageId}};
 
 import mb.common.message.KeyedMessages;
 import mb.common.message.KeyedMessagesBuilder;
@@ -19,7 +19,7 @@ import java.io.UncheckedIOException;
 import java.util.Objects;
 
 @{{scope.qualifiedId}}
-public class {{genCheckMultiTaskDef.id}} implements TaskDef<{{genCheckMultiTaskDef.id}}.Input, KeyedMessages> {
+public class {{baseCheckMultiTaskDef.id}} implements TaskDef<{{baseCheckMultiTaskDef.id}}.Input, KeyedMessages> {
     public static class Input implements Serializable {
         public final ResourcePath root;
         public final ResourceWalker walker;
@@ -59,7 +59,7 @@ public class {{genCheckMultiTaskDef.id}} implements TaskDef<{{genCheckMultiTaskD
         {{variable}};
     {{/checkMultiInjections}}
 
-    @Inject public {{genCheckMultiTaskDef.id}}(
+    @Inject public {{baseCheckMultiTaskDef.id}}(
     {{#checkMultiInjections}}
         {{variable}}{{^-last}},{{/-last}}
     {{/checkMultiInjections}}
@@ -70,7 +70,7 @@ public class {{genCheckMultiTaskDef.id}} implements TaskDef<{{genCheckMultiTaskD
     }
 
     @Override public String getId() {
-        return "{{genCheckMultiTaskDef.qualifiedId}}";
+        return "{{baseCheckMultiTaskDef.qualifiedId}}";
     }
 
     @Override public KeyedMessages exec(ExecContext context, Input input) throws IOException {

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genCheckTaskDef.packageId}};
+package {{baseCheckTaskDef.packageId}};
 
 import mb.common.message.Messages;
 import mb.common.message.MessagesBuilder;
@@ -12,13 +12,13 @@ import javax.inject.Inject;
 import java.io.IOException;
 
 @{{scope.qualifiedId}}
-public class {{genCheckTaskDef.id}} implements TaskDef<ResourceKey, Messages> {
+public class {{baseCheckTaskDef.id}} implements TaskDef<ResourceKey, Messages> {
 
 {{#checkInjections}}
     {{variable}};
 {{/checkInjections}}
 
-    @Inject public {{genCheckTaskDef.id}}(
+    @Inject public {{baseCheckTaskDef.id}}(
 {{#checkInjections}}
     {{variable}}{{^-last}},{{/-last}}
 {{/checkInjections}}
@@ -29,7 +29,7 @@ public class {{genCheckTaskDef.id}} implements TaskDef<ResourceKey, Messages> {
     }
 
     @Override public String getId() {
-        return "{{genCheckTaskDef.qualifiedId}}";
+        return "{{baseCheckTaskDef.qualifiedId}}";
     }
 
     @Override public Messages exec(ExecContext context, ResourceKey key) throws IOException {

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Component.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Component.java.mustache
@@ -1,4 +1,4 @@
-package {{genComponent.packageId}};
+package {{baseComponent.packageId}};
 
 import dagger.Component;
 import mb.spoofax.core.language.LanguageComponent;
@@ -16,11 +16,11 @@ import {{qualifier.qualifiedId}};
 
 @{{scope.qualifiedId}}
 @Component(
-    modules = { {{genModule.qualifiedId}}.class{{#additionalModules}}{{#-first}}, {{/-first}}{{qualifiedId}}.class{{^-last}}, {{/-last}}{{/additionalModules}} },
+    modules = { {{baseModule.qualifiedId}}.class{{#additionalModules}}{{#-first}}, {{/-first}}{{qualifiedId}}.class{{^-last}}, {{/-last}}{{/additionalModules}} },
     dependencies = { PlatformComponent.class{{#isMultiLang}}, MultiLangComponent.class{{/isMultiLang}} }
 )
-public interface {{genComponent.id}} extends LanguageComponent{{#isMultiLang}}, LanguageMetadataProvider{{/isMultiLang}}  {
-    @Override {{genInstance.id}} getLanguageInstance();
+public interface {{baseComponent.id}} extends LanguageComponent{{#isMultiLang}}, LanguageMetadataProvider{{/isMultiLang}}  {
+    @Override {{baseInstance.id}} getLanguageInstance();
 
     @Override @{{qualifier.id}} ResourceService getResourceService();
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Component.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Component.java.mustache
@@ -16,11 +16,11 @@ import {{qualifier.qualifiedId}};
 
 @{{scope.qualifiedId}}
 @Component(
-    modules = { {{baseModule.qualifiedId}}.class{{#additionalModules}}{{#-first}}, {{/-first}}{{qualifiedId}}.class{{^-last}}, {{/-last}}{{/additionalModules}} },
+    modules = { {{module.qualifiedId}}.class{{#additionalModules}}{{#-first}}, {{/-first}}{{qualifiedId}}.class{{^-last}}, {{/-last}}{{/additionalModules}} },
     dependencies = { PlatformComponent.class{{#isMultiLang}}, MultiLangComponent.class{{/isMultiLang}} }
 )
 public interface {{baseComponent.id}} extends LanguageComponent{{#isMultiLang}}, LanguageMetadataProvider{{/isMultiLang}}  {
-    @Override {{baseInstance.id}} getLanguageInstance();
+    @Override {{instance.qualifiedId}} getLanguageInstance();
 
     @Override @{{qualifier.id}} ResourceService getResourceService();
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Instance.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Instance.java.mustache
@@ -1,4 +1,4 @@
-package {{genInstance.packageId}};
+package {{baseInstance.packageId}};
 
 import mb.common.message.KeyedMessages;
 import mb.common.message.Messages;
@@ -43,7 +43,7 @@ import java.util.ArrayList;
 import java.util.Set;
 
 
-public class {{genInstance.id}} implements LanguageInstance {
+public class {{baseInstance.id}} implements LanguageInstance {
     private final static SetView<String> fileExtensions = SetView.of({{#shared.fileExtensions}}"{{this}}"{{^-last}}, {{/-last}}{{/shared.fileExtensions}});
 
 {{#injected}}
@@ -53,7 +53,7 @@ public class {{genInstance.id}} implements LanguageInstance {
     private final CollectionView<CommandDef<?>> commandDefs;
     private final CollectionView<AutoCommandRequest<?>> autoCommandDefs;
 
-    @Inject public {{genInstance.id}}(
+    @Inject public {{baseInstance.id}}(
 {{#injected}}
         {{variable}},
 {{/injected}}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Module.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Module.java.mustache
@@ -1,4 +1,4 @@
-package {{genModule.packageId}};
+package {{baseModule.packageId}};
 
 import dagger.Module;
 import dagger.Provides;
@@ -62,7 +62,7 @@ import java.util.Set;
 import java.util.Map;
 
 @Module
-public class {{genModule.id}} {
+public class {{baseModule.id}} {
     @Provides @{{scope.id}}
     static ClassLoaderResourceRegistry provideClassLoaderResourceRegistry() {
         return {{classloaderResources.classloaderResources.qualifiedId}}.createClassLoaderResourceRegistry();
@@ -211,7 +211,7 @@ public class {{genModule.id}} {
 
 
     @Provides @{{scope.id}}
-    static LanguageInstance provideLanguageInstance({{genInstance.id}} instance) {
+    static LanguageInstance provideLanguageInstance({{baseInstance.id}} instance) {
         return instance;
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Module.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Module.java.mustache
@@ -211,7 +211,7 @@ public class {{baseModule.id}} {
 
 
     @Provides @{{scope.id}}
-    static LanguageInstance provideLanguageInstance({{baseInstance.id}} instance) {
+    static LanguageInstance provideLanguageInstance({{instance.qualifiedId}} instance) {
         return instance;
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Module.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Module.java.mustache
@@ -92,12 +92,12 @@ public class {{genModule.id}} {
 
 
     @Provides @{{scope.id}}
-    static {{this.languageProjectInput.factory.qualifiedId}} provideParserFactory(@{{qualifier.id}}("definition-dir") HierarchicalResource definitionDir) {
-        return new {{this.languageProjectInput.factory.qualifiedId}}(definitionDir);
+    static {{this.languageProjectInput.parserFactory.qualifiedId}} provideParserFactory(@{{qualifier.id}}("definition-dir") HierarchicalResource definitionDir) {
+        return new {{this.languageProjectInput.parserFactory.qualifiedId}}(definitionDir);
     }
 
     @Provides /* Unscoped: parser has state, so create a new parser every call. */
-    static {{this.languageProjectInput.parser.qualifiedId}} provideParser({{this.languageProjectInput.factory.qualifiedId}} parserFactory) {
+    static {{this.languageProjectInput.parser.qualifiedId}} provideParser({{this.languageProjectInput.parserFactory.qualifiedId}} parserFactory) {
         return parserFactory.create();
     }
 {{/parser}}
@@ -105,12 +105,12 @@ public class {{genModule.id}} {
 
 
     @Provides @{{scope.id}}
-    static {{this.languageProjectInput.factory.qualifiedId}} provideStylerFactory(LoggerFactory loggerFactory, @{{qualifier.id}}("definition-dir") HierarchicalResource definitionDir) {
-        return new {{this.languageProjectInput.factory.qualifiedId}}(loggerFactory, definitionDir);
+    static {{this.languageProjectInput.stylerFactory.qualifiedId}} provideStylerFactory(LoggerFactory loggerFactory, @{{qualifier.id}}("definition-dir") HierarchicalResource definitionDir) {
+        return new {{this.languageProjectInput.stylerFactory.qualifiedId}}(loggerFactory, definitionDir);
     }
 
     @Provides @{{scope.id}}
-    static {{this.languageProjectInput.styler.qualifiedId}} provideStyler({{this.languageProjectInput.factory.qualifiedId}} stylerFactory) {
+    static {{this.languageProjectInput.styler.qualifiedId}} provideStyler({{this.languageProjectInput.stylerFactory.qualifiedId}} stylerFactory) {
         return stylerFactory.create();
     }
 {{/styler}}
@@ -118,12 +118,12 @@ public class {{genModule.id}} {
 
 
     @Provides @{{scope.id}}
-    static {{this.languageProjectInput.factory.qualifiedId}} provideConstraintAnalyzerFactory(ResourceService resourceService) {
-        return new {{this.languageProjectInput.factory.qualifiedId}}(resourceService);
+    static {{this.languageProjectInput.constraintAnalyzerFactory.qualifiedId}} provideConstraintAnalyzerFactory(ResourceService resourceService) {
+        return new {{this.languageProjectInput.constraintAnalyzerFactory.qualifiedId}}(resourceService);
     }
 
     @Provides @{{scope.id}}
-    static {{this.languageProjectInput.constraintAnalyzer.qualifiedId}} provideConstraintAnalyzer({{this.languageProjectInput.factory.qualifiedId}} factory) {
+    static {{this.languageProjectInput.constraintAnalyzer.qualifiedId}} provideConstraintAnalyzer({{this.languageProjectInput.constraintAnalyzerFactory.qualifiedId}} factory) {
         return factory.create();
     }
 {{/constraintAnalyzer}}
@@ -131,12 +131,12 @@ public class {{genModule.id}} {
 
 
     @Provides @{{scope.id}}
-    static {{this.languageProjectInput.factory.qualifiedId}} provideStrategoRuntimeBuilderFactory(LoggerFactory loggerFactory, ResourceService resourceService, @{{qualifier.id}}("definition-dir") HierarchicalResource definitionDir) {
-        return new {{this.languageProjectInput.factory.qualifiedId}}(loggerFactory, resourceService, definitionDir);
+    static {{this.languageProjectInput.strategoRuntimeBuilderFactory.qualifiedId}} provideStrategoRuntimeBuilderFactory(LoggerFactory loggerFactory, ResourceService resourceService, @{{qualifier.id}}("definition-dir") HierarchicalResource definitionDir) {
+        return new {{this.languageProjectInput.strategoRuntimeBuilderFactory.qualifiedId}}(loggerFactory, resourceService, definitionDir);
     }
 
     @Provides @{{scope.id}} @{{qualifier.id}}
-    static StrategoRuntimeBuilder provideQualifiedStrategoRuntimeBuilder({{this.languageProjectInput.factory.qualifiedId}} factory) {
+    static StrategoRuntimeBuilder provideQualifiedStrategoRuntimeBuilder({{this.languageProjectInput.strategoRuntimeBuilderFactory.qualifiedId}} factory) {
         return factory.create();
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Qualifier.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Qualifier.java.mustache
@@ -1,4 +1,4 @@
-package {{genQualifier.packageId}};
+package {{baseQualifier.packageId}};
 
 import javax.inject.Qualifier;
 import java.lang.annotation.Documented;
@@ -8,6 +8,6 @@ import java.lang.annotation.RetentionPolicy;
 @Qualifier
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-public @interface {{genQualifier.id}} {
+public @interface {{baseQualifier.id}} {
     String value() default "";
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Scope.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Scope.java.mustache
@@ -1,4 +1,4 @@
-package {{genScope.packageId}};
+package {{baseScope.packageId}};
 
 import javax.inject.Scope;
 import java.lang.annotation.Documented;
@@ -8,4 +8,4 @@ import java.lang.annotation.RetentionPolicy;
 @Scope
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-public @interface {{genScope.id}} {}
+public @interface {{baseScope.id}} {}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/package-info.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/package-info.java.mustache
@@ -1,5 +1,5 @@
 @DefaultQualifier(NonNull.class)
-package {{genPackageInfo.packageId}};
+package {{basePackageInfo.packageId}};
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/completer/CompleteTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/completer/CompleteTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genCompleteTaskDef.packageId}};
+package {{baseCompleteTaskDef.packageId}};
 
 import mb.common.style.StyleName;
 import mb.common.util.ListView;
@@ -15,7 +15,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genCompleteTaskDef.id}} implements TaskDef<{{genCompleteTaskDef.id}}.Input, @Nullable CompletionResult> {
+public class {{baseCompleteTaskDef.id}} implements TaskDef<{{baseCompleteTaskDef.id}}.Input, @Nullable CompletionResult> {
 
     public static class Input implements Serializable {
         public final Supplier<@Nullable IStrategoTerm> astSupplier;
@@ -44,11 +44,11 @@ public class {{genCompleteTaskDef.id}} implements TaskDef<{{genCompleteTaskDef.i
 
     }
 
-    @Inject public {{genCompleteTaskDef.id}}() {}
+    @Inject public {{baseCompleteTaskDef.id}}() {}
 
     @Override
     public String getId() {
-        return "{{genCompleteTaskDef.id}}";
+        return "{{baseCompleteTaskDef.id}}";
     }
 
     @Override

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/constraint_analyzer/AnalyzeMultiTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/constraint_analyzer/AnalyzeMultiTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genAnalyzeMultiTaskDef.packageId}};
+package {{baseAnalyzeMultiTaskDef.packageId}};
 
 import mb.constraint.common.ConstraintAnalyzer.MultiFileResult;
 import mb.constraint.common.ConstraintAnalyzerContext;
@@ -14,19 +14,19 @@ import javax.inject.Provider;
 import java.util.HashMap;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genAnalyzeMultiTaskDef.id}} extends ConstraintAnalyzeMultiTaskDef {
+public class {{baseAnalyzeMultiTaskDef.id}} extends ConstraintAnalyzeMultiTaskDef {
     private final {{languageProjectInput.constraintAnalyzer.qualifiedId}} constraintAnalyzer;
     private final Provider<StrategoRuntime> strategoRuntimeProvider;
 
     @Inject
-    public {{genAnalyzeMultiTaskDef.id}}({{languageProjectInput.constraintAnalyzer.qualifiedId}} constraintAnalyzer, Provider<StrategoRuntime> strategoRuntimeProvider) {
+    public {{baseAnalyzeMultiTaskDef.id}}({{languageProjectInput.constraintAnalyzer.qualifiedId}} constraintAnalyzer, Provider<StrategoRuntime> strategoRuntimeProvider) {
         this.constraintAnalyzer = constraintAnalyzer;
         this.strategoRuntimeProvider = strategoRuntimeProvider;
     }
 
     @Override
     public String getId() {
-        return "{{genAnalyzeMultiTaskDef.qualifiedId}}";
+        return "{{baseAnalyzeMultiTaskDef.qualifiedId}}";
     }
 
     @Override

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/constraint_analyzer/AnalyzeTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/constraint_analyzer/AnalyzeTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genAnalyzeTaskDef.packageId}};
+package {{baseAnalyzeTaskDef.packageId}};
 
 import mb.constraint.common.ConstraintAnalyzer.SingleFileResult;
 import mb.constraint.common.ConstraintAnalyzerContext;
@@ -12,19 +12,19 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genAnalyzeTaskDef.id}} extends ConstraintAnalyzeTaskDef {
+public class {{baseAnalyzeTaskDef.id}} extends ConstraintAnalyzeTaskDef {
     private final {{languageProjectInput.constraintAnalyzer.qualifiedId}} constraintAnalyzer;
     private final Provider<StrategoRuntime> strategoRuntimeProvider;
 
     @Inject
-    public {{genAnalyzeTaskDef.id}}({{languageProjectInput.constraintAnalyzer.qualifiedId}} constraintAnalyzer, Provider<StrategoRuntime> strategoRuntimeProvider) {
+    public {{baseAnalyzeTaskDef.id}}({{languageProjectInput.constraintAnalyzer.qualifiedId}} constraintAnalyzer, Provider<StrategoRuntime> strategoRuntimeProvider) {
         this.constraintAnalyzer = constraintAnalyzer;
         this.strategoRuntimeProvider = strategoRuntimeProvider;
     }
 
     @Override
     public String getId() {
-        return "{{genAnalyzeTaskDef.qualifiedId}}";
+        return "{{baseAnalyzeTaskDef.qualifiedId}}";
     }
 
     @Override

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/AnalyzeProjectTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/AnalyzeProjectTaskDef.java.mustache
@@ -11,9 +11,9 @@ import javax.inject.Inject;
 @{{adapterProject.scope.qualifiedId}}
 public class {{baseAnalyzeTaskDef.id}} implements TaskDef<ResourcePath, CommandFeedback> {
 
-    private final {{baseCheckTaskDef.qualifiedId}} check;
+    private final {{checkTaskDef.qualifiedId}} check;
 
-    @Inject public {{baseAnalyzeTaskDef.id}}({{baseCheckTaskDef.qualifiedId}} check) {
+    @Inject public {{baseAnalyzeTaskDef.id}}({{checkTaskDef.qualifiedId}} check) {
         this.check = check;
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/AnalyzeProjectTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/AnalyzeProjectTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genAnalyzeTaskDef.packageId}};
+package {{baseAnalyzeTaskDef.packageId}};
 
 import mb.common.message.KeyedMessages;
 import mb.pie.api.ExecContext;
@@ -9,16 +9,16 @@ import mb.spoofax.core.language.command.CommandFeedback;
 import javax.inject.Inject;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genAnalyzeTaskDef.id}} implements TaskDef<ResourcePath, CommandFeedback> {
+public class {{baseAnalyzeTaskDef.id}} implements TaskDef<ResourcePath, CommandFeedback> {
 
-    private final {{genCheckTaskDef.qualifiedId}} check;
+    private final {{baseCheckTaskDef.qualifiedId}} check;
 
-    @Inject public {{genAnalyzeTaskDef.id}}({{genCheckTaskDef.qualifiedId}} check) {
+    @Inject public {{baseAnalyzeTaskDef.id}}({{baseCheckTaskDef.qualifiedId}} check) {
         this.check = check;
     }
 
     @Override public String getId() {
-        return "{{genAnalyzeTaskDef.qualifiedId}}";
+        return "{{baseAnalyzeTaskDef.qualifiedId}}";
     }
 
     @Override

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/IndexAstTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/IndexAstTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genIndexAstTaskDef.packageId}};
+package {{baseIndexAstTaskDef.packageId}};
 
 import mb.common.result.Result;
 import mb.jsglr1.common.JSGLR1ParseException;
@@ -12,9 +12,9 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genIndexAstTaskDef.id}} extends SmlIndexAstTaskDef<JSGLR1ParseException> {
+public class {{baseIndexAstTaskDef.id}} extends SmlIndexAstTaskDef<JSGLR1ParseException> {
 
-    @Inject public {{genIndexAstTaskDef.id}}(
+    @Inject public {{baseIndexAstTaskDef.id}}(
         Provider<StrategoRuntime> strategoRuntimeProvider,
         Function<Supplier<String>, Result<IStrategoTerm, JSGLR1ParseException>> astSupplier
     ) {
@@ -22,6 +22,6 @@ public class {{genIndexAstTaskDef.id}} extends SmlIndexAstTaskDef<JSGLR1ParseExc
     }
 
     @Override public String getId() {
-        return "{{genIndexAstTaskDef.qualifiedId}}";
+        return "{{baseIndexAstTaskDef.qualifiedId}}";
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/PostStatixTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/PostStatixTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genPostStatixTaskDef.packageId}};
+package {{basePostStatixTaskDef.packageId}};
 
 import mb.common.result.Result;
 import mb.pie.api.ExecContext;
@@ -12,13 +12,13 @@ import javax.inject.Provider;
 import java.io.IOException;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genPostStatixTaskDef.id}} extends AstStrategoTransformTaskDef {
-    @Inject public {{genPostStatixTaskDef.id}}(Provider<StrategoRuntime> strategoRuntimeProvider) {
+public class {{basePostStatixTaskDef.id}} extends AstStrategoTransformTaskDef {
+    @Inject public {{basePostStatixTaskDef.id}}(Provider<StrategoRuntime> strategoRuntimeProvider) {
         super(strategoRuntimeProvider, "{{postAnalysisStrategy}}");
     }
 
     @Override public String getId() {
-        return "{{genPostStatixTaskDef.qualifiedId}}";
+        return "{{basePostStatixTaskDef.qualifiedId}}";
     }
 
     @Override

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/PreStatixTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/PreStatixTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genPreStatixTaskDef.packageId}};
+package {{basePreStatixTaskDef.packageId}};
 import mb.common.result.Result;
 import mb.pie.api.ExecContext;
 import mb.pie.api.Supplier;
@@ -11,13 +11,13 @@ import javax.inject.Provider;
 import java.io.IOException;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genPreStatixTaskDef.id}} extends AstStrategoTransformTaskDef {
-    @Inject public {{genPreStatixTaskDef.id}}(Provider<StrategoRuntime> strategoRuntimeProvider) {
+public class {{basePreStatixTaskDef.id}} extends AstStrategoTransformTaskDef {
+    @Inject public {{basePreStatixTaskDef.id}}(Provider<StrategoRuntime> strategoRuntimeProvider) {
         super(strategoRuntimeProvider, "{{preAnalysisStrategy}}");
     }
 
     @Override public String getId() {
-        return "{{genPreStatixTaskDef.qualifiedId}}";
+        return "{{basePreStatixTaskDef.qualifiedId}}";
     }
 
     @Override

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/SmlCheckTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/multilang_analyzer/SmlCheckTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genCheckTaskDef.packageId}};
+package {{baseCheckTaskDef.packageId}};
 
 import dagger.Lazy;
 import mb.common.message.Messages;
@@ -17,9 +17,9 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import javax.inject.Inject;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genCheckTaskDef.id}} extends SmlCheckTaskDef {
+public class {{baseCheckTaskDef.id}} extends SmlCheckTaskDef {
 
-    @Inject public {{genCheckTaskDef.id}}(
+    @Inject public {{baseCheckTaskDef.id}}(
         Function<Supplier<String>, Messages> messagesSupplier,
         SmlBuildContextConfiguration buildContextConfiguration,
         SmlSolveProject solveProject,
@@ -30,7 +30,7 @@ public class {{genCheckTaskDef.id}} extends SmlCheckTaskDef {
     }
 
     @Override public String getId() {
-        return "{{genCheckTaskDef.qualifiedId}}";
+        return "{{baseCheckTaskDef.qualifiedId}}";
     }
 
     @Override protected LanguageId getLanguageId() {

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/parser/ParseTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/parser/ParseTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genParseTaskDef.packageId}};
+package {{baseParseTaskDef.packageId}};
 
 import mb.common.result.Result;
 import mb.jsglr1.common.JSGLR1ParseException;
@@ -8,16 +8,16 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genParseTaskDef.id}} extends JSGLR1ParseTaskDef {
+public class {{baseParseTaskDef.id}} extends JSGLR1ParseTaskDef {
     private final Provider<{{languageProjectInput.parser.qualifiedId}}> parserProvider;
 
     @Inject
-    public {{genParseTaskDef.id}}(Provider<{{languageProjectInput.parser.qualifiedId}}> parserProvider) {
+    public {{baseParseTaskDef.id}}(Provider<{{languageProjectInput.parser.qualifiedId}}> parserProvider) {
         this.parserProvider = parserProvider;
     }
 
     @Override public String getId() {
-        return "{{genParseTaskDef.qualifiedId}}";
+        return "{{baseParseTaskDef.qualifiedId}}";
     }
 
     @Override protected Result<JSGLR1ParseOutput, JSGLR1ParseException> parse(String text) throws InterruptedException {

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/parser/TokenizeTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/parser/TokenizeTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genTokenizeTaskDef.packageId}};
+package {{baseTokenizeTaskDef.packageId}};
 
 import mb.common.option.Option;
 import mb.jsglr.common.JSGLRTokens;
@@ -11,15 +11,15 @@ import javax.inject.Inject;
 import java.io.IOException;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genTokenizeTaskDef.id}} implements TaskDef<ResourceKey, Option<JSGLRTokens>> {
+public class {{baseTokenizeTaskDef.id}} implements TaskDef<ResourceKey, Option<JSGLRTokens>> {
     private final {{parseTaskDef.qualifiedId}} parse;
 
-    @Inject public {{genTokenizeTaskDef.id}}({{parseTaskDef.qualifiedId}} parse) {
+    @Inject public {{baseTokenizeTaskDef.id}}({{parseTaskDef.qualifiedId}} parse) {
         this.parse = parse;
     }
 
     @Override public String getId() {
-        return "{{genTokenizeTaskDef.qualifiedId}}";
+        return "{{baseTokenizeTaskDef.qualifiedId}}";
     }
 
     @Override

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/styler/StyleTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/styler/StyleTaskDef.java.mustache
@@ -1,4 +1,4 @@
-package {{genStyleTaskDef.packageId}};
+package {{baseStyleTaskDef.packageId}};
 
 import mb.common.option.Option;
 import mb.common.style.Styling;
@@ -11,15 +11,15 @@ import javax.inject.Inject;
 import java.io.IOException;
 
 @{{adapterProject.scope.qualifiedId}}
-public class {{genStyleTaskDef.id}} implements TaskDef<Supplier<Option<JSGLRTokens>>, Option<Styling>> {
+public class {{baseStyleTaskDef.id}} implements TaskDef<Supplier<Option<JSGLRTokens>>, Option<Styling>> {
     private final {{languageProjectInput.styler.qualifiedId}} styler;
 
-    @Inject public {{genStyleTaskDef.id}}({{languageProjectInput.styler.qualifiedId}} styler) {
+    @Inject public {{baseStyleTaskDef.id}}({{languageProjectInput.styler.qualifiedId}} styler) {
         this.styler = styler;
     }
 
     @Override public String getId() {
-        return "{{genStyleTaskDef.qualifiedId}}";
+        return "{{baseStyleTaskDef.qualifiedId}}";
     }
 
     @Override

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/classloader_resources/ClassloaderResources.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/classloader_resources/ClassloaderResources.java.mustache
@@ -1,12 +1,12 @@
-package {{genClassloaderResources.packageId}};
+package {{baseClassloaderResources.packageId}};
 
 import mb.resource.ResourceKeyString;
 import mb.resource.classloader.ClassLoaderResource;
 import mb.resource.classloader.ClassLoaderResourceRegistry;
 
-public class {{genClassloaderResources.id}} {
+public class {{baseClassloaderResources.id}} {
     public static ClassLoaderResourceRegistry createClassLoaderResourceRegistry() {
-        return new ClassLoaderResourceRegistry("{{qualifier}}", {{genClassloaderResources.id}}.class.getClassLoader());
+        return new ClassLoaderResourceRegistry("{{qualifier}}", {{baseClassloaderResources.id}}.class.getClassLoader());
     }
 
     public static ClassLoaderResource createDefinitionDir(ClassLoaderResourceRegistry classLoaderResourceRegistry) {

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/constraint_analyzer/ConstraintAnalyzer.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/constraint_analyzer/ConstraintAnalyzer.java.mustache
@@ -1,12 +1,12 @@
-package {{genConstraintAnalyzer.packageId}};
+package {{baseConstraintAnalyzer.packageId}};
 
 import mb.constraint.common.ConstraintAnalyzer;
 import mb.log.api.LoggerFactory;
 import mb.resource.ResourceService;
 import mb.stratego.common.StrategoRuntime;
 
-public class {{genConstraintAnalyzer.id}} extends ConstraintAnalyzer {
-    public {{genConstraintAnalyzer.id}}(ResourceService resourceService) {
+public class {{baseConstraintAnalyzer.id}} extends ConstraintAnalyzer {
+    public {{baseConstraintAnalyzer.id}}(ResourceService resourceService) {
         super(resourceService, "{{strategoStrategy}}", {{multiFile}});
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/constraint_analyzer/ConstraintAnalyzerFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/constraint_analyzer/ConstraintAnalyzerFactory.java.mustache
@@ -1,12 +1,12 @@
-package {{genFactory.packageId}};
+package {{genConstraintAnalyzerFactory.packageId}};
 
 import mb.resource.ResourceService;
 import mb.spoofax.compiler.interfaces.spoofaxcore.ConstraintAnalyzerFactory;
 
-public class {{genFactory.id}} implements ConstraintAnalyzerFactory {
+public class {{genConstraintAnalyzerFactory.id}} implements ConstraintAnalyzerFactory {
     private final ResourceService resourceService;
 
-    public {{genFactory.id}}(ResourceService resourceService) {
+    public {{genConstraintAnalyzerFactory.id}}(ResourceService resourceService) {
         this.resourceService = resourceService;
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/constraint_analyzer/ConstraintAnalyzerFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/constraint_analyzer/ConstraintAnalyzerFactory.java.mustache
@@ -10,7 +10,7 @@ public class {{baseConstraintAnalyzerFactory.id}} implements ConstraintAnalyzerF
         this.resourceService = resourceService;
     }
 
-    @Override public {{baseConstraintAnalyzer.qualifiedId}} create() {
-        return new {{baseConstraintAnalyzer.qualifiedId}}(resourceService);
+    @Override public {{constraintAnalyzer.qualifiedId}} create() {
+        return new {{constraintAnalyzer.qualifiedId}}(resourceService);
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/constraint_analyzer/ConstraintAnalyzerFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/constraint_analyzer/ConstraintAnalyzerFactory.java.mustache
@@ -1,16 +1,16 @@
-package {{genConstraintAnalyzerFactory.packageId}};
+package {{baseConstraintAnalyzerFactory.packageId}};
 
 import mb.resource.ResourceService;
 import mb.spoofax.compiler.interfaces.spoofaxcore.ConstraintAnalyzerFactory;
 
-public class {{genConstraintAnalyzerFactory.id}} implements ConstraintAnalyzerFactory {
+public class {{baseConstraintAnalyzerFactory.id}} implements ConstraintAnalyzerFactory {
     private final ResourceService resourceService;
 
-    public {{genConstraintAnalyzerFactory.id}}(ResourceService resourceService) {
+    public {{baseConstraintAnalyzerFactory.id}}(ResourceService resourceService) {
         this.resourceService = resourceService;
     }
 
-    @Override public {{genConstraintAnalyzer.qualifiedId}} create() {
-        return new {{genConstraintAnalyzer.qualifiedId}}(resourceService);
+    @Override public {{baseConstraintAnalyzer.qualifiedId}} create() {
+        return new {{baseConstraintAnalyzer.qualifiedId}}(resourceService);
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/exports/Exports.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/exports/Exports.java.mustache
@@ -1,10 +1,10 @@
-package {{genExportsClass.packageId}};
+package {{genExports.packageId}};
 
 import mb.resource.hierarchical.HierarchicalResource;
 
 import java.util.ArrayList;
 
-public class {{genExportsClass.id}} {
+public class {{genExports.id}} {
 {{#combinedExports}}
     public static ArrayList<String> get{{languageIdCapitalized}}Exports() {
         final ArrayList<String> exports = new ArrayList<>();

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/exports/Exports.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/exports/Exports.java.mustache
@@ -1,10 +1,10 @@
-package {{genExports.packageId}};
+package {{baseExports.packageId}};
 
 import mb.resource.hierarchical.HierarchicalResource;
 
 import java.util.ArrayList;
 
-public class {{genExports.id}} {
+public class {{baseExports.id}} {
 {{#combinedExports}}
     public static ArrayList<String> get{{languageIdCapitalized}}Exports() {
         final ArrayList<String> exports = new ArrayList<>();

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/multilang_analyzer/SpecConfigFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/multilang_analyzer/SpecConfigFactory.java.mustache
@@ -1,4 +1,4 @@
-package {{genSpecConfigFactory.packageId}};
+package {{baseSpecConfigFactory.packageId}};
 
 import mb.statix.multilang.metadata.SpecFragmentId;
 import mb.statix.multilang.metadata.spec.ImmutableSpecConfig;
@@ -10,7 +10,7 @@ import org.spoofax.terms.TermFactory;
 import java.util.HashMap;
 import java.util.Map;
 
-public class {{genSpecConfigFactory.id}} {
+public class {{baseSpecConfigFactory.id}} {
 
     public static SpecFragmentId getSpecId() {
         return new SpecFragmentId("{{languageId}}");

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/package-info.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/package-info.java.mustache
@@ -1,5 +1,5 @@
 @DefaultQualifier(NonNull.class)
-package {{genPackageInfo.packageId}};
+package {{basePackageInfo.packageId}};
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/ParseTable.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/ParseTable.java.mustache
@@ -1,4 +1,4 @@
-package {{genTable.packageId}};
+package {{baseParseTable.packageId}};
 
 import mb.jsglr1.common.JSGLR1ParseTable;
 import mb.jsglr1.common.JSGLR1ParseTableException;
@@ -8,18 +8,18 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
-public class {{genTable.id}} implements Serializable {
+public class {{baseParseTable.id}} implements Serializable {
     final JSGLR1ParseTable parseTable;
 
-    private {{genTable.id}}(JSGLR1ParseTable parseTable) {
+    private {{baseParseTable.id}}(JSGLR1ParseTable parseTable) {
         this.parseTable = parseTable;
     }
 
-    public static {{genTable.id}} fromDefinitionDir(HierarchicalResource definitionDir) {
+    public static {{baseParseTable.id}} fromDefinitionDir(HierarchicalResource definitionDir) {
         final HierarchicalResource resource = definitionDir.appendRelativePath("{{parseTableRelativePath}}");
         try(final InputStream inputStream = resource.openRead()) {
             final JSGLR1ParseTable parseTable = JSGLR1ParseTable.fromStream(inputStream);
-            return new {{genTable.id}}(parseTable);
+            return new {{baseParseTable.id}}(parseTable);
         } catch(JSGLR1ParseTableException | IOException e) {
             throw new RuntimeException("Cannot create parse table; cannot read parse table from resource '" + resource + "' in classloader resources");
         }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/Parser.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/Parser.java.mustache
@@ -7,12 +7,12 @@ import mb.resource.ResourceKey;
 import mb.spoofax.compiler.interfaces.spoofaxcore.Parser;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import {{baseParseTable.qualifiedId}};
+import {{parseTable.qualifiedId}};
 
 public class {{baseParser.id}} implements Parser {
     private final JSGLR1Parser parser;
 
-    public {{baseParser.id}}({{baseParseTable.id}} parseTable) {
+    public {{baseParser.id}}({{parseTable.id}} parseTable) {
         this.parser = new JSGLR1Parser(parseTable.parseTable);
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/Parser.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/Parser.java.mustache
@@ -1,4 +1,4 @@
-package {{genParser.packageId}};
+package {{baseParser.packageId}};
 
 import mb.jsglr1.common.JSGLR1ParseException;
 import mb.jsglr1.common.JSGLR1ParseOutput;
@@ -7,12 +7,12 @@ import mb.resource.ResourceKey;
 import mb.spoofax.compiler.interfaces.spoofaxcore.Parser;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import {{genTable.qualifiedId}};
+import {{baseParseTable.qualifiedId}};
 
-public class {{genParser.id}} implements Parser {
+public class {{baseParser.id}} implements Parser {
     private final JSGLR1Parser parser;
 
-    public {{genParser.id}}({{genTable.id}} parseTable) {
+    public {{baseParser.id}}({{baseParseTable.id}} parseTable) {
         this.parser = new JSGLR1Parser(parseTable.parseTable);
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/ParserFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/ParserFactory.java.mustache
@@ -4,13 +4,13 @@ import mb.resource.hierarchical.HierarchicalResource;
 import mb.spoofax.compiler.interfaces.spoofaxcore.ParserFactory;
 
 public class {{baseParserFactory.id}} implements ParserFactory {
-    private final {{baseParseTable.qualifiedId}} parseTable;
+    private final {{parseTable.qualifiedId}} parseTable;
 
     public {{baseParserFactory.id}}(HierarchicalResource definitionDir) {
-        this.parseTable = {{baseParseTable.qualifiedId}}.fromDefinitionDir(definitionDir);
+        this.parseTable = {{parseTable.qualifiedId}}.fromDefinitionDir(definitionDir);
     }
 
-    @Override public {{baseParser.qualifiedId}} create() {
-        return new {{baseParser.qualifiedId}}(parseTable);
+    @Override public {{parser.qualifiedId}} create() {
+        return new {{parser.qualifiedId}}(parseTable);
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/ParserFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/ParserFactory.java.mustache
@@ -1,16 +1,16 @@
-package {{genParserFactory.packageId}};
+package {{baseParserFactory.packageId}};
 
 import mb.resource.hierarchical.HierarchicalResource;
 import mb.spoofax.compiler.interfaces.spoofaxcore.ParserFactory;
 
-public class {{genParserFactory.id}} implements ParserFactory {
-    private final {{genTable.qualifiedId}} parseTable;
+public class {{baseParserFactory.id}} implements ParserFactory {
+    private final {{baseParseTable.qualifiedId}} parseTable;
 
-    public {{genParserFactory.id}}(HierarchicalResource definitionDir) {
-        this.parseTable = {{genTable.qualifiedId}}.fromDefinitionDir(definitionDir);
+    public {{baseParserFactory.id}}(HierarchicalResource definitionDir) {
+        this.parseTable = {{baseParseTable.qualifiedId}}.fromDefinitionDir(definitionDir);
     }
 
-    @Override public {{genParser.qualifiedId}} create() {
-        return new {{genParser.qualifiedId}}(parseTable);
+    @Override public {{baseParser.qualifiedId}} create() {
+        return new {{baseParser.qualifiedId}}(parseTable);
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/ParserFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/parser/ParserFactory.java.mustache
@@ -1,12 +1,12 @@
-package {{genFactory.packageId}};
+package {{genParserFactory.packageId}};
 
 import mb.resource.hierarchical.HierarchicalResource;
 import mb.spoofax.compiler.interfaces.spoofaxcore.ParserFactory;
 
-public class {{genFactory.id}} implements ParserFactory {
+public class {{genParserFactory.id}} implements ParserFactory {
     private final {{genTable.qualifiedId}} parseTable;
 
-    public {{genFactory.id}}(HierarchicalResource definitionDir) {
+    public {{genParserFactory.id}}(HierarchicalResource definitionDir) {
         this.parseTable = {{genTable.qualifiedId}}.fromDefinitionDir(definitionDir);
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/stratego_runtime/StrategoRuntimeBuilderFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/stratego_runtime/StrategoRuntimeBuilderFactory.java.mustache
@@ -1,4 +1,4 @@
-package {{genFactory.packageId}};
+package {{genStrategoRuntimeBuilderFactory.packageId}};
 
 import mb.log.api.LoggerFactory;
 import mb.resource.ResourceService;
@@ -6,12 +6,12 @@ import mb.resource.hierarchical.HierarchicalResource;
 import mb.spoofax.compiler.interfaces.spoofaxcore.StrategoRuntimeBuilderFactory;
 import mb.stratego.common.StrategoRuntimeBuilder;
 
-public class {{genFactory.id}} implements StrategoRuntimeBuilderFactory {
+public class {{genStrategoRuntimeBuilderFactory.id}} implements StrategoRuntimeBuilderFactory {
     private final LoggerFactory loggerFactory;
     private final ResourceService resourceService;
     private final HierarchicalResource definitionDir;
 
-    public {{genFactory.id}}(LoggerFactory loggerFactory, ResourceService resourceService, HierarchicalResource definitionDir) {
+    public {{genStrategoRuntimeBuilderFactory.id}}(LoggerFactory loggerFactory, ResourceService resourceService, HierarchicalResource definitionDir) {
         this.loggerFactory = loggerFactory;
         this.resourceService = resourceService;
         this.definitionDir = definitionDir;
@@ -25,7 +25,7 @@ public class {{genFactory.id}} implements StrategoRuntimeBuilderFactory {
 {{#ctreeRelativePaths}}
         builder.addCtree(definitionDir.appendRelativePath("{{this}}"));
 {{/ctreeRelativePaths}}
-        builder.withJarParentClassLoader({{factory.id}}.class.getClassLoader());
+        builder.withJarParentClassLoader({{genStrategoRuntimeBuilderFactory.id}}.class.getClassLoader());
 {{#addNaBL2Primitives}}
         builder.addLibrary(new mb.nabl2.common.NaBL2PrimitiveLibrary());
 {{/addNaBL2Primitives}}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/stratego_runtime/StrategoRuntimeBuilderFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/stratego_runtime/StrategoRuntimeBuilderFactory.java.mustache
@@ -1,4 +1,4 @@
-package {{genStrategoRuntimeBuilderFactory.packageId}};
+package {{baseStrategoRuntimeBuilderFactory.packageId}};
 
 import mb.log.api.LoggerFactory;
 import mb.resource.ResourceService;
@@ -6,12 +6,12 @@ import mb.resource.hierarchical.HierarchicalResource;
 import mb.spoofax.compiler.interfaces.spoofaxcore.StrategoRuntimeBuilderFactory;
 import mb.stratego.common.StrategoRuntimeBuilder;
 
-public class {{genStrategoRuntimeBuilderFactory.id}} implements StrategoRuntimeBuilderFactory {
+public class {{baseStrategoRuntimeBuilderFactory.id}} implements StrategoRuntimeBuilderFactory {
     private final LoggerFactory loggerFactory;
     private final ResourceService resourceService;
     private final HierarchicalResource definitionDir;
 
-    public {{genStrategoRuntimeBuilderFactory.id}}(LoggerFactory loggerFactory, ResourceService resourceService, HierarchicalResource definitionDir) {
+    public {{baseStrategoRuntimeBuilderFactory.id}}(LoggerFactory loggerFactory, ResourceService resourceService, HierarchicalResource definitionDir) {
         this.loggerFactory = loggerFactory;
         this.resourceService = resourceService;
         this.definitionDir = definitionDir;
@@ -25,7 +25,7 @@ public class {{genStrategoRuntimeBuilderFactory.id}} implements StrategoRuntimeB
 {{#ctreeRelativePaths}}
         builder.addCtree(definitionDir.appendRelativePath("{{this}}"));
 {{/ctreeRelativePaths}}
-        builder.withJarParentClassLoader({{genStrategoRuntimeBuilderFactory.id}}.class.getClassLoader());
+        builder.withJarParentClassLoader({{baseStrategoRuntimeBuilderFactory.id}}.class.getClassLoader());
 {{#addNaBL2Primitives}}
         builder.addLibrary(new mb.nabl2.common.NaBL2PrimitiveLibrary());
 {{/addNaBL2Primitives}}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/Styler.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/Styler.java.mustache
@@ -10,7 +10,7 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 public class {{baseStyler.id}} implements Styler {
     private final ESVStyler styler;
 
-    public {{baseStyler.id}}({{baseStylingRules.qualifiedId}} stylingRules, LoggerFactory loggerFactory) {
+    public {{baseStyler.id}}({{stylingRules.qualifiedId}} stylingRules, LoggerFactory loggerFactory) {
         this.styler = new ESVStyler(stylingRules.stylingRules, loggerFactory);
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/Styler.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/Styler.java.mustache
@@ -1,4 +1,4 @@
-package {{genStyler.packageId}};
+package {{baseStyler.packageId}};
 
 import mb.common.style.Styling;
 import mb.common.token.Token;
@@ -7,10 +7,10 @@ import mb.log.api.LoggerFactory;
 import mb.spoofax.compiler.interfaces.spoofaxcore.Styler;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 
-public class {{genStyler.id}} implements Styler {
+public class {{baseStyler.id}} implements Styler {
     private final ESVStyler styler;
 
-    public {{genStyler.id}}({{genRules.qualifiedId}} stylingRules, LoggerFactory loggerFactory) {
+    public {{baseStyler.id}}({{baseStylingRules.qualifiedId}} stylingRules, LoggerFactory loggerFactory) {
         this.styler = new ESVStyler(stylingRules.stylingRules, loggerFactory);
     }
 

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/StylerFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/StylerFactory.java.mustache
@@ -5,15 +5,15 @@ import mb.resource.hierarchical.HierarchicalResource;
 import mb.spoofax.compiler.interfaces.spoofaxcore.StylerFactory;
 
 public class {{baseStylerFactory.id}} implements StylerFactory {
-    private final {{baseStylingRules.qualifiedId}} stylingRules;
+    private final {{stylingRules.qualifiedId}} stylingRules;
     private final LoggerFactory loggerFactory;
 
     public {{baseStylerFactory.id}}(LoggerFactory loggerFactory, HierarchicalResource definitionDir) {
-        this.stylingRules = {{baseStylingRules.qualifiedId}}.fromDefinitionDir(definitionDir);
+        this.stylingRules = {{stylingRules.qualifiedId}}.fromDefinitionDir(definitionDir);
         this.loggerFactory = loggerFactory;
     }
 
-    @Override public {{baseStyler.qualifiedId}} create() {
-        return new {{baseStyler.qualifiedId}}(stylingRules, loggerFactory);
+    @Override public {{styler.qualifiedId}} create() {
+        return new {{styler.qualifiedId}}(stylingRules, loggerFactory);
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/StylerFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/StylerFactory.java.mustache
@@ -1,14 +1,14 @@
-package {{genFactory.packageId}};
+package {{genStylerFactory.packageId}};
 
 import mb.log.api.LoggerFactory;
 import mb.resource.hierarchical.HierarchicalResource;
 import mb.spoofax.compiler.interfaces.spoofaxcore.StylerFactory;
 
-public class {{genFactory.id}} implements StylerFactory {
+public class {{genStylerFactory.id}} implements StylerFactory {
     private final {{genRules.qualifiedId}} stylingRules;
     private final LoggerFactory loggerFactory;
 
-    public {{genFactory.id}}(LoggerFactory loggerFactory, HierarchicalResource definitionDir) {
+    public {{genStylerFactory.id}}(LoggerFactory loggerFactory, HierarchicalResource definitionDir) {
         this.stylingRules = {{genRules.qualifiedId}}.fromDefinitionDir(definitionDir);
         this.loggerFactory = loggerFactory;
     }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/StylerFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/StylerFactory.java.mustache
@@ -1,19 +1,19 @@
-package {{genStylerFactory.packageId}};
+package {{baseStylerFactory.packageId}};
 
 import mb.log.api.LoggerFactory;
 import mb.resource.hierarchical.HierarchicalResource;
 import mb.spoofax.compiler.interfaces.spoofaxcore.StylerFactory;
 
-public class {{genStylerFactory.id}} implements StylerFactory {
-    private final {{genRules.qualifiedId}} stylingRules;
+public class {{baseStylerFactory.id}} implements StylerFactory {
+    private final {{baseStylingRules.qualifiedId}} stylingRules;
     private final LoggerFactory loggerFactory;
 
-    public {{genStylerFactory.id}}(LoggerFactory loggerFactory, HierarchicalResource definitionDir) {
-        this.stylingRules = {{genRules.qualifiedId}}.fromDefinitionDir(definitionDir);
+    public {{baseStylerFactory.id}}(LoggerFactory loggerFactory, HierarchicalResource definitionDir) {
+        this.stylingRules = {{baseStylingRules.qualifiedId}}.fromDefinitionDir(definitionDir);
         this.loggerFactory = loggerFactory;
     }
 
-    @Override public {{genStyler.qualifiedId}} create() {
-        return new {{genStyler.qualifiedId}}(stylingRules, loggerFactory);
+    @Override public {{baseStyler.qualifiedId}} create() {
+        return new {{baseStyler.qualifiedId}}(stylingRules, loggerFactory);
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/StylingRules.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/language/styler/StylingRules.java.mustache
@@ -1,4 +1,4 @@
-package {{genRules.packageId}};
+package {{baseStylingRules.packageId}};
 
 import mb.esv.common.ESVStylingRules;
 import mb.resource.hierarchical.HierarchicalResource;
@@ -7,18 +7,18 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
-public class {{genRules.id}} implements Serializable {
+public class {{baseStylingRules.id}} implements Serializable {
     final ESVStylingRules stylingRules;
 
-    private {{genRules.id}}(ESVStylingRules stylingRules) {
+    private {{baseStylingRules.id}}(ESVStylingRules stylingRules) {
         this.stylingRules = stylingRules;
     }
 
-    public static {{genRules.id}} fromDefinitionDir(HierarchicalResource definitionDir) {
+    public static {{baseStylingRules.id}} fromDefinitionDir(HierarchicalResource definitionDir) {
         final HierarchicalResource resource = definitionDir.appendRelativePath("{{packedEsvRelativePath}}");
         try(final InputStream inputStream = resource.openRead()) {
             final ESVStylingRules stylingRules = ESVStylingRules.fromStream(inputStream);
-            return new {{genRules.id}}(stylingRules);
+            return new {{baseStylingRules.id}}(stylingRules);
         } catch(IOException e) {
             throw new RuntimeException("Cannot create styling rules; cannot read styling rules from '" + resource + "' in classloader resources", e);
         }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/cli_project/Main.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/cli_project/Main.java.mustache
@@ -1,4 +1,4 @@
-package {{genMain.packageId}};
+package {{baseMain.packageId}};
 
 import mb.log.slf4j.SLF4JLoggerFactory;
 import mb.pie.runtime.PieBuilderImpl;
@@ -8,7 +8,7 @@ import mb.spoofax.cli.SpoofaxCliComponent;
 import mb.spoofax.core.platform.LoggerFactoryModule;
 import mb.spoofax.core.platform.PlatformPieModule;
 
-public class {{genMain.id}} {
+public class {{baseMain.id}} {
     public static void main(String[] args) {
         final SpoofaxCliComponent platformComponent = DaggerSpoofaxCliComponent.builder()
             .loggerFactoryModule(new LoggerFactoryModule(new SLF4JLoggerFactory()))

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/cli_project/package-info.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/cli_project/package-info.java.mustache
@@ -1,5 +1,5 @@
 @DefaultQualifier(NonNull.class)
-package {{genPackageInfo.packageId}};
+package {{basePackageInfo.packageId}};
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/AddNatureHandler.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/AddNatureHandler.java.mustache
@@ -1,9 +1,9 @@
-package {{genAddNatureHandler.packageId}};
+package {{baseAddNatureHandler.packageId}};
 
 import mb.spoofax.eclipse.nature.AddNatureHandler;
 
-public class {{genAddNatureHandler.id}} extends AddNatureHandler {
-    public {{genAddNatureHandler.id}}() {
+public class {{baseAddNatureHandler.id}} extends AddNatureHandler {
+    public {{baseAddNatureHandler.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Component.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Component.java.mustache
@@ -1,4 +1,4 @@
-package {{genEclipseComponent.packageId}};
+package {{baseEclipseComponent.packageId}};
 
 import dagger.Component;
 import mb.spoofax.core.platform.PlatformComponent;
@@ -12,6 +12,6 @@ import mb.statix.multilang.eclipse.MultiLangEclipseComponent;
     modules = { {{adapterProjectCompilerInput.module.qualifiedId}}.class, {{eclipseModule.qualifiedId}}.class{{#adapterProjectCompilerInput.additionalModules}}{{#-first}}, {{/-first}}{{qualifiedId}}.class{{^-last}}, {{/-last}}{{/adapterProjectCompilerInput.additionalModules}} },
     dependencies = { PlatformComponent.class{{#this.adapterProjectCompilerInput.isMultiLang}}, MultiLangEclipseComponent.class{{/this.adapterProjectCompilerInput.isMultiLang}} }
 )
-public interface {{genEclipseComponent.id}} extends EclipseLanguageComponent, {{adapterProjectCompilerInput.component.qualifiedId}} {
+public interface {{baseEclipseComponent.id}} extends EclipseLanguageComponent, {{adapterProjectCompilerInput.component.qualifiedId}} {
     {{editorTracker.qualifiedId}} getEditorTracker();
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/DocumentProvider.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/DocumentProvider.java.mustache
@@ -1,5 +1,5 @@
-package {{genDocumentProvider.packageId}};
+package {{baseDocumentProvider.packageId}};
 
 import mb.spoofax.eclipse.editor.SpoofaxDocumentProvider;
 
-public class {{genDocumentProvider.id}} extends SpoofaxDocumentProvider {}
+public class {{baseDocumentProvider.id}} extends SpoofaxDocumentProvider {}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Editor.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Editor.java.mustache
@@ -1,9 +1,9 @@
-package {{genEditor.packageId}};
+package {{baseEditor.packageId}};
 
 import mb.spoofax.eclipse.editor.SpoofaxEditor;
 
-public class {{genEditor.id}} extends SpoofaxEditor {
-    public {{genEditor.id}}() {
+public class {{baseEditor.id}} extends SpoofaxEditor {
+    public {{baseEditor.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/EditorContextMenu.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/EditorContextMenu.java.mustache
@@ -1,9 +1,9 @@
-package {{genEditorContextMenu.packageId}};
+package {{baseEditorContextMenu.packageId}};
 
 import mb.spoofax.eclipse.menu.EditorContextMenu;
 
-public class {{genEditorContextMenu.id}} extends EditorContextMenu {
-    public {{genEditorContextMenu.id}}() {
+public class {{baseEditorContextMenu.id}} extends EditorContextMenu {
+    public {{baseEditorContextMenu.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/EditorTracker.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/EditorTracker.java.mustache
@@ -1,4 +1,4 @@
-package {{genEditorTracker.packageId}};
+package {{baseEditorTracker.packageId}};
 
 import mb.spoofax.eclipse.EclipseIdentifiers;
 import mb.spoofax.eclipse.editor.EditorTracker;
@@ -6,8 +6,8 @@ import mb.spoofax.eclipse.editor.EditorTracker;
 import javax.inject.Inject;
 
 @{{adapterProjectCompilerInput.scope.qualifiedId}}
-public class {{genEditorTracker.id}} extends EditorTracker {
-    @Inject public {{genEditorTracker.id}}(EclipseIdentifiers eclipseIdentifiers) {
+public class {{baseEditorTracker.id}} extends EditorTracker {
+    @Inject public {{baseEditorTracker.id}}(EclipseIdentifiers eclipseIdentifiers) {
         super(eclipseIdentifiers);
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Identifiers.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Identifiers.java.mustache
@@ -1,9 +1,9 @@
-package {{genEclipseIdentifiers.packageId}};
+package {{baseEclipseIdentifiers.packageId}};
 
 import mb.spoofax.eclipse.EclipseIdentifiers;
 
 @{{adapterProjectCompilerInput.scope.qualifiedId}}
-public class {{genEclipseIdentifiers.id}} implements EclipseIdentifiers {
+public class {{baseEclipseIdentifiers.id}} implements EclipseIdentifiers {
     @Override public String getPlugin() {
         return "{{pluginId}}";
     }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/MainMenu.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/MainMenu.java.mustache
@@ -1,9 +1,9 @@
-package {{genMainMenu.packageId}};
+package {{baseMainMenu.packageId}};
 
 import mb.spoofax.eclipse.menu.MainMenu;
 
-public class {{genMainMenu.id}} extends MainMenu {
-    public {{genMainMenu.id}}() {
+public class {{baseMainMenu.id}} extends MainMenu {
+    public {{baseMainMenu.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/MetadataProvider.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/MetadataProvider.java.mustache
@@ -1,4 +1,4 @@
-package {{genMetadataProvider.packageId}};
+package {{baseMetadataProvider.packageId}};
 
 import mb.statix.multilang.metadata.ContextId;
 import mb.statix.multilang.metadata.LanguageId;
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class {{genMetadataProvider.id}} implements LanguageMetadataProvider {
+public class {{baseMetadataProvider.id}} implements LanguageMetadataProvider {
     // Don't inline this method into getLanguageMetadataSuppliers
     // Because call to getComponent should be delayed for concurrency reasons
     private LanguageMetadata getLanguageMetadata() {

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Module.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Module.java.mustache
@@ -1,4 +1,4 @@
-package {{genEclipseModule.packageId}};
+package {{baseEclipseModule.packageId}};
 
 import dagger.Module;
 import dagger.Provides;
@@ -14,7 +14,7 @@ import {{adapterProjectCompilerInput.scope.qualifiedId}};
 import javax.inject.Named;
 
 @Module
-public class {{genEclipseModule.id}} {
+public class {{baseEclipseModule.id}} {
     @Provides @{{adapterProjectCompilerInput.scope.id}}
     static EclipseIdentifiers provideEclipseIdentifiers() {
         return new {{eclipseIdentifiers.qualifiedId}}();

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Nature.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Nature.java.mustache
@@ -1,9 +1,9 @@
-package {{genNature.packageId}};
+package {{baseNature.packageId}};
 
 import mb.spoofax.eclipse.nature.SpoofaxNature;
 
-public class {{genNature.id}} extends SpoofaxNature {
-    public {{genNature.id}}() {
+public class {{baseNature.id}} extends SpoofaxNature {
+    public {{baseNature.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/ObserveHandler.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/ObserveHandler.java.mustache
@@ -1,9 +1,9 @@
-package {{genObserveHandler.packageId}};
+package {{baseObserveHandler.packageId}};
 
 import mb.spoofax.eclipse.menu.ObserveHandler;
 
-public class {{genObserveHandler.id}} extends ObserveHandler {
-    public {{genObserveHandler.id}}() {
+public class {{baseObserveHandler.id}} extends ObserveHandler {
+    public {{baseObserveHandler.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Plugin.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/Plugin.java.mustache
@@ -1,4 +1,4 @@
-package {{genPlugin.packageId}};
+package {{basePlugin.packageId}};
 
 import mb.pie.api.ExecException;
 import mb.spoofax.eclipse.SpoofaxPlugin;
@@ -17,7 +17,7 @@ import org.osgi.framework.BundleContext;
 
 import java.io.IOException;
 
-public class {{genPlugin.id}} extends AbstractUIPlugin {
+public class {{basePlugin.id}} extends AbstractUIPlugin {
     public static final String pluginId = "{{pluginId}}";
 
     private static {{eclipseComponent.nullableQualifiedId}} component;
@@ -25,7 +25,7 @@ public class {{genPlugin.id}} extends AbstractUIPlugin {
     public static {{eclipseComponent.qualifiedId}} getComponent() {
         if(component == null) {
             throw new RuntimeException(
-                "Cannot access {{eclipseComponent.id}}; {{genPlugin.id}} has not been started yet, or has been stopped");
+                "Cannot access {{eclipseComponent.id}}; {{basePlugin.id}} has not been started yet, or has been stopped");
         }
         return component;
     }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/ProjectBuilder.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/ProjectBuilder.java.mustache
@@ -1,9 +1,9 @@
-package {{genProjectBuilder.packageId}};
+package {{baseProjectBuilder.packageId}};
 
 import mb.spoofax.eclipse.build.SpoofaxProjectBuilder;
 
-public class {{genProjectBuilder.id}} extends SpoofaxProjectBuilder {
-    public {{genProjectBuilder.id}}() {
+public class {{baseProjectBuilder.id}} extends SpoofaxProjectBuilder {
+    public {{baseProjectBuilder.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/RemoveNatureHandler.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/RemoveNatureHandler.java.mustache
@@ -1,9 +1,9 @@
-package {{genRemoveNatureHandler.packageId}};
+package {{baseRemoveNatureHandler.packageId}};
 
 import mb.spoofax.eclipse.nature.RemoveNatureHandler;
 
-public class {{genRemoveNatureHandler.id}} extends RemoveNatureHandler {
-    public {{genRemoveNatureHandler.id}}() {
+public class {{baseRemoveNatureHandler.id}} extends RemoveNatureHandler {
+    public {{baseRemoveNatureHandler.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/ResourceContextMenu.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/ResourceContextMenu.java.mustache
@@ -1,9 +1,9 @@
-package {{genResourceContextMenu.packageId}};
+package {{baseResourceContextMenu.packageId}};
 
 import mb.spoofax.eclipse.menu.ResourceContextMenu;
 
-public class {{genResourceContextMenu.id}} extends ResourceContextMenu {
-    public {{genResourceContextMenu.id}}() {
+public class {{baseResourceContextMenu.id}} extends ResourceContextMenu {
+    public {{baseResourceContextMenu.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/RunCommandHandler.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/RunCommandHandler.java.mustache
@@ -1,9 +1,9 @@
-package {{genRunCommandHandler.packageId}};
+package {{baseRunCommandHandler.packageId}};
 
 import mb.spoofax.eclipse.command.RunCommandHandler;
 
-public class {{genRunCommandHandler.id}} extends RunCommandHandler {
-    public {{genRunCommandHandler.id}}() {
+public class {{baseRunCommandHandler.id}} extends RunCommandHandler {
+    public {{baseRunCommandHandler.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/UnobserveHandler.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/UnobserveHandler.java.mustache
@@ -1,9 +1,9 @@
-package {{genUnobserveHandler.packageId}};
+package {{baseUnobserveHandler.packageId}};
 
 import mb.spoofax.eclipse.menu.UnobserveHandler;
 
-public class {{genUnobserveHandler.id}} extends UnobserveHandler {
-    public {{genUnobserveHandler.id}}() {
+public class {{baseUnobserveHandler.id}} extends UnobserveHandler {
+    public {{baseUnobserveHandler.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/package-info.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/eclipse_project/package-info.java.mustache
@@ -1,5 +1,5 @@
 @DefaultQualifier(NonNull.class)
-package {{genPackageInfo.packageId}};
+package {{basePackageInfo.packageId}};
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Component.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Component.java.mustache
@@ -1,4 +1,4 @@
-package {{genComponent.packageId}};
+package {{baseComponent.packageId}};
 
 import dagger.Component;
 import mb.spoofax.intellij.IntellijLanguageComponent;
@@ -6,7 +6,7 @@ import mb.spoofax.intellij.SpoofaxIntellijComponent;
 
 @{{adapterProjectCompilerInput.scope.qualifiedId}}
 @Component(modules = { {{adapterProjectCompilerInput.module.qualifiedId}}.class, {{module.qualifiedId}}.class{{#adapterProjectCompilerInput.additionalModules}}{{#-first}}, {{/-first}}{{qualifiedId}}.class{{^-last}}, {{/-last}}{{/adapterProjectCompilerInput.additionalModules}} }, dependencies = SpoofaxIntellijComponent.class)
-public interface {{genComponent.id}} extends IntellijLanguageComponent, {{adapterProjectCompilerInput.component.qualifiedId}} {
+public interface {{baseComponent.id}} extends IntellijLanguageComponent, {{adapterProjectCompilerInput.component.qualifiedId}} {
     @Override {{language.qualifiedId}} getLanguage();
 
     @Override {{fileType.qualifiedId}} getFileType();

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/FileElementType.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/FileElementType.java.mustache
@@ -1,12 +1,12 @@
-package {{genFileElementType.packageId}};
+package {{baseFileElementType.packageId}};
 
 import mb.spoofax.intellij.IntellijFileElementType;
 
 import javax.inject.Inject;
 
 @{{adapterProjectCompilerInput.scope.qualifiedId}}
-public class {{genFileElementType.id}} extends IntellijFileElementType {
-    @Inject public {{genFileElementType.id}}() {
+public class {{baseFileElementType.id}} extends IntellijFileElementType {
+    @Inject public {{baseFileElementType.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/FileType.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/FileType.java.mustache
@@ -5,8 +5,8 @@ import mb.spoofax.intellij.IntellijLanguageFileType;
 import javax.inject.Inject;
 
 @{{adapterProjectCompilerInput.scope.qualifiedId}}
-public class {{genFileType.id}} extends IntellijLanguageFileType {
-    @Inject protected {{genFileType.id}}() {
+public class {{baseFileType.id}} extends IntellijLanguageFileType {
+    @Inject protected {{baseFileType.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/FileTypeFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/FileTypeFactory.java.mustache
@@ -1,10 +1,10 @@
-package {{genFileTypeFactory.packageId}};
+package {{baseFileTypeFactory.packageId}};
 
 import mb.spoofax.intellij.IntellijFileTypeFactory;
 
-public class {{genFileTypeFactory.id}} extends IntellijFileTypeFactory {
+public class {{baseFileTypeFactory.id}} extends IntellijFileTypeFactory {
     // Instantiated by IntelliJ.
-    private {{genFileTypeFactory.id}}() {
+    private {{baseFileTypeFactory.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Language.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Language.java.mustache
@@ -1,12 +1,12 @@
-package {{genLanguage.packageId}};
+package {{baseLanguage.packageId}};
 
 import mb.spoofax.intellij.IntellijLanguage;
 
 import javax.inject.Inject;
 
 @{{adapterProjectCompilerInput.scope.qualifiedId}}
-public class {{genLanguage.id}} extends IntellijLanguage {
-    @Inject public {{genLanguage.id}}() {
+public class {{baseLanguage.id}} extends IntellijLanguage {
+    @Inject public {{baseLanguage.id}}() {
         super({{plugin.id}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Loader.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Loader.java.mustache
@@ -1,11 +1,11 @@
-package {{genLoader.packageId}};
+package {{baseLoader.packageId}};
 
 import com.intellij.ide.ApplicationLoadListener;
 import com.intellij.openapi.application.Application;
 
-public class {{genLoader.id}} implements ApplicationLoadListener {
+public class {{baseLoader.id}} implements ApplicationLoadListener {
     // Instantiated by IntelliJ.
-    private {{genLoader.id}}() {}
+    private {{baseLoader.id}}() {}
 
     @Override public void beforeApplicationLoaded(Application application, String configPath) {
         try {

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Module.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Module.java.mustache
@@ -1,4 +1,4 @@
-package {{genModule.packageId}};
+package {{baseModule.packageId}};
 
 import com.intellij.openapi.util.IconLoader;
 import dagger.Module;
@@ -13,7 +13,7 @@ import {{adapterProjectCompilerInput.scope.qualifiedId}};
 import javax.swing.*;
 
 @Module
-public class {{genModule.id}} {
+public class {{baseModule.id}} {
     @Provides @{{adapterProjectCompilerInput.scope.id}}
     static IntellijLanguage provideSpoofaxLanguage({{language.qualifiedId}} language) {
         // Downcast because injections in spoofax.intellij require an IntellijLanguage, and dagger does not implicitly downcast.

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Plugin.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/Plugin.java.mustache
@@ -1,14 +1,14 @@
-package {{genPlugin.packageId}};
+package {{basePlugin.packageId}};
 
 import mb.spoofax.intellij.SpoofaxPlugin;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class {{genPlugin.id}} {
+public class {{basePlugin.id}} {
     private static {{component.nullableQualifiedId}} component;
 
     public static {{component.qualifiedId}} getComponent() {
         if(component == null) {
-            throw new RuntimeException("Cannot access {{component.id}}; {{genPlugin.id}} has not been started yet, or has been stopped");
+            throw new RuntimeException("Cannot access {{component.id}}; {{basePlugin.id}} has not been started yet, or has been stopped");
         }
         return component;
     }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/SyntaxHighlighterFactory.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/SyntaxHighlighterFactory.java.mustache
@@ -1,10 +1,10 @@
-package {{syntaxHighlighterFactory.packageId}};
+package {{baseSyntaxHighlighterFactory.packageId}};
 
 import mb.spoofax.intellij.editor.SpoofaxSyntaxHighlighterFactory;
 
-public class {{syntaxHighlighterFactory.id}} extends SpoofaxSyntaxHighlighterFactory {
+public class {{baseSyntaxHighlighterFactory.id}} extends SpoofaxSyntaxHighlighterFactory {
     // Instantiated by IntelliJ.
-    private {{syntaxHighlighterFactory.id}}() {
+    private {{baseSyntaxHighlighterFactory.id}}() {
         super({{plugin.qualifiedId}}.getComponent());
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/package-info.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/platform/intellij_project/package-info.java.mustache
@@ -1,5 +1,5 @@
 @DefaultQualifier(NonNull.class)
-package {{genPackageInfo.packageId}};
+package {{basePackageInfo.packageId}};
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/AdapterProjectCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/AdapterProjectCompilerTest.java
@@ -17,10 +17,10 @@ class AdapterProjectCompilerTest extends TestBase {
             final AdapterProjectCompiler.Input input = compileLanguageAndAdapterProject(session, inputs);
             fileAssertions.scopedExists(input.generatedJavaSourcesDirectory(), (s) -> {
                 s.asserts(input.packageInfo(), FileAssertion::assertNotExists);
-                s.assertPublicJavaInterface(input.genComponent(), "TigerComponent");
-                s.assertPublicJavaClass(input.genModule(), "TigerModule");
-                s.assertPublicJavaClass(input.genInstance(), "TigerInstance");
-                s.assertPublicJavaClass(input.genCheckTaskDef(), "TigerCheck");
+                s.assertPublicJavaInterface(input.baseComponent(), "TigerComponent");
+                s.assertPublicJavaClass(input.baseModule(), "TigerModule");
+                s.assertPublicJavaClass(input.baseInstance(), "TigerInstance");
+                s.assertPublicJavaClass(input.baseCheckTaskDef(), "TigerCheck");
             });
         }
     }
@@ -32,10 +32,10 @@ class AdapterProjectCompilerTest extends TestBase {
             final AdapterProjectCompiler.Input input = compileLanguageAndAdapterProject(session, inputs);
             fileAssertions.scopedExists(input.generatedJavaSourcesDirectory(), (s) -> {
                 s.asserts(input.packageInfo(), (a) -> a.assertAll("package-info.java", "@DefaultQualifier(NonNull.class)"));
-                s.assertPublicJavaInterface(input.genComponent(), "TigerComponent");
-                s.assertPublicJavaClass(input.genModule(), "TigerModule");
-                s.assertPublicJavaClass(input.genInstance(), "TigerInstance");
-                s.assertPublicJavaClass(input.genCheckTaskDef(), "TigerCheck");
+                s.assertPublicJavaInterface(input.baseComponent(), "TigerComponent");
+                s.assertPublicJavaClass(input.baseModule(), "TigerModule");
+                s.assertPublicJavaClass(input.baseInstance(), "TigerInstance");
+                s.assertPublicJavaClass(input.baseCheckTaskDef(), "TigerCheck");
             });
         }
     }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/CliProjectCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/CliProjectCompilerTest.java
@@ -15,7 +15,7 @@ class CliProjectCompilerTest extends TestBase {
             session.require(component.getCliProjectCompiler().createTask(input));
             fileAssertions.scopedExists(input.generatedJavaSourcesDirectory(), (s) -> {
                 s.asserts(input.packageInfo(), (a) -> a.assertAll("package-info.java", "@DefaultQualifier(NonNull.class)"));
-                s.assertPublicJavaClass(input.genMain(), "Main");
+                s.assertPublicJavaClass(input.baseMain(), "Main");
             });
         }
     }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/CompleterCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/CompleterCompilerTest.java
@@ -21,7 +21,7 @@ class CompleterCompilerTest extends TestBase {
             final CompleterAdapterCompiler.Input adapterProjectInput = inputs.completerAdapterCompilerInput();
             session.require(component.getCompleterAdapterCompiler().createTask(adapterProjectInput));
             fileAssertions.scopedExists(adapterProjectInput.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertPublicJavaClass(adapterProjectInput.genCompleteTaskDef(), "TigerCompleteTaskDef");
+                s.assertPublicJavaClass(adapterProjectInput.baseCompleteTaskDef(), "TigerCompleteTaskDef");
             });
         }
     }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ConstraintAnalyzerCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ConstraintAnalyzerCompilerTest.java
@@ -15,7 +15,7 @@ class ConstraintAnalyzerCompilerTest extends TestBase {
             session.require(component.getConstraintAnalyzerLanguageCompiler().createTask(languageProjectInput));
             fileAssertions.scopedExists(languageProjectInput.generatedJavaSourcesDirectory(), (s) -> {
                 s.assertPublicJavaClass(languageProjectInput.genConstraintAnalyzer(), "TigerConstraintAnalyzer");
-                s.assertPublicJavaClass(languageProjectInput.genFactory(), "TigerConstraintAnalyzerFactory");
+                s.assertPublicJavaClass(languageProjectInput.genConstraintAnalyzerFactory(), "TigerConstraintAnalyzerFactory");
             });
 
             final ConstraintAnalyzerAdapterCompiler.Input adapterProjectInput = inputs.constraintAnalyzerAdapterCompilerInput();

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ConstraintAnalyzerCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ConstraintAnalyzerCompilerTest.java
@@ -14,8 +14,8 @@ class ConstraintAnalyzerCompilerTest extends TestBase {
             final ConstraintAnalyzerLanguageCompiler.Input languageProjectInput = inputs.constraintAnalyzerLanguageCompilerInput();
             session.require(component.getConstraintAnalyzerLanguageCompiler().createTask(languageProjectInput));
             fileAssertions.scopedExists(languageProjectInput.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertPublicJavaClass(languageProjectInput.genConstraintAnalyzer(), "TigerConstraintAnalyzer");
-                s.assertPublicJavaClass(languageProjectInput.genConstraintAnalyzerFactory(), "TigerConstraintAnalyzerFactory");
+                s.assertPublicJavaClass(languageProjectInput.baseConstraintAnalyzer(), "TigerConstraintAnalyzer");
+                s.assertPublicJavaClass(languageProjectInput.baseConstraintAnalyzerFactory(), "TigerConstraintAnalyzerFactory");
             });
 
             final ConstraintAnalyzerAdapterCompiler.Input adapterProjectInput = inputs.constraintAnalyzerAdapterCompilerInput();

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/EclipseProjectCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/EclipseProjectCompilerTest.java
@@ -17,22 +17,22 @@ class EclipseProjectCompilerTest extends TestBase {
             fileAssertions.asserts(input.manifestMfFile(), (s) -> s.assertAll("MANIFEST.MF", "Bundle-ManifestVersion"));
             fileAssertions.scopedExists(input.generatedJavaSourcesDirectory(), (s) -> {
                 s.asserts(input.packageInfo(), (a) -> a.assertAll("package-info.java", "@DefaultQualifier(NonNull.class)"));
-                s.assertPublicJavaClass(input.genPlugin(), "TigerPlugin");
-                s.assertPublicJavaInterface(input.genEclipseComponent(), "TigerEclipseComponent");
-                s.assertPublicJavaClass(input.genEclipseModule(), "TigerEclipseModule");
-                s.assertPublicJavaClass(input.genEclipseIdentifiers(), "TigerEclipseIdentifiers");
-                s.assertPublicJavaClass(input.genEditor(), "TigerEditor");
-                s.assertPublicJavaClass(input.genEditorTracker(), "TigerEditorTracker");
-                s.assertPublicJavaClass(input.genNature(), "TigerNature");
-                s.assertPublicJavaClass(input.genAddNatureHandler(), "TigerAddNatureHandler");
-                s.assertPublicJavaClass(input.genRemoveNatureHandler(), "TigerRemoveNatureHandler");
-                s.assertPublicJavaClass(input.genProjectBuilder(), "TigerProjectBuilder");
-                s.assertPublicJavaClass(input.genMainMenu(), "TigerMainMenu");
-                s.assertPublicJavaClass(input.genEditorContextMenu(), "TigerEditorContextMenu");
-                s.assertPublicJavaClass(input.genResourceContextMenu(), "TigerResourceContextMenu");
-                s.assertPublicJavaClass(input.genRunCommandHandler(), "TigerRunCommandHandler");
-                s.assertPublicJavaClass(input.genObserveHandler(), "TigerObserveHandler");
-                s.assertPublicJavaClass(input.genUnobserveHandler(), "TigerUnobserveHandler");
+                s.assertPublicJavaClass(input.basePlugin(), "TigerPlugin");
+                s.assertPublicJavaInterface(input.baseEclipseComponent(), "TigerEclipseComponent");
+                s.assertPublicJavaClass(input.baseEclipseModule(), "TigerEclipseModule");
+                s.assertPublicJavaClass(input.baseEclipseIdentifiers(), "TigerEclipseIdentifiers");
+                s.assertPublicJavaClass(input.baseEditor(), "TigerEditor");
+                s.assertPublicJavaClass(input.baseEditorTracker(), "TigerEditorTracker");
+                s.assertPublicJavaClass(input.baseNature(), "TigerNature");
+                s.assertPublicJavaClass(input.baseAddNatureHandler(), "TigerAddNatureHandler");
+                s.assertPublicJavaClass(input.baseRemoveNatureHandler(), "TigerRemoveNatureHandler");
+                s.assertPublicJavaClass(input.baseProjectBuilder(), "TigerProjectBuilder");
+                s.assertPublicJavaClass(input.baseMainMenu(), "TigerMainMenu");
+                s.assertPublicJavaClass(input.baseEditorContextMenu(), "TigerEditorContextMenu");
+                s.assertPublicJavaClass(input.baseResourceContextMenu(), "TigerResourceContextMenu");
+                s.assertPublicJavaClass(input.baseRunCommandHandler(), "TigerRunCommandHandler");
+                s.assertPublicJavaClass(input.baseObserveHandler(), "TigerObserveHandler");
+                s.assertPublicJavaClass(input.baseUnobserveHandler(), "TigerUnobserveHandler");
             });
         }
     }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/IntellijProjectCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/IntellijProjectCompilerTest.java
@@ -17,17 +17,17 @@ class IntellijProjectCompilerTest extends TestBase {
             fileAssertions.asserts(input.pluginXmlFile(), (a) -> a.assertAll("plugin.xml", "<idea-plugin>"));
             fileAssertions.scopedExists(input.generatedJavaSourcesDirectory(), (s) -> {
                 s.asserts(input.packageInfo(), (a) -> a.assertAll("package-info.java", "@DefaultQualifier(NonNull.class)"));
-                s.assertPublicJavaClass(input.genPlugin(), "TigerPlugin");
-                s.assertPublicJavaInterface(input.genComponent(), "TigerIntellijComponent");
-                s.assertPublicJavaClass(input.genModule(), "TigerIntellijModule");
-                s.assertPublicJavaClass(input.genPlugin(), "TigerPlugin");
-                s.assertPublicJavaClass(input.genLoader(), "TigerLoader");
-                s.assertPublicJavaClass(input.genLanguage(), "TigerLanguage");
-                s.assertPublicJavaClass(input.genFileType(), "TigerFileType");
-                s.assertPublicJavaClass(input.genFileElementType(), "TigerFileElementType");
-                s.assertPublicJavaClass(input.genFileTypeFactory(), "TigerFileTypeFactory");
-                s.assertPublicJavaClass(input.genSyntaxHighlighterFactory(), "TigerSyntaxHighlighterFactory");
-                s.assertPublicJavaClass(input.genParserDefinition(), "TigerParserDefinition");
+                s.assertPublicJavaClass(input.basePlugin(), "TigerPlugin");
+                s.assertPublicJavaInterface(input.baseComponent(), "TigerIntellijComponent");
+                s.assertPublicJavaClass(input.baseModule(), "TigerIntellijModule");
+                s.assertPublicJavaClass(input.basePlugin(), "TigerPlugin");
+                s.assertPublicJavaClass(input.baseLoader(), "TigerLoader");
+                s.assertPublicJavaClass(input.baseLanguage(), "TigerLanguage");
+                s.assertPublicJavaClass(input.baseFileType(), "TigerFileType");
+                s.assertPublicJavaClass(input.baseFileElementType(), "TigerFileElementType");
+                s.assertPublicJavaClass(input.baseFileTypeFactory(), "TigerFileTypeFactory");
+                s.assertPublicJavaClass(input.baseSyntaxHighlighterFactory(), "TigerSyntaxHighlighterFactory");
+                s.assertPublicJavaClass(input.baseParserDefinition(), "TigerParserDefinition");
             });
         }
     }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ParserCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ParserCompilerTest.java
@@ -21,7 +21,7 @@ class ParserCompilerTest extends TestBase {
             fileAssertions.scopedExists(languageProjectInput.generatedJavaSourcesDirectory(), (s) -> {
                 s.assertPublicJavaClass(languageProjectInput.genTable(), "TigerParseTable");
                 s.assertPublicJavaClass(languageProjectInput.genParser(), "TigerParser");
-                s.assertPublicJavaClass(languageProjectInput.genFactory(), "TigerParserFactory");
+                s.assertPublicJavaClass(languageProjectInput.genParserFactory(), "TigerParserFactory");
             });
 
             final ParserAdapterCompiler.Input adapterProjectInput = inputs.parserAdapterCompilerInput();
@@ -39,20 +39,20 @@ class ParserCompilerTest extends TestBase {
         try(MixedSession session = pie.newSession()) {
             inputs.languageProjectCompilerInputBuilder.withParser()
                 .classKind(ClassKind.Manual)
-                .manualParser("my.lang", "MyParser")
-                .manualFactory("my.lang", "MyParserFactory");
+                .genParser("my.lang", "MyParser")
+                .genParserFactory("my.lang", "MyParserFactory");
             final ParserLanguageCompiler.Input languageProjectInput = inputs.parserLanguageCompilerInput();
             session.require(component.getParserLanguageCompiler().createTask(languageProjectInput));
             fileAssertions.scopedNotExists(languageProjectInput.generatedJavaSourcesDirectory(), (s) -> {
                 s.assertNotExists(languageProjectInput.genTable());
                 s.assertNotExists(languageProjectInput.genParser());
-                s.assertNotExists(languageProjectInput.genFactory());
+                s.assertNotExists(languageProjectInput.genParserFactory());
             });
 
             inputs.adapterProjectCompilerInputBuilder.withParser()
                 .classKind(ClassKind.Manual)
-                .manualParseTaskDef("my.adapter.taskdef", "MyParseTaskDef")
-                .manualTokenizeTaskDef("my.adapter.taskdef", "MyTokenizeTaskDef");
+                .genParseTaskDef("my.adapter.taskdef", "MyParseTaskDef")
+                .genTokenizeTaskDef("my.adapter.taskdef", "MyTokenizeTaskDef");
             final ParserAdapterCompiler.Input adapterProjectInput = inputs.parserAdapterCompilerInput();
             session.require(component.getParserAdapterCompiler().createTask(adapterProjectInput));
             fileAssertions.scopedNotExists(adapterProjectInput.generatedJavaSourcesDirectory(), (s) -> {
@@ -73,8 +73,8 @@ class ParserCompilerTest extends TestBase {
 
         inputs.languageProjectCompilerInputBuilder.withParser()
             .classKind(classKind)
-            .manualParser("my.lang", "MyParser")
-            .manualFactory("my.lang", "MyParserFactory");
+            .genParser("my.lang", "MyParser")
+            .genParserFactory("my.lang", "MyParserFactory");
         inputs.languageProjectCompilerInput(); // Manual classes are set: no exception.
 
         inputs.adapterProjectCompilerInputBuilder.withParser()
@@ -84,8 +84,8 @@ class ParserCompilerTest extends TestBase {
 
         inputs.adapterProjectCompilerInputBuilder.withParser()
             .classKind(classKind)
-            .manualParseTaskDef("my.adapter.taskdef", "MyParseTaskDef")
-            .manualTokenizeTaskDef("my.adapter.taskdef", "MyTokenizeTaskDef");
+            .genParseTaskDef("my.adapter.taskdef", "MyParseTaskDef")
+            .genTokenizeTaskDef("my.adapter.taskdef", "MyTokenizeTaskDef");
         inputs.adapterProjectCompilerInput(); // Manual classes are set: no exception.
     }
 }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ParserCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ParserCompilerTest.java
@@ -62,30 +62,4 @@ class ParserCompilerTest extends TestBase {
         }
     }
 
-    @ParameterizedTest @EnumSource(value = ClassKind.class, names = {"Manual"})
-    void testManualRequiresClasses(ClassKind classKind) {
-        final TigerInputs inputs = defaultInputs();
-
-        inputs.languageProjectCompilerInputBuilder.withParser()
-            .classKind(classKind);
-        assertThrows(IllegalArgumentException.class, inputs::languageProjectCompilerInput); // Class kind is Manual but manual class names were not set: check fails.
-        inputs.clearBuiltInputs();
-
-        inputs.languageProjectCompilerInputBuilder.withParser()
-            .classKind(classKind)
-            .genParser("my.lang", "MyParser")
-            .genParserFactory("my.lang", "MyParserFactory");
-        inputs.languageProjectCompilerInput(); // Manual classes are set: no exception.
-
-        inputs.adapterProjectCompilerInputBuilder.withParser()
-            .classKind(classKind);
-        assertThrows(IllegalArgumentException.class, inputs::adapterProjectCompilerInput); // Class kind is Manual but manual class names were not set: check fails.
-        inputs.clearBuiltInputs();
-
-        inputs.adapterProjectCompilerInputBuilder.withParser()
-            .classKind(classKind)
-            .genParseTaskDef("my.adapter.taskdef", "MyParseTaskDef")
-            .genTokenizeTaskDef("my.adapter.taskdef", "MyTokenizeTaskDef");
-        inputs.adapterProjectCompilerInput(); // Manual classes are set: no exception.
-    }
 }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ParserCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/ParserCompilerTest.java
@@ -19,15 +19,15 @@ class ParserCompilerTest extends TestBase {
             final ParserLanguageCompiler.Input languageProjectInput = inputs.parserLanguageCompilerInput();
             session.require(component.getParserLanguageCompiler().createTask(languageProjectInput));
             fileAssertions.scopedExists(languageProjectInput.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertPublicJavaClass(languageProjectInput.genTable(), "TigerParseTable");
-                s.assertPublicJavaClass(languageProjectInput.genParser(), "TigerParser");
-                s.assertPublicJavaClass(languageProjectInput.genParserFactory(), "TigerParserFactory");
+                s.assertPublicJavaClass(languageProjectInput.baseParseTable(), "TigerParseTable");
+                s.assertPublicJavaClass(languageProjectInput.baseParser(), "TigerParser");
+                s.assertPublicJavaClass(languageProjectInput.baseParserFactory(), "TigerParserFactory");
             });
 
             final ParserAdapterCompiler.Input adapterProjectInput = inputs.parserAdapterCompilerInput();
             session.require(component.getParserAdapterCompiler().createTask(adapterProjectInput));
             fileAssertions.scopedExists(adapterProjectInput.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertPublicJavaClass(adapterProjectInput.genParseTaskDef(), "TigerParse");
+                s.assertPublicJavaClass(adapterProjectInput.baseParseTaskDef(), "TigerParse");
                 s.assertPublicJavaClass(adapterProjectInput.tokenizeTaskDef(), "TigerTokenize");
             });
         }
@@ -39,24 +39,24 @@ class ParserCompilerTest extends TestBase {
         try(MixedSession session = pie.newSession()) {
             inputs.languageProjectCompilerInputBuilder.withParser()
                 .classKind(ClassKind.Manual)
-                .genParser("my.lang", "MyParser")
-                .genParserFactory("my.lang", "MyParserFactory");
+                .baseParser("my.lang", "MyParser")
+                .baseParserFactory("my.lang", "MyParserFactory");
             final ParserLanguageCompiler.Input languageProjectInput = inputs.parserLanguageCompilerInput();
             session.require(component.getParserLanguageCompiler().createTask(languageProjectInput));
             fileAssertions.scopedNotExists(languageProjectInput.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertNotExists(languageProjectInput.genTable());
-                s.assertNotExists(languageProjectInput.genParser());
-                s.assertNotExists(languageProjectInput.genParserFactory());
+                s.assertNotExists(languageProjectInput.baseParseTable());
+                s.assertNotExists(languageProjectInput.baseParser());
+                s.assertNotExists(languageProjectInput.baseParserFactory());
             });
 
             inputs.adapterProjectCompilerInputBuilder.withParser()
                 .classKind(ClassKind.Manual)
-                .genParseTaskDef("my.adapter.taskdef", "MyParseTaskDef")
-                .genTokenizeTaskDef("my.adapter.taskdef", "MyTokenizeTaskDef");
+                .baseParseTaskDef("my.adapter.taskdef", "MyParseTaskDef")
+                .baseTokenizeTaskDef("my.adapter.taskdef", "MyTokenizeTaskDef");
             final ParserAdapterCompiler.Input adapterProjectInput = inputs.parserAdapterCompilerInput();
             session.require(component.getParserAdapterCompiler().createTask(adapterProjectInput));
             fileAssertions.scopedNotExists(adapterProjectInput.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertNotExists(adapterProjectInput.genParseTaskDef());
+                s.assertNotExists(adapterProjectInput.baseParseTaskDef());
                 s.assertNotExists(adapterProjectInput.tokenizeTaskDef());
             });
         }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/StrategoRuntimeCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/StrategoRuntimeCompilerTest.java
@@ -13,7 +13,7 @@ class StrategoRuntimeCompilerTest extends TestBase {
         try(MixedSession session = pie.newSession()) {
             session.require(component.getStrategoRuntimeLanguageCompiler().createTask(input));
             fileAssertions.scopedExists(input.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertPublicJavaClass(input.genFactory(), "TigerStrategoRuntimeBuilderFactory");
+                s.assertPublicJavaClass(input.genStrategoRuntimeBuilderFactory(), "TigerStrategoRuntimeBuilderFactory");
             });
         }
     }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/StrategoRuntimeCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/StrategoRuntimeCompilerTest.java
@@ -13,7 +13,7 @@ class StrategoRuntimeCompilerTest extends TestBase {
         try(MixedSession session = pie.newSession()) {
             session.require(component.getStrategoRuntimeLanguageCompiler().createTask(input));
             fileAssertions.scopedExists(input.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertPublicJavaClass(input.genStrategoRuntimeBuilderFactory(), "TigerStrategoRuntimeBuilderFactory");
+                s.assertPublicJavaClass(input.baseStrategoRuntimeBuilderFactory(), "TigerStrategoRuntimeBuilderFactory");
             });
         }
     }

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/StylerCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/StylerCompilerTest.java
@@ -16,7 +16,7 @@ class StylerCompilerTest extends TestBase {
             fileAssertions.scopedExists(languageProjectInput.generatedJavaSourcesDirectory(), (s) -> {
                 s.assertPublicJavaClass(languageProjectInput.genRules(), "TigerStylingRules");
                 s.assertPublicJavaClass(languageProjectInput.genStyler(), "TigerStyler");
-                s.assertPublicJavaClass(languageProjectInput.genFactory(), "TigerStylerFactory");
+                s.assertPublicJavaClass(languageProjectInput.genStylerFactory(), "TigerStylerFactory");
             });
 
             final StylerAdapterCompiler.Input adapterProjectInput = inputs.stylerAdapterCompilerInput();

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/StylerCompilerTest.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/StylerCompilerTest.java
@@ -14,15 +14,15 @@ class StylerCompilerTest extends TestBase {
             final StylerLanguageCompiler.Input languageProjectInput = inputs.stylerLanguageCompilerInput();
             session.require(component.getStylerLanguageCompiler().createTask(languageProjectInput));
             fileAssertions.scopedExists(languageProjectInput.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertPublicJavaClass(languageProjectInput.genRules(), "TigerStylingRules");
-                s.assertPublicJavaClass(languageProjectInput.genStyler(), "TigerStyler");
-                s.assertPublicJavaClass(languageProjectInput.genStylerFactory(), "TigerStylerFactory");
+                s.assertPublicJavaClass(languageProjectInput.baseStylingRules(), "TigerStylingRules");
+                s.assertPublicJavaClass(languageProjectInput.baseStyler(), "TigerStyler");
+                s.assertPublicJavaClass(languageProjectInput.baseStylerFactory(), "TigerStylerFactory");
             });
 
             final StylerAdapterCompiler.Input adapterProjectInput = inputs.stylerAdapterCompilerInput();
             session.require(component.getStylerAdapterCompiler().createTask(adapterProjectInput));
             fileAssertions.scopedExists(adapterProjectInput.generatedJavaSourcesDirectory(), (s) -> {
-                s.assertPublicJavaClass(adapterProjectInput.genStyleTaskDef(), "TigerStyle");
+                s.assertPublicJavaClass(adapterProjectInput.baseStyleTaskDef(), "TigerStyle");
             });
         }
     }

--- a/lwb/sdf3/sdf3/build.gradle.kts
+++ b/lwb/sdf3/sdf3/build.gradle.kts
@@ -46,7 +46,7 @@ languageProject {
     }
     withStrategoRuntime().run {
       addInteropRegisterersByReflection("org.metaborg.meta.lang.template.strategies.InteropRegisterer")
-      extendedStrategoRuntimeBuilderFactory("mb.sdf3", "Sdf3ManualStrategoRuntimeBuilderFactory")
+      extendStrategoRuntimeBuilderFactory("mb.sdf3", "Sdf3ManualStrategoRuntimeBuilderFactory")
     }
   }
 }

--- a/lwb/sdf3/sdf3/build.gradle.kts
+++ b/lwb/sdf3/sdf3/build.gradle.kts
@@ -46,8 +46,7 @@ languageProject {
     }
     withStrategoRuntime().run {
       addInteropRegisterersByReflection("org.metaborg.meta.lang.template.strategies.InteropRegisterer")
-      classKind(mb.spoofax.compiler.util.ClassKind.Extended)
-      manualFactory("mb.sdf3", "Sdf3ManualStrategoRuntimeBuilderFactory")
+      extendedStrategoRuntimeBuilderFactory("mb.sdf3", "Sdf3ManualStrategoRuntimeBuilderFactory")
     }
   }
 }

--- a/lwb/statix/statix/build.gradle.kts
+++ b/lwb/statix/statix/build.gradle.kts
@@ -77,7 +77,7 @@ languageAdapterProject {
       classKind(ClassKind.Extended)
       // Manual analyze multi implementation to add Spoofax2ProjectContext
       genAnalyzeMultiTaskDef(taskPackageId, "GeneratedStatixAnalyzeMulti")
-      manualAnalyzeMultiTaskDef(taskPackageId, "StatixAnalyzeMulti")
+      extendedAnalyzeMultiTaskDef(taskPackageId, "StatixAnalyzeMulti")
     }
     withStrategoRuntime()
     project.configureCompilerInput()

--- a/lwb/statix/statix/build.gradle.kts
+++ b/lwb/statix/statix/build.gradle.kts
@@ -74,8 +74,8 @@ languageAdapterProject {
     withStyler()
     withConstraintAnalyzer().run {
       // Manual analyze multi implementation to add Spoofax2ProjectContext
-      genAnalyzeMultiTaskDef(taskPackageId, "GeneratedStatixAnalyzeMulti")
-      extendedAnalyzeMultiTaskDef(taskPackageId, "StatixAnalyzeMulti")
+      baseAnalyzeMultiTaskDef(taskPackageId, "GeneratedStatixAnalyzeMulti")
+      extendAnalyzeMultiTaskDef(taskPackageId, "StatixAnalyzeMulti")
     }
     withStrategoRuntime()
     project.configureCompilerInput()

--- a/lwb/statix/statix/build.gradle.kts
+++ b/lwb/statix/statix/build.gradle.kts
@@ -73,8 +73,6 @@ languageAdapterProject {
     withParser()
     withStyler()
     withConstraintAnalyzer().run {
-      // Enable manual class implementation
-      classKind(ClassKind.Extended)
       // Manual analyze multi implementation to add Spoofax2ProjectContext
       genAnalyzeMultiTaskDef(taskPackageId, "GeneratedStatixAnalyzeMulti")
       extendedAnalyzeMultiTaskDef(taskPackageId, "StatixAnalyzeMulti")

--- a/lwb/stratego/stratego/build.gradle.kts
+++ b/lwb/stratego/stratego/build.gradle.kts
@@ -78,7 +78,7 @@ fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {
 
   // Custom component and additional modules
   genComponent(packageId, "GeneratedStrategoComponent")
-  manualComponent(packageId, "StrategoComponent")
+  extendedComponent(packageId, "StrategoComponent")
   addAdditionalModules(packageId, "JavaTasksModule")
   addAdditionalModules(incrPackageId, "StrategoIncrModule")
   addAdditionalModules(configPackageId, "StrategoConfigModule")
@@ -89,7 +89,7 @@ fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {
   // Manual multifile check implementation
   isMultiFile(true)
   genCheckMultiTaskDef(taskPackageId, "GeneratedStrategoCheckMulti")
-  manualCheckMultiTaskDef(taskPackageId, "StrategoCheckMulti")
+  extendedCheckMultiTaskDef(taskPackageId, "StrategoCheckMulti")
   addTaskDefs(taskPackageId, "StrategoAnalyze")
 
   // Utility task definitions

--- a/lwb/stratego/stratego/build.gradle.kts
+++ b/lwb/stratego/stratego/build.gradle.kts
@@ -77,16 +77,16 @@ fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {
   val commandPackageId = "$packageId.command"
 
   // Custom component and additional modules
-  genComponent(packageId, "GeneratedStrategoComponent")
-  extendedComponent(packageId, "StrategoComponent")
+  baseComponent(packageId, "GeneratedStrategoComponent")
+  extendComponent(packageId, "StrategoComponent")
   addAdditionalModules(packageId, "JavaTasksModule")
   addAdditionalModules(incrPackageId, "StrategoIncrModule")
   addAdditionalModules(configPackageId, "StrategoConfigModule")
 
   // Manual multifile check implementation
   isMultiFile(true)
-  genCheckMultiTaskDef(taskPackageId, "GeneratedStrategoCheckMulti")
-  extendedCheckMultiTaskDef(taskPackageId, "StrategoCheckMulti")
+  baseCheckMultiTaskDef(taskPackageId, "GeneratedStrategoCheckMulti")
+  extendCheckMultiTaskDef(taskPackageId, "StrategoCheckMulti")
   addTaskDefs(taskPackageId, "StrategoAnalyze")
 
   // Utility task definitions

--- a/lwb/stratego/stratego/build.gradle.kts
+++ b/lwb/stratego/stratego/build.gradle.kts
@@ -83,9 +83,6 @@ fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {
   addAdditionalModules(incrPackageId, "StrategoIncrModule")
   addAdditionalModules(configPackageId, "StrategoConfigModule")
 
-  // Enable manual class implementation
-  classKind(ClassKind.Extended)
-
   // Manual multifile check implementation
   isMultiFile(true)
   genCheckMultiTaskDef(taskPackageId, "GeneratedStrategoCheckMulti")


### PR DESCRIPTION
This PR attempts to make it a lot easier to make a manual Spoofax 3 implementation of a language. The idea is that the compiler either generates all files (`ClassKind == Generated`) or the files are manually provided (`ClassKind == Manual`). In both cases, the name is determined by the `gen*()` methods of the builder, such as `genParser()` and `genModule()` (perhaps they should get a different name?). This way you don't have to specify all the class names again when copying the generated files into the project to make them manual, but you can still override them.

The only remaining option is `ClassKind == Extended`, and this PR removes that option. Simply specifying an `extended*()` method on the builder (such as `extendedParser()`) will make the compiled code reference the extended class. This way you don't have to extend _all_ classes, you can selectively extend only some of them.

The builder `check()` methods are now empty, since it is not a requirement any more for all manual/extended classes to be specified. Manual classes take their generated class names as default, and extended classes need only to be specified when you actually want to extend the class. The corresponding test is also removed.

