### PR TITLE
Add Makefile (using Docker) for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Jenkins](https://img.shields.io/jenkins/build/https/buildfarm.metaborg.org/job/metaborg/job/spoofax-pie/job/master)](https://buildfarm.metaborg.org/job/metaborg/job/spoofax-pie/job/master/lastBuild)
 [![Jenkins Tests](https://img.shields.io/jenkins/tests/https/buildfarm.metaborg.org/job/metaborg/job/spoofax-pie/job/master)](https://buildfarm.metaborg.org/job/metaborg/job/spoofax-pie/job/master/lastBuild/testReport/)
 [![Spoofax 3 core](https://img.shields.io/maven-metadata/v?label=spoofax.core&metadataUrl=https%3A%2F%2Fartifacts.metaborg.org%2Fcontent%2Frepositories%2Freleases%2Forg%2Fmetaborg%2Fspoofax.core%2Fmaven-metadata.xml)](https://mvnrepository.com/artifact/org.metaborg/spoofax.core?repo=metaborg-releases)
+[![Documentation](https://img.shields.io/badge/docs-latest-brightgreen)](https://metaborg.github.io/spoofax-pie/)
 
 # Spoofax 3
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+SELF_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+DOCKER_IMAGE := squidfunk/mkdocs-material:7.0.6
+ROOT_DIR := $(SELF_DIR)..
+BASE_COMMAND := docker run --rm -it -p 8000:8000 -v ${ROOT_DIR}:/docs ${DOCKER_IMAGE}
+
+serve:
+	$(BASE_COMMAND) serve --dev-addr=0.0.0.0:8000
+
+new:
+	$(BASE_COMMAND) new $(ROOT_DIR)
+
+build:
+	$(BASE_COMMAND) build
+
+help:
+	$(BASE_COMMAND) -h
+
+.PHONY: serve new build help
+SILENT:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Spoofax 3
+site_description: Spoofax 3 user guide and reference.
 
 nav:
   - Introduction: index.md
@@ -9,11 +10,14 @@ theme:
   palette:
     primary: indigo
     accent: indigo
+  font:
+    code: JetBrains Mono
 
 repo_name: metaborg/spoofax-pie
 repo_url: https://github.com/metaborg/spoofax-pie
 
 markdown_extensions:
+  - abbr
   - admonition
   - codehilite:
       guess_lang: false
@@ -23,14 +27,19 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.caret
   - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.inlinehilite
+  - pymdownx.keys
   - pymdownx.magiclink
   - pymdownx.mark
+  - pymdownx.saneheaders
   - pymdownx.smartsymbols
   - pymdownx.superfences
+  - pymdownx.tabbed
   - pymdownx.tasklist:
       custom_checkbox: true
-  - pymdownx.tabbed
   - pymdownx.tilde
 
 plugins:

--- a/mkdocs_requirements.txt
+++ b/mkdocs_requirements.txt
@@ -1,1 +1,1 @@
-mkdocs-material==5.1.6
+mkdocs-material==7.0.6


### PR DESCRIPTION
Run `make` in the `docs/` directory to start a Docker container that publishes the built documentation to <http://localhost:8000> and automatically rebuilds the documentation on changes. No other dependencies or (Python) installation instructions are needed.