### PR TITLE
Fix gradle language plugins in combination with spoofax 3 projects

### DIFF
--- a/core/spoofax.compiler.gradle/src/main/kotlin/mb/spoofax/compiler/gradle/plugin/AdapterPlugin.kt
+++ b/core/spoofax.compiler.gradle/src/main/kotlin/mb/spoofax/compiler/gradle/plugin/AdapterPlugin.kt
@@ -40,7 +40,7 @@ open class AdapterProjectExtension(project: Project) {
     private const val name = "language adapter project"
   }
 
-  internal val languageProjectFinalized: Project? by lazy {
+  open val languageProjectFinalized: Project? by lazy {
     project.logger.debug("Finalizing $name's language project reference in $project")
     languageProject.finalizeValue()
     if(languageProject.isPresent) {
@@ -67,7 +67,7 @@ open class AdapterProjectExtension(project: Project) {
       .build()
   }
 
-  internal val compilerInputFinalized: AdapterProjectCompiler.Input by lazy {
+  open val compilerInputFinalized: AdapterProjectCompiler.Input by lazy {
     project.logger.debug("Finalizing $name's compiler input in $project")
     compilerInput.finalizeValue()
     val languageProjectDependency = Option.ofNullable(languageProjectFinalized).map { it.toSpoofaxCompilerProject().asProjectDependency() }

--- a/core/spoofax.compiler.gradle/src/main/kotlin/mb/spoofax/compiler/gradle/plugin/LanguagePlugin.kt
+++ b/core/spoofax.compiler.gradle/src/main/kotlin/mb/spoofax/compiler/gradle/plugin/LanguagePlugin.kt
@@ -78,7 +78,7 @@ open class LanguageProjectExtension(project: Project) {
 
   val components: Components by lazy { Components() }
 
-  val sharedFinalized: Shared by lazy {
+  open val sharedFinalized: Shared by lazy {
     project.logger.debug("Finalizing $name shared settings in $project")
     shared.finalizeValue()
 
@@ -100,7 +100,7 @@ open class LanguageProjectExtension(project: Project) {
       .build()
   }
 
-  val compilerInputFinalized: LanguageProjectCompiler.Input by lazy {
+  open val compilerInputFinalized: LanguageProjectCompiler.Input by lazy {
     project.logger.debug("Finalizing $name's compiler input in $project")
     compilerInput.finalizeValue()
     val languageProjectBuilder = compilerInput.get()
@@ -126,7 +126,7 @@ open class LanguageProjectExtension(project: Project) {
     languageProjectBuilder.build(sharedFinalized, languageProjectFinalized)
   }
 
-  val statixDependenciesFinalized: List<Project> by lazy {
+  open val statixDependenciesFinalized: List<Project> by lazy {
     project.logger.debug("Finalizing $name statix dependencies in $project")
     statixDependencies.finalizeValue()
     statixDependencies.get()

--- a/lwb/spoofax.lwb.compiler.gradle/build.gradle.kts
+++ b/lwb/spoofax.lwb.compiler.gradle/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   api(platform(compositeBuild("spoofax.depconstraints")))
   kapt(platform(compositeBuild("spoofax.depconstraints")))
 
+  compileOnly("org.metaborg:spoofax.compiler.gradle")
   api(project(":spoofax.lwb.compiler"))
   api(project(":spoofax.lwb.compiler.dagger"))
   api("com.google.dagger:dagger")


### PR DESCRIPTION
Currently the CliPlugin, EclipsePlugin and IntellijPlugin do not work with Spoofax 3 projects.

These plugins rely on `AdapterPlugin` to compile the adapter project and add an `AdapterExtension` to the project. The plugins use `Project::whenAdapterProjectFinalized` method to ensure that the adapter project exists (this method relies on the `AdapterExtension` added by `AdapterPlugin`), before the plugin is configured. If the `AdapterExtension` is missing, then the plugin isn't configured.

Spoofax 3 projects use `spoofax.lwb.compile.gradle.LanguagePlugin` to compile the adapter project.
This `LanguagePlugin` does not create the required `AdapterExtension`, causing the reliant plugins to never be configured correctly.

The same issue occurs for the `LanguageExtension` which is supposed to be created by the `spoofax.compiler.gradle.LanguagePlugin` (note that this is a different `LanguagePlugin` than the one mentioned before).

This merge request fixes this issue by making subclasses `Spoofax3AdapterExtension` and `Spoofax3LanguageExtension` which are added to the project by the `spoofax.lwb.compile.gradle.LanguagePlugin`, resulting in the other plugins being able to configure their tasks correctly.