### PR TITLE
Reduce logging of ConstraintAnalyzeMultiTaskDef.Output

### DIFF
--- a/core/constraint.pie/src/main/java/mb/constraint/pie/ConstraintAnalyzeMultiTaskDef.java
+++ b/core/constraint.pie/src/main/java/mb/constraint/pie/ConstraintAnalyzeMultiTaskDef.java
@@ -86,8 +86,6 @@ public abstract class ConstraintAnalyzeMultiTaskDef implements TaskDef<Constrain
         @Override public String toString() {
             return "Output{" +
                 "messagesFromAstProviders=" + messagesFromAstProviders +
-                ", context=" + context +
-                ", result=" + result +
                 '}';
         }
     }


### PR DESCRIPTION
Removing the context and result from the string representation
significantly decreases build times