### PR TITLE
Implement a way to get access to term location data relative to the start of a test fragment

### DIFF
--- a/core/jsglr.common/src/main/java/mb/jsglr/common/FragmentedOriginLocationFixer.java
+++ b/core/jsglr.common/src/main/java/mb/jsglr/common/FragmentedOriginLocationFixer.java
@@ -115,6 +115,13 @@ public class FragmentedOriginLocationFixer {
         });
     }
 
+    public static IToken getOriginalToken(IToken token) {
+        if (token instanceof MappedToken) {
+            return ((MappedToken)token).originalToken;
+        }
+        return token;
+    }
+
     private static class MappingTokens implements ITokens {
         private final ArrayList<IToken> tokens = new ArrayList<>();
         private final LinkedHashMap<IToken, IToken> oldToNewTokens = new LinkedHashMap<>();

--- a/lwb/metalang/spt/spt/src/main/java/mb/spt/expectation/RunStrategoExpectation.java
+++ b/lwb/metalang/spt/spt/src/main/java/mb/spt/expectation/RunStrategoExpectation.java
@@ -74,7 +74,7 @@ public class RunStrategoExpectation implements TestExpectation {
         }
         final TestableStratego testableStratego = (TestableStratego)languageInstance;
         Option<Region> region = selectionReference.map(
-            (sel) -> testCase.testFragment.getSelections().get(sel.selection - 1)
+            (sel) -> testCase.testFragment.getInFragmentSelections().get(sel.selection - 1)
         );
         final Result<IStrategoTerm, ?> result = testableStratego.testRunStrategy(languageUnderTestSession, testCase.resource, strategy, processArguments(arguments, testCase), region, testCase.rootDirectoryHint);
 
@@ -124,7 +124,7 @@ public class RunStrategoExpectation implements TestExpectation {
                 }
                 case "SelectionRef": {
                     int index = Integer.parseInt(TermUtils.toJavaStringAt(term, 0));
-                    Region region = testCase.testFragment.getSelections().get(index - 1);
+                    Region region = testCase.testFragment.getInFragmentSelections().get(index - 1);
                     args.add(StrategoRunArgument.selectionArg(region));
                     break;
                 }

--- a/lwb/metalang/spt/spt/src/main/java/mb/spt/model/TestFragment.java
+++ b/lwb/metalang/spt/spt/src/main/java/mb/spt/model/TestFragment.java
@@ -9,7 +9,15 @@ import mb.common.util.ListView;
 public interface TestFragment {
     Region getRegion();
 
+    /**
+     * @return regions of the selections relative to the start of the SPT file
+     */
     ListView<Region> getSelections();
+
+    /**
+     * @return regions of the selections relative to the start of the fragment
+     */
+    ListView<Region> getInFragmentSelections();
 
     FragmentedString getFragmentedString();
 

--- a/lwb/metalang/spt/spt/src/main/java/mb/spt/model/TestFragmentImpl.java
+++ b/lwb/metalang/spt/spt/src/main/java/mb/spt/model/TestFragmentImpl.java
@@ -9,11 +9,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class TestFragmentImpl implements TestFragment {
     private final Region region;
     private final ListView<Region> selections;
+    private final ListView<Region> inFragmentSelections;
     private final FragmentedString fragmentedString;
 
-    public TestFragmentImpl(Region region, ListView<Region> selections, FragmentedString fragmentedString) {
+    public TestFragmentImpl(Region region, ListView<Region> selections, ListView<Region> inFragmentSelections, FragmentedString fragmentedString) {
         this.region = region;
         this.selections = selections;
+        this.inFragmentSelections = inFragmentSelections;
         this.fragmentedString = fragmentedString;
     }
 
@@ -23,6 +25,11 @@ public class TestFragmentImpl implements TestFragment {
 
     @Override public ListView<Region> getSelections() {
         return selections;
+    }
+
+    @Override
+    public ListView<Region> getInFragmentSelections() {
+        return inFragmentSelections;
     }
 
     @Override public FragmentedString getFragmentedString() {


### PR DESCRIPTION
Partial fix for #25 , a complete fix would require implementing a way to represent a `Region` spanning several `fragments` of a `FragmentedString`.

I added a function `getInFragmentRegion` to `TermTracer`, which returns the region of a term with offsets from the start of the fragment, instead of the offset from the start of the SPT file. `TestFragment` now also has `getInFragmentSelections` in the same manner.

For displaying messages at the right locations in an SPT file, `getRegion` and `getSelections` should still be used.

If `getInFragmentRegion` is used on a term outside of a fragment, it will behave identical to `getRegion`.