### PR TITLE
Support custom arguments for tasks

### DIFF
--- a/core/spoofax.compiler/build.gradle.kts
+++ b/core/spoofax.compiler/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
   compileOnly("org.checkerframework:checker-qual-android")
   compileOnly("org.immutables:value-annotations")
+  compileOnly("org.immutables:builder")
   compileOnly("org.derive4j:derive4j-annotation")
 
   annotationProcessor("org.immutables:value")

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/data/ArgRepr.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/data/ArgRepr.java
@@ -1,0 +1,7 @@
+package mb.spoofax.compiler.adapter.data;
+
+import java.io.Serializable;
+
+public interface ArgRepr extends Serializable {
+    String toJava();
+}

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/data/CommandDefRepr.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/data/CommandDefRepr.java
@@ -8,10 +8,23 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.io.Serializable;
+import java.util.stream.Collectors;
 
 @Value.Immutable
 public interface CommandDefRepr extends Serializable {
-    class Builder extends ImmutableCommandDefRepr.Builder {}
+    @org.immutables.builder.Builder.AccessibleFields
+    class Builder extends ImmutableCommandDefRepr.Builder {
+
+        @Override
+        public ImmutableCommandDefRepr build() {
+            if (args.isEmpty()) {
+                // Copy the parameters as arguments by default
+                addAllArgs(params.stream().map(p -> VarRepr.of(p.id())).collect(Collectors.toList()));
+            }
+            return super.build();
+        }
+    }
 
     static Builder builder() {
         return new Builder();
@@ -32,6 +45,7 @@ public interface CommandDefRepr extends Serializable {
 
     List<ParamRepr> params();
 
+    List<ArgRepr> args();
 
     default CommandRequestRepr request(CommandExecutionType executionType, Map<String, String> initialArgs) {
         return CommandRequestRepr.of(type(), executionType, initialArgs);

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/data/ConstRepr.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/data/ConstRepr.java
@@ -1,0 +1,32 @@
+package mb.spoofax.compiler.adapter.data;
+
+import org.immutables.value.Value;
+
+import java.io.Serializable;
+
+@Value.Immutable
+public interface ConstRepr extends ArgRepr {
+    class Builder extends ImmutableConstRepr.Builder {}
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static ImmutableConstRepr ofNull() {
+        return ImmutableConstRepr.of("null");
+    }
+
+    static ImmutableConstRepr of(String value) {
+        return ImmutableConstRepr.of(value);
+    }
+
+    static ImmutableConstRepr of(boolean value) {
+        return ImmutableConstRepr.of(value ? "true" : "false");
+    }
+
+    @Value.Parameter String value();
+
+    @Override
+    default String toJava() { return value(); }
+
+}

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/data/VarRepr.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/data/VarRepr.java
@@ -1,0 +1,23 @@
+package mb.spoofax.compiler.adapter.data;
+
+import org.immutables.value.Value;
+
+import java.io.Serializable;
+
+@Value.Immutable
+public interface VarRepr extends ArgRepr {
+    class Builder extends ImmutableVarRepr.Builder {}
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static ImmutableVarRepr of(String id) {
+        return ImmutableVarRepr.of(id);
+    }
+
+    @Value.Parameter String id();
+
+    @Override
+    default String toJava() { return id(); }
+}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CommandDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CommandDef.java.mustache
@@ -63,7 +63,7 @@ public class {{type.id}} implements CommandDef<{{argType.qualifiedId}}> {
         final {{type.nullableQualifiedId}} {{id}} = rawArgs.getOrNull("{{id}}");
  {{/required}}
 {{/params}}
-        return new {{argType.qualifiedId}}({{#params}}{{id}}{{^-last}}, {{/-last}}{{/params}});
+        return new {{argType.qualifiedId}}({{#args}}{{toJava}}{{^-last}}, {{/-last}}{{/args}});
     }
 
     @Override public Task<CommandFeedback> createTask({{argType.qualifiedId}} args) {

--- a/core/spoofax.depconstraints/build.gradle.kts
+++ b/core/spoofax.depconstraints/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
     api("org.derive4j:derive4j-annotation:$derive4jVersion")
     /// org.immutables
     api("org.immutables:value:$immutablesVersion")
+    api("org.immutables:builder:$immutablesVersion")
     api("org.immutables:value-annotations:$immutablesVersion")
     // Yaml
     api("org.yaml:snakeyaml:$yamlVersion")


### PR DESCRIPTION
Not all tasks invocation arguments correspond one-to-one to the command definition's parameters. This PR makes the task arguments match the command parameters by default, but allows this behavior to be overridden. In the following example, `addAllArgs` is used to create the tasks's arguments (`ShowArgs(ResourceKey, @Nullable Region)` constructor) as `new ShowArgs(resource, null)`.

```kotlin
  // Show scope graph
  val showScopeGraph = TypeInfo.of(taskPackageId, "ShowScopeGraph")
  addTaskDefs(showScopeGraph)
  val showScopeGraphCommand = CommandDefRepr.builder()
    .type(commandPackageId, "ShowScopeGraphCommand")
    .taskDefType(showScopeGraph)
    .argType(showArgsType)
    .addSupportedExecutionTypes(CommandExecutionType.ManualOnce, CommandExecutionType.ManualContinuous)
    .addAllParams(listOf(
      ParamRepr.of("resource", TypeInfo.of("mb.resource", "ResourceKey"), true,
        ArgProviderRepr.context(CommandContextType.ResourceKey))
    ))
    .addAllArgs(listOf(
      VarRepr.of("resource"),
      ConstRepr.ofNull()
    ))
    .build()
  addCommandDefs(showScopeGraphCommand)
```