### PR TITLE
Make AdapterProjectCompilerInputBuilder extend AdapterProjectCompiler.Input.Builder

### DIFF
--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
@@ -273,7 +273,7 @@ public class AdapterProjectCompiler implements TaskDef<AdapterProjectCompiler.In
     @Value.Immutable public interface Input extends Serializable {
         class Builder extends AdapterProjectCompilerData.Input.Builder {}
 
-        static Builder builder() { return new Builder(); }
+        static AdapterProjectCompilerInputBuilder builder() { return new AdapterProjectCompilerInputBuilder(); }
 
 
         /// Project

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
@@ -11,7 +11,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * Facade for consistently and easily building a {@link AdapterProjectCompiler.Input} instance.
  */
-public class AdapterProjectCompilerInputBuilder {
+public class AdapterProjectCompilerInputBuilder extends AdapterProjectCompiler.Input.Builder {
     public final ClassloaderResourcesCompiler.Input.Builder classloaderResources = ClassloaderResourcesCompiler.Input.builder();
 
     private boolean parserEnabled = false;
@@ -31,8 +31,6 @@ public class AdapterProjectCompilerInputBuilder {
 
     private boolean completerEnabled = false;
     public final CompleterAdapterCompiler.Input.Builder completer = CompleterAdapterCompiler.Input.builder();
-
-    public AdapterProjectCompiler.Input.Builder project = AdapterProjectCompiler.Input.builder();
 
 
     public ClassloaderResourcesCompiler.Input.Builder withClassloaderResources() {
@@ -74,29 +72,29 @@ public class AdapterProjectCompilerInputBuilder {
         final Shared shared = languageProjectInput.shared();
 
         final ClassloaderResourcesCompiler.Input classloaderResources = buildClassLoaderResources(shared, languageProjectInput.languageProject());
-        project.classloaderResources(classloaderResources);
+        this.classloaderResources(classloaderResources);
 
         final ParserAdapterCompiler.@Nullable Input parser = buildParser(shared, adapterProject, languageProjectInput);
-        if(parser != null) project.parser(parser);
+        if(parser != null) this.parser(parser);
 
         final StylerAdapterCompiler.@Nullable Input styler = buildStyler(shared, adapterProject, languageProjectInput);
-        if(styler != null) project.styler(styler);
+        if(styler != null) this.styler(styler);
 
         final ConstraintAnalyzerAdapterCompiler.@Nullable Input constraintAnalyzer = buildConstraintAnalyzer(shared, adapterProject, languageProjectInput);
-        if(constraintAnalyzer != null) project.constraintAnalyzer(constraintAnalyzer);
+        if(constraintAnalyzer != null) this.constraintAnalyzer(constraintAnalyzer);
 
         final MultilangAnalyzerAdapterCompiler.@Nullable Input multilangAnalyzer = buildMultilangAnalyzer(shared, adapterProject, languageProjectInput);
-        if(multilangAnalyzer != null) project.multilangAnalyzer(multilangAnalyzer);
+        if(multilangAnalyzer != null) this.multilangAnalyzer(multilangAnalyzer);
 
         final StrategoRuntimeAdapterCompiler.@Nullable Input strategoRuntime = buildStrategoRuntime(shared, adapterProject, languageProjectInput);
-        if(strategoRuntime != null) project.strategoRuntime(strategoRuntime);
+        if(strategoRuntime != null) this.strategoRuntime(strategoRuntime);
 
         final CompleterAdapterCompiler.@Nullable Input completer = buildCompleter(shared, adapterProject, languageProjectInput);
 
-        if(completer != null) project.completer(completer);
-        project.languageProjectDependency(languageProjectDependency);
+        if(completer != null) this.completer(completer);
+        this.languageProjectDependency(languageProjectDependency);
 
-        return project
+        return this
             .adapterProject(adapterProject)
             .shared(shared)
             .build();

--- a/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/tiger/TigerInputs.java
+++ b/core/spoofax.compiler/src/test/java/mb/spoofax/compiler/spoofaxcore/tiger/TigerInputs.java
@@ -250,7 +250,7 @@ public class TigerInputs {
             .addParams("compiledFileNameSuffix", TypeInfo.ofString(), true, Optional.empty(), Collections.singletonList(ArgProviderRepr.value(StringUtil.doubleQuote("defnames.aterm"))))
             .build();
 
-        adapterProjectCompilerInputBuilder.project
+        adapterProjectCompilerInputBuilder
             .addTaskDefs(
                 showParsedAstTaskDef,
                 listDefNamesTaskDef,

--- a/example/calc/calc/build.gradle.kts
+++ b/example/calc/calc/build.gradle.kts
@@ -54,7 +54,7 @@ languageAdapterProject {
     withStyler()
     withConstraintAnalyzer()
     withStrategoRuntime()
-    project.configureCompilerInput()
+    configureCompilerInput()
   }
 }
 fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {

--- a/example/mod/mod.spoofax/build.gradle.kts
+++ b/example/mod/mod.spoofax/build.gradle.kts
@@ -16,7 +16,7 @@ languageAdapterProject {
     withStyler()
     withStrategoRuntime()
     withConstraintAnalyzer()
-    project.configureCompilerInput()
+    configureCompilerInput()
   }
 }
 

--- a/lwb/esv/esv/build.gradle.kts
+++ b/lwb/esv/esv/build.gradle.kts
@@ -62,7 +62,7 @@ languageAdapterProject {
     withParser()
     withStyler()
     withStrategoRuntime()
-    project.configureCompilerInput()
+    configureCompilerInput()
   }
 }
 fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {

--- a/lwb/libspoofax2/build.gradle.kts
+++ b/lwb/libspoofax2/build.gradle.kts
@@ -41,7 +41,7 @@ spoofax2BasedLanguageProject {
 
 languageAdapterProject {
   compilerInput {
-    project.configureCompilerInput()
+    configureCompilerInput()
   }
 }
 fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {

--- a/lwb/libstatix/build.gradle.kts
+++ b/lwb/libstatix/build.gradle.kts
@@ -41,7 +41,7 @@ spoofax2BasedLanguageProject {
 
 languageAdapterProject {
   compilerInput {
-    project.configureCompilerInput()
+    configureCompilerInput()
   }
 }
 fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {

--- a/lwb/sdf3/sdf3/build.gradle.kts
+++ b/lwb/sdf3/sdf3/build.gradle.kts
@@ -79,7 +79,7 @@ languageAdapterProject {
     withStyler()
     withStrategoRuntime()
     withConstraintAnalyzer()
-    project.configureCompilerInput()
+    configureCompilerInput()
   }
 }
 fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {

--- a/lwb/statix/statix/build.gradle.kts
+++ b/lwb/statix/statix/build.gradle.kts
@@ -80,7 +80,7 @@ languageAdapterProject {
       manualAnalyzeMultiTaskDef(taskPackageId, "StatixAnalyzeMulti")
     }
     withStrategoRuntime()
-    project.configureCompilerInput()
+    configureCompilerInput()
   }
 }
 fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {

--- a/lwb/stratego/stratego/build.gradle.kts
+++ b/lwb/stratego/stratego/build.gradle.kts
@@ -66,7 +66,7 @@ languageAdapterProject {
     withParser()
     withStyler()
     withStrategoRuntime()
-    project.configureCompilerInput()
+    configureCompilerInput()
   }
 }
 fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {


### PR DESCRIPTION
This PR makes `AdapterProjectCompilerInputBuilder` extend `AdapterProjectCompiler.Input.Builder`.

This removes the need to write something like `project.configureCompilerInput()` in the Gradle file. You can still call extension methods such as `configureCompilerInput()` (but without the `project.` prefix), but this PR allows you to also use the builder directly, removing the need for `configureCompilerInput()` in many cases. For example, setting `classKind`:

```
languageAdapterProject {
  languageProject.set(project(":tiger.statix"))
  compilerInput {
    withParser()
    classKind(ClassKind.Manual)
  }
}
```