### PR TITLE
Add task definition for getting all source files of a language.

### DIFF
--- a/core/jsglr.pie/src/main/java/mb/jsglr/pie/JsglrParseTaskDef.java
+++ b/core/jsglr.pie/src/main/java/mb/jsglr/pie/JsglrParseTaskDef.java
@@ -3,6 +3,7 @@ package mb.jsglr.pie;
 import mb.common.message.Messages;
 import mb.common.result.Result;
 import mb.common.text.Text;
+import mb.common.util.ListView;
 import mb.common.util.MapView;
 import mb.jsglr.common.JSGLRTokens;
 import mb.jsglr.common.JsglrParseException;
@@ -56,11 +57,19 @@ public abstract class JsglrParseTaskDef implements TaskDef<JsglrParseTaskInput, 
     }
 
     public Function<ResourcePath, MapView<ResourceKey, Supplier<Result<IStrategoTerm, JsglrParseException>>>> createMultiAstSupplierFunction(ResourceWalker walker, ResourceMatcher matcher) {
-        return new MultiAstSupplierFunction(astFunction, walker, matcher);
+        return new WalkingMultiAstSupplierFunction(astFunction, walker, matcher);
     }
 
     public Function<ResourcePath, MapView<ResourceKey, Supplier<Result<IStrategoTerm, JsglrParseException>>>> createRecoverableMultiAstSupplierFunction(ResourceWalker walker, ResourceMatcher matcher) {
-        return new MultiAstSupplierFunction(recoverableAstFunction, walker, matcher);
+        return new WalkingMultiAstSupplierFunction(recoverableAstFunction, walker, matcher);
+    }
+
+    public Function<ResourcePath, MapView<ResourceKey, Supplier<Result<IStrategoTerm, JsglrParseException>>>> createMultiAstSupplierFunction(ListView<ResourceKey> files) {
+        return new MultiAstSupplierFunction(astFunction, files);
+    }
+
+    public Function<ResourcePath, MapView<ResourceKey, Supplier<Result<IStrategoTerm, JsglrParseException>>>> createRecoverableMultiAstSupplierFunction(ListView<ResourceKey> files) {
+        return new MultiAstSupplierFunction(recoverableAstFunction, files);
     }
 
     public Function<JsglrParseTaskInput, Result<JSGLRTokens, JsglrParseException>> createTokensFunction() {

--- a/core/jsglr.pie/src/main/java/mb/jsglr/pie/WalkingMultiAstSupplierFunction.java
+++ b/core/jsglr.pie/src/main/java/mb/jsglr/pie/WalkingMultiAstSupplierFunction.java
@@ -1,0 +1,61 @@
+package mb.jsglr.pie;
+
+import mb.common.result.Result;
+import mb.common.util.MapView;
+import mb.jsglr.common.JsglrParseException;
+import mb.pie.api.ExecContext;
+import mb.pie.api.Function;
+import mb.pie.api.Supplier;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.ResourceKey;
+import mb.resource.hierarchical.HierarchicalResource;
+import mb.resource.hierarchical.ResourcePath;
+import mb.resource.hierarchical.match.ResourceMatcher;
+import mb.resource.hierarchical.walk.ResourceWalker;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.stream.Stream;
+
+public class WalkingMultiAstSupplierFunction implements Function<ResourcePath, MapView<ResourceKey, Supplier<Result<IStrategoTerm, JsglrParseException>>>> {
+    private final Function<JsglrParseTaskInput, Result<IStrategoTerm, JsglrParseException>> parseToAstFunction;
+    private final ResourceWalker walker;
+    private final ResourceMatcher matcher;
+
+    public WalkingMultiAstSupplierFunction(Function<JsglrParseTaskInput, Result<IStrategoTerm, JsglrParseException>> parseToAstFunction, ResourceWalker walker, ResourceMatcher matcher) {
+        this.parseToAstFunction = parseToAstFunction;
+        this.walker = walker;
+        this.matcher = matcher;
+    }
+
+    @Override
+    public MapView<ResourceKey, Supplier<Result<IStrategoTerm, JsglrParseException>>> apply(ExecContext context, ResourcePath rootDirectory) {
+        final HashMap<ResourceKey, Supplier<Result<IStrategoTerm, JsglrParseException>>> astsAndErrors = new HashMap<>();
+        try(final Stream<? extends HierarchicalResource> stream = context.require(rootDirectory, ResourceStampers.modifiedDirRec(walker, matcher)).walk(walker, matcher)) {
+            stream.forEach(file -> astsAndErrors.put(file.getKey(), parseToAstFunction.createSupplier(JsglrParseTaskInput.builder().withFile(file.getKey()).rootDirectoryHint(rootDirectory).build())));
+        } catch(IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return MapView.of(astsAndErrors);
+    }
+
+    @Override public boolean equals(Object o) {
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+
+        WalkingMultiAstSupplierFunction that = (WalkingMultiAstSupplierFunction)o;
+
+        if(!parseToAstFunction.equals(that.parseToAstFunction)) return false;
+        if(!walker.equals(that.walker)) return false;
+        return matcher.equals(that.matcher);
+    }
+
+    @Override public int hashCode() {
+        int result = parseToAstFunction.hashCode();
+        result = 31 * result + walker.hashCode();
+        result = 31 * result + matcher.hashCode();
+        return result;
+    }
+}

--- a/core/spoofax.compiler.dagger/src/main/java/mb/spoofax/compiler/dagger/SpoofaxCompilerComponent.java
+++ b/core/spoofax.compiler.dagger/src/main/java/mb/spoofax/compiler/dagger/SpoofaxCompilerComponent.java
@@ -8,6 +8,7 @@ import mb.resource.dagger.ResourceServiceComponent;
 import mb.spoofax.compiler.adapter.AdapterProjectCompiler;
 import mb.spoofax.compiler.adapter.CompleterAdapterCompiler;
 import mb.spoofax.compiler.adapter.ConstraintAnalyzerAdapterCompiler;
+import mb.spoofax.compiler.adapter.GetSourceFilesAdapterCompiler;
 import mb.spoofax.compiler.adapter.MultilangAnalyzerAdapterCompiler;
 import mb.spoofax.compiler.adapter.ParserAdapterCompiler;
 import mb.spoofax.compiler.adapter.ReferenceResolutionAdapterCompiler;
@@ -71,6 +72,8 @@ public interface SpoofaxCompilerComponent extends TaskDefsProvider {
     MultilangAnalyzerAdapterCompiler getMultilangAnalyzerAdapterCompiler();
 
     ReferenceResolutionAdapterCompiler getReferenceResolutionAdapterCompiler();
+
+    GetSourceFilesAdapterCompiler getGetSourceFilesAdapterCompiler();
 
 
     CliProjectCompiler getCliProjectCompiler();

--- a/core/spoofax.compiler.dagger/src/main/java/mb/spoofax/compiler/dagger/SpoofaxCompilerModule.java
+++ b/core/spoofax.compiler.dagger/src/main/java/mb/spoofax/compiler/dagger/SpoofaxCompilerModule.java
@@ -7,6 +7,7 @@ import mb.pie.api.TaskDef;
 import mb.spoofax.compiler.adapter.AdapterProjectCompiler;
 import mb.spoofax.compiler.adapter.CompleterAdapterCompiler;
 import mb.spoofax.compiler.adapter.ConstraintAnalyzerAdapterCompiler;
+import mb.spoofax.compiler.adapter.GetSourceFilesAdapterCompiler;
 import mb.spoofax.compiler.adapter.MultilangAnalyzerAdapterCompiler;
 import mb.spoofax.compiler.adapter.ParserAdapterCompiler;
 import mb.spoofax.compiler.adapter.ReferenceResolutionAdapterCompiler;
@@ -62,6 +63,7 @@ public class SpoofaxCompilerModule {
         CompleterAdapterCompiler completerAdapterCompiler,
         StrategoRuntimeAdapterCompiler strategoRuntimeAdapterCompiler,
         ReferenceResolutionAdapterCompiler referenceResolutionAdapterCompiler,
+        GetSourceFilesAdapterCompiler getSourceFilesAdapterCompiler,
 
         CliProjectCompiler cliProjectCompiler,
         EclipseProjectCompiler eclipseProjectCompiler,
@@ -86,6 +88,7 @@ public class SpoofaxCompilerModule {
         taskDefs.add(strategoRuntimeAdapterCompiler);
         taskDefs.add(completerAdapterCompiler);
         taskDefs.add(referenceResolutionAdapterCompiler);
+        taskDefs.add(getSourceFilesAdapterCompiler);
 
         taskDefs.add(cliProjectCompiler);
         taskDefs.add(eclipseProjectCompiler);

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
@@ -461,6 +461,7 @@ public class AdapterProjectCompiler implements TaskDef<Supplier<Result<AdapterPr
         default List<NamedTypeInfo> checkMultiInjections() {
             ArrayList<NamedTypeInfo> results = new ArrayList<>();
             results.add(NamedTypeInfo.of("classLoaderResources", classLoaderResources().classLoaderResources()));
+            results.add(NamedTypeInfo.of("getSourceFiles", getSourceFiles().getSourceFilesTaskDef()));
             parser().ifPresent(i -> results.add(NamedTypeInfo.of("parse", i.parseTaskDef())));
             constraintAnalyzer().ifPresent(i -> results.add(NamedTypeInfo.of("analyze", i.analyzeMultiTaskDef())));
             return results;

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
@@ -13,6 +13,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class AdapterProjectCompilerInputBuilder {
     public final ClassLoaderResourcesCompiler.Input.Builder classLoaderResources = ClassLoaderResourcesCompiler.Input.builder();
+    public final GetSourceFilesAdapterCompiler.Input.Builder getSourceFiles = GetSourceFilesAdapterCompiler.Input.builder();
 
     private boolean parserEnabled = false;
     public final ParserAdapterCompiler.Input.Builder parser = ParserAdapterCompiler.Input.builder();
@@ -84,6 +85,9 @@ public class AdapterProjectCompilerInputBuilder {
         final ClassLoaderResourcesCompiler.Input classLoaderResources = buildClassLoaderResources(shared, languageProjectInput.languageProject());
         project.classLoaderResources(classLoaderResources);
 
+        final GetSourceFilesAdapterCompiler.Input getSourceFiles = buildGetSourceFiles(shared, adapterProject, classLoaderResources);
+        project.sourceFiles(getSourceFiles);
+
         final ParserAdapterCompiler.@Nullable Input parser = buildParser(shared, adapterProject, languageProjectInput, classLoaderResources);
         if(parser != null) project.parser(parser);
 
@@ -118,6 +122,18 @@ public class AdapterProjectCompilerInputBuilder {
         return classLoaderResources
             .shared(shared)
             .languageProject(languageProject)
+            .build();
+    }
+
+    private GetSourceFilesAdapterCompiler.Input buildGetSourceFiles(
+        Shared shared,
+        AdapterProject adapterProject,
+        ClassLoaderResourcesCompiler.Input classloaderResources
+    ) {
+        return getSourceFiles
+            .shared(shared)
+            .adapterProject(adapterProject)
+            .classLoaderResourcesInput(classloaderResources)
             .build();
     }
 

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
@@ -103,7 +103,7 @@ public class AdapterProjectCompilerInputBuilder {
         final MultilangAnalyzerAdapterCompiler.@Nullable Input multilangAnalyzer = buildMultilangAnalyzer(shared, adapterProject, languageProjectInput, strategoRuntime);
         if(multilangAnalyzer != null) project.multilangAnalyzer(multilangAnalyzer);
 
-        final ReferenceResolutionAdapterCompiler.@Nullable Input referenceResolution = buildReferenceResolution(shared, adapterProject, strategoRuntime, parser, constraintAnalyzer, classLoaderResources);
+        final ReferenceResolutionAdapterCompiler.@Nullable Input referenceResolution = buildReferenceResolution(shared, adapterProject, strategoRuntime, parser, constraintAnalyzer, classLoaderResources, getSourceFiles);
         if(referenceResolution != null) project.referenceResolution(referenceResolution);
 
         final CompleterAdapterCompiler.@Nullable Input completer = buildCompleter(shared, adapterProject, languageProjectInput);
@@ -239,7 +239,8 @@ public class AdapterProjectCompilerInputBuilder {
         StrategoRuntimeAdapterCompiler.@Nullable Input strategoRuntimeInput,
         ParserAdapterCompiler.@Nullable Input parseInput,
         ConstraintAnalyzerAdapterCompiler.@Nullable Input constraintAnalyzerInput,
-        ClassLoaderResourcesCompiler.Input classloaderResources
+        ClassLoaderResourcesCompiler.Input classloaderResources,
+        GetSourceFilesAdapterCompiler.Input getSourceFiles
     ) {
         if(!referenceResolutionEnabled) return null;
         return referenceResolution
@@ -249,6 +250,7 @@ public class AdapterProjectCompilerInputBuilder {
             .parseInput(parseInput)
             .constraintAnalyzerInput(constraintAnalyzerInput)
             .classLoaderResourcesInput(classloaderResources)
+            .sourceFilesInput(getSourceFiles)
             .build();
     }
 }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/GetSourceFilesAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/GetSourceFilesAdapterCompiler.java
@@ -1,0 +1,100 @@
+package mb.spoofax.compiler.adapter;
+
+import mb.common.util.ListView;
+import mb.pie.api.ExecContext;
+import mb.pie.api.None;
+import mb.pie.api.TaskDef;
+import mb.resource.hierarchical.ResourcePath;
+import mb.spoofax.compiler.language.ClassLoaderResourcesCompiler;
+import mb.spoofax.compiler.util.*;
+import org.immutables.value.Value;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Optional;
+
+@Value.Enclosing
+public class GetSourceFilesAdapterCompiler implements TaskDef<GetSourceFilesAdapterCompiler.Input, None> {
+    private final TemplateWriter getSourceFilesTaskDefTemplate;
+
+    @Inject public GetSourceFilesAdapterCompiler(TemplateCompiler templateCompiler) {
+        templateCompiler = templateCompiler.loadingFromClass(getClass());
+
+        this.getSourceFilesTaskDefTemplate = templateCompiler.getOrCompileToWriter("adapter_project/GetSourceFilesTaskDef.java.mustache");
+    }
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override public None exec(ExecContext context, Input input) throws IOException {
+        if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
+        final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
+
+        getSourceFilesTaskDefTemplate.write(context, input.getSourceFilesTaskDef().file(generatedJavaSourcesDirectory), input);
+
+        return None.instance;
+    }
+
+    @Override public Serializable key(Input input) {
+        return input.adapterProject().project().baseDirectory();
+    }
+
+
+    @Value.Immutable
+    public interface Input extends Serializable {
+        class Builder extends GetSourceFilesAdapterCompilerData.Input.Builder {
+        }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        /// Kinds of classes (generated/extended/manual)
+
+        @Value.Default default ClassKind classKind() {
+            return ClassKind.Generated;
+        }
+
+
+        /// Adapter project classes
+
+        default ResourcePath generatedJavaSourcesDirectory() {
+            return adapterProject().generatedJavaSourcesDirectory();
+        }
+
+        // Get language source files definition
+
+        @Value.Default default TypeInfo baseGetSourceFilesTaskDef() {
+            return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "GetSourceFiles");
+        }
+
+        Optional<TypeInfo> extendGetSourceFilesTaskDef();
+
+        default TypeInfo getSourceFilesTaskDef() {
+            return extendGetSourceFilesTaskDef().orElseGet(this::baseGetSourceFilesTaskDef);
+        }
+
+
+        /// Files information, known up-front for build systems with static dependencies such as Gradle.
+
+        default ListView<ResourcePath> javaSourceFiles() {
+            if(classKind().isManual()) {
+                return ListView.of();
+            }
+            final ResourcePath generatedJavaSourcesDirectory = generatedJavaSourcesDirectory();
+            return ListView.of(
+                getSourceFilesTaskDef().file(generatedJavaSourcesDirectory)
+            );
+        }
+
+        /// Automatically provided sub-inputs
+
+        @Value.Auxiliary Shared shared();
+
+        AdapterProject adapterProject();
+
+        ClassLoaderResourcesCompiler.Input classLoaderResourcesInput();
+    }
+}

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ReferenceResolutionAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ReferenceResolutionAdapterCompiler.java
@@ -125,5 +125,7 @@ public class ReferenceResolutionAdapterCompiler implements TaskDef<ReferenceReso
         ConstraintAnalyzerAdapterCompiler.Input constraintAnalyzerInput();
 
         ClassLoaderResourcesCompiler.Input classLoaderResourcesInput();
+
+        GetSourceFilesAdapterCompiler.Input getSourceFilesInput();
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckMultiTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/CheckMultiTaskDef.java.mustache
@@ -5,14 +5,12 @@ import mb.common.message.KeyedMessagesBuilder;
 import mb.common.message.Messages;
 import mb.common.message.Severity;
 import mb.common.result.Result;
+import mb.common.util.ListView;
 import mb.pie.api.ExecContext;
 import mb.pie.api.TaskDef;
 import mb.pie.api.stamp.resource.ResourceStampers;
-import mb.resource.hierarchical.HierarchicalResource;
+import mb.resource.ResourceKey;
 import mb.resource.hierarchical.ResourcePath;
-import mb.resource.hierarchical.match.ResourceMatcher;
-import mb.resource.hierarchical.match.path.PathMatcher;
-import mb.resource.hierarchical.walk.ResourceWalker;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -40,20 +38,18 @@ public class {{baseCheckMultiTaskDef.id}} implements TaskDef<ResourcePath, Keyed
     @Override public KeyedMessages exec(ExecContext context, ResourcePath input) throws IOException {
         context.require(classLoaderResources.tryGetAsLocalResource(getClass()), ResourceStampers.hashFile());
         final KeyedMessagesBuilder messagesBuilder = new KeyedMessagesBuilder();
-        final ResourceWalker walker = ResourceWalker.ofPath(PathMatcher.ofNoHidden());
-        final HierarchicalResource rootDirectory = context.getHierarchicalResource(input);
-        // Require directories recursively, so we re-execute whenever a file is added/removed from a directory.
-        rootDirectory.walkForEach(walker, ResourceMatcher.ofDirectory(), context::require);
-        final ResourceMatcher matcher = ResourceMatcher.ofFile().and(ResourceMatcher.ofPath(PathMatcher.ofExtensions({{#shared.fileExtensions}}"{{this}}"{{^-last}}, {{/-last}}{{/shared.fileExtensions}})));
+
+        final ListView<ResourceKey> sourceFiles = context.require(getSourceFiles, input);
+
         {{#parser}}
-        rootDirectory.walkForEach(walker, matcher, file -> {
-            final ResourcePath filePath = file.getPath();
-            final Messages messages = context.require(parse.inputBuilder().withFile(filePath).rootDirectoryHint(input).buildMessagesSupplier());
-            messagesBuilder.addMessages(filePath, messages);
-        });
+        for(final ResourceKey file : sourceFiles) {
+            final Messages messages = context.require(parse.inputBuilder().withFile(file).rootDirectoryHint(input).buildMessagesSupplier());
+            messagesBuilder.addMessages(file, messages);
+        }
         {{/parser}}
+
         {{#constraintAnalyzer}}
-        final {{this.analyzeMultiTaskDef.qualifiedId}}.Input analyzeInput = new {{this.analyzeMultiTaskDef.qualifiedId}}.Input(input, parse.createRecoverableMultiAstSupplierFunction(walker, matcher));
+        final {{this.analyzeMultiTaskDef.qualifiedId}}.Input analyzeInput = new {{this.analyzeMultiTaskDef.qualifiedId}}.Input(input, parse.createRecoverableMultiAstSupplierFunction(sourceFiles));
         final Result<{{this.analyzeMultiTaskDef.qualifiedId}}.Output, ?> analysisResult = context.require(analyze, analyzeInput);
         analysisResult
             .ifOk(output -> {
@@ -62,6 +58,7 @@ public class {{baseCheckMultiTaskDef.id}} implements TaskDef<ResourcePath, Keyed
             })
             .ifErr(e -> messagesBuilder.addMessage("Project-wide analysis failed", e, Severity.Error, input));
         {{/constraintAnalyzer}}
+
         return messagesBuilder.build();
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/GetSourceFilesTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/GetSourceFilesTaskDef.java.mustache
@@ -1,0 +1,54 @@
+package {{baseGetSourceFilesTaskDef.packageId}};
+
+import mb.common.util.ListView;
+import mb.pie.api.ExecContext;
+import mb.pie.api.TaskDef;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.ResourceKey;
+import mb.resource.hierarchical.HierarchicalResource;
+import mb.resource.hierarchical.ResourcePath;
+import mb.resource.hierarchical.match.ResourceMatcher;
+import mb.resource.hierarchical.match.path.PathMatcher;
+import mb.resource.hierarchical.walk.ResourceWalker;
+
+import javax.inject.Inject;
+import java.util.LinkedList;
+import java.util.List;
+
+@{{adapterProject.scope.qualifiedId}}
+public class {{baseGetSourceFilesTaskDef.id}} implements TaskDef<ResourcePath, ListView<ResourceKey>> {
+    private static final ResourceWalker WALKER = ResourceWalker.ofNoHidden();
+    private static final ResourceMatcher MATCHER = ResourceMatcher.ofPath(
+        PathMatcher.ofExtensions({{#shared.fileExtensions}}"{{this}}"{{^-last}}, {{/-last}}{{/shared.fileExtensions}})
+    ).and(ResourceMatcher.ofFile());
+
+    private final {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources;
+
+    @Inject
+    public {{baseGetSourceFilesTaskDef.id}}(
+        {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources
+    ) {
+        this.classLoaderResources = classLoaderResources;
+    }
+
+    @Override public String getId() {
+        return "{{baseGetSourceFilesTaskDef.qualifiedId}}";
+    }
+
+    @Override public ListView<ResourceKey> exec(ExecContext context, ResourcePath input) throws Exception {
+        context.require(classLoaderResources.tryGetAsLocalResource(getClass()), ResourceStampers.hashFile());
+
+        final HierarchicalResource rootDirectory = context.getHierarchicalResource(input);
+        // Require directories recursively, so we re-execute whenever a file is added/removed from a directory.
+        rootDirectory.walkForEach(WALKER, ResourceMatcher.ofDirectory(), context::require);
+
+        final List<ResourceKey> files = new LinkedList<>();
+
+        rootDirectory.walkForEach(WALKER, MATCHER, file -> {
+            final ResourceKey fileKey = file.getKey();
+            files.add(fileKey);
+        });
+
+        return ListView.of(files);
+    }
+}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/editor_services/ResolveTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/editor_services/ResolveTaskDef.java.mustache
@@ -84,6 +84,7 @@ public class {{baseResolveTaskDef.id}} implements TaskDef<{{baseResolveTaskDef.i
     private final {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources;
     private final {{parseInput.parseTaskDef.qualifiedId}} parse;
     private final {{analyzeTaskDef.qualifiedId}} analyze;
+    private final {{getSourceFilesInput.getSourceFilesTaskDef.qualifiedId}} getSourceFiles;
     private final {{strategoRuntimeInput.getStrategoRuntimeProviderTaskDef.qualifiedId}} getStrategoRuntimeProvider;
 
     @Inject
@@ -91,11 +92,13 @@ public class {{baseResolveTaskDef.id}} implements TaskDef<{{baseResolveTaskDef.i
         {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources,
         {{parseInput.parseTaskDef.qualifiedId}} parse,
         {{analyzeTaskDef.qualifiedId}} analyze,
+        {{getSourceFilesInput.getSourceFilesTaskDef.qualifiedId}} getSourceFiles,
         {{strategoRuntimeInput.getStrategoRuntimeProviderTaskDef.qualifiedId}} getStrategoRuntimeProvider
     ) {
         this.classLoaderResources = classLoaderResources;
         this.parse = parse;
         this.analyze = analyze;
+        this.getSourceFiles = getSourceFiles;
         this.getStrategoRuntimeProvider = getStrategoRuntimeProvider;
     }
 
@@ -110,16 +113,13 @@ public class {{baseResolveTaskDef.id}} implements TaskDef<{{baseResolveTaskDef.i
 
         // Step 1: get analysis
 {{#isMultiFile}}
-        final ResourceWalker walker = ResourceWalker.ofPath(PathMatcher.ofNoHidden());
-        final ResourceMatcher matcher = ResourceMatcher.ofPath(
-            PathMatcher.ofExtensions({{#shared.fileExtensions}}"{{this}}"{{^-last}}, {{/-last}}{{/shared.fileExtensions}})
-        ).and(ResourceMatcher.ofFile());
+        final ListView<ResourceKey> sourceFiles = context.require(getSourceFiles, args.rootDirectory);
 
         final Result<ConstraintAnalyzeMultiTaskDef.SingleFileOutput, ?> analysis = context.require(
             analyze.createSingleFileOutputSupplier(
                 new ConstraintAnalyzeMultiTaskDef.Input(
                     args.rootDirectory,
-                    parse.createRecoverableMultiAstSupplierFunction(walker, matcher)
+                    parse.createRecoverableMultiAstSupplierFunction(sourceFiles)
                 ),
                 args.file
             )


### PR DESCRIPTION
This adds a new task definition in the adapter project for retrieving a list of all source files of the language located in a given root folder. This allows the caching of the set of source files (drastically speeding up multi-file resolving) and allows a language to implement a custom task that further restricts the lookup to only specific folders. From my experience, this isn't currently needed for the resolve task, but it may be useful for other tasks in the future.

The original methods for creating a parse supplier that use the walker still exist, with an additional set of functions that take in the list of files.

Both `ResolveTaskDef` and `CheckMultiTaskDef` use this new task. I don't currently expose it in the language instance, but this might be something useful enough to warrant exposing.