### PR TITLE
Implement hover editor service

### DIFF
--- a/core/spoofax.compiler.dagger/src/main/java/mb/spoofax/compiler/dagger/SpoofaxCompilerComponent.java
+++ b/core/spoofax.compiler.dagger/src/main/java/mb/spoofax/compiler/dagger/SpoofaxCompilerComponent.java
@@ -9,6 +9,7 @@ import mb.spoofax.compiler.adapter.AdapterProjectCompiler;
 import mb.spoofax.compiler.adapter.CompleterAdapterCompiler;
 import mb.spoofax.compiler.adapter.ConstraintAnalyzerAdapterCompiler;
 import mb.spoofax.compiler.adapter.GetSourceFilesAdapterCompiler;
+import mb.spoofax.compiler.adapter.HoverAdapterCompiler;
 import mb.spoofax.compiler.adapter.MultilangAnalyzerAdapterCompiler;
 import mb.spoofax.compiler.adapter.ParserAdapterCompiler;
 import mb.spoofax.compiler.adapter.ReferenceResolutionAdapterCompiler;
@@ -72,6 +73,8 @@ public interface SpoofaxCompilerComponent extends TaskDefsProvider {
     MultilangAnalyzerAdapterCompiler getMultilangAnalyzerAdapterCompiler();
 
     ReferenceResolutionAdapterCompiler getReferenceResolutionAdapterCompiler();
+
+    HoverAdapterCompiler getHoverAdapterCompiler();
 
     GetSourceFilesAdapterCompiler getGetSourceFilesAdapterCompiler();
 

--- a/core/spoofax.compiler.dagger/src/main/java/mb/spoofax/compiler/dagger/SpoofaxCompilerModule.java
+++ b/core/spoofax.compiler.dagger/src/main/java/mb/spoofax/compiler/dagger/SpoofaxCompilerModule.java
@@ -8,6 +8,7 @@ import mb.spoofax.compiler.adapter.AdapterProjectCompiler;
 import mb.spoofax.compiler.adapter.CompleterAdapterCompiler;
 import mb.spoofax.compiler.adapter.ConstraintAnalyzerAdapterCompiler;
 import mb.spoofax.compiler.adapter.GetSourceFilesAdapterCompiler;
+import mb.spoofax.compiler.adapter.HoverAdapterCompiler;
 import mb.spoofax.compiler.adapter.MultilangAnalyzerAdapterCompiler;
 import mb.spoofax.compiler.adapter.ParserAdapterCompiler;
 import mb.spoofax.compiler.adapter.ReferenceResolutionAdapterCompiler;
@@ -63,6 +64,7 @@ public class SpoofaxCompilerModule {
         CompleterAdapterCompiler completerAdapterCompiler,
         StrategoRuntimeAdapterCompiler strategoRuntimeAdapterCompiler,
         ReferenceResolutionAdapterCompiler referenceResolutionAdapterCompiler,
+        HoverAdapterCompiler hoverAdapterCompiler,
         GetSourceFilesAdapterCompiler getSourceFilesAdapterCompiler,
 
         CliProjectCompiler cliProjectCompiler,
@@ -88,6 +90,7 @@ public class SpoofaxCompilerModule {
         taskDefs.add(strategoRuntimeAdapterCompiler);
         taskDefs.add(completerAdapterCompiler);
         taskDefs.add(referenceResolutionAdapterCompiler);
+        taskDefs.add(hoverAdapterCompiler);
         taskDefs.add(getSourceFilesAdapterCompiler);
 
         taskDefs.add(cliProjectCompiler);

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompiler.java
@@ -160,6 +160,7 @@ public class AdapterProjectCompiler implements TaskDef<Supplier<Result<AdapterPr
         input.constraintAnalyzer().ifPresent((i) -> {
             addTaskDef(allTaskDefs, i.analyzeTaskDef(), i.baseAnalyzeTaskDef());
             addTaskDef(allTaskDefs, i.analyzeMultiTaskDef(), i.baseAnalyzeMultiTaskDef());
+            addTaskDef(allTaskDefs, i.analyzeFileTaskDef(), i.baseAnalyzeFileTaskDef());
         });
         input.multilangAnalyzer().ifPresent((i) -> {
             addTaskDef(allTaskDefs, i.analyzeTaskDef(), i.baseAnalyzeTaskDef());

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
@@ -97,13 +97,13 @@ public class AdapterProjectCompilerInputBuilder {
         final StrategoRuntimeAdapterCompiler.@Nullable Input strategoRuntime = buildStrategoRuntime(shared, adapterProject, languageProjectInput, classLoaderResources);
         if(strategoRuntime != null) project.strategoRuntime(strategoRuntime);
 
-        final ConstraintAnalyzerAdapterCompiler.@Nullable Input constraintAnalyzer = buildConstraintAnalyzer(shared, adapterProject, languageProjectInput, classLoaderResources, strategoRuntime);
+        final ConstraintAnalyzerAdapterCompiler.@Nullable Input constraintAnalyzer = buildConstraintAnalyzer(shared, adapterProject, languageProjectInput, parser, getSourceFiles, classLoaderResources, strategoRuntime);
         if(constraintAnalyzer != null) project.constraintAnalyzer(constraintAnalyzer);
 
         final MultilangAnalyzerAdapterCompiler.@Nullable Input multilangAnalyzer = buildMultilangAnalyzer(shared, adapterProject, languageProjectInput, strategoRuntime);
         if(multilangAnalyzer != null) project.multilangAnalyzer(multilangAnalyzer);
 
-        final ReferenceResolutionAdapterCompiler.@Nullable Input referenceResolution = buildReferenceResolution(shared, adapterProject, strategoRuntime, parser, constraintAnalyzer, classLoaderResources, getSourceFiles);
+        final ReferenceResolutionAdapterCompiler.@Nullable Input referenceResolution = buildReferenceResolution(shared, adapterProject, strategoRuntime, constraintAnalyzer, classLoaderResources);
         if(referenceResolution != null) project.referenceResolution(referenceResolution);
 
         final CompleterAdapterCompiler.@Nullable Input completer = buildCompleter(shared, adapterProject, languageProjectInput);
@@ -186,6 +186,8 @@ public class AdapterProjectCompilerInputBuilder {
         Shared shared,
         AdapterProject adapterProject,
         LanguageProjectCompiler.Input languageProjectInput,
+        ParserAdapterCompiler.@Nullable Input parseInput,
+        GetSourceFilesAdapterCompiler.Input getSourceFilesInput,
         ClassLoaderResourcesCompiler.Input classloaderResources,
         StrategoRuntimeAdapterCompiler.@Nullable Input strategoRuntimeInput
     ) {
@@ -199,6 +201,8 @@ public class AdapterProjectCompilerInputBuilder {
             .languageProjectInput(languageProjectInput.constraintAnalyzer().orElseThrow(() -> new RuntimeException("Mismatch between presence of constraint analyzer input between language project and adapter project")))
             .classLoaderResourcesInput(classloaderResources)
             .strategoRuntimeInput(strategoRuntimeInput)
+            .parseInput(parseInput)
+            .sourceFilesInput(getSourceFilesInput)
             .build();
     }
 
@@ -237,20 +241,16 @@ public class AdapterProjectCompilerInputBuilder {
         Shared shared,
         AdapterProject adapterProject,
         StrategoRuntimeAdapterCompiler.@Nullable Input strategoRuntimeInput,
-        ParserAdapterCompiler.@Nullable Input parseInput,
         ConstraintAnalyzerAdapterCompiler.@Nullable Input constraintAnalyzerInput,
-        ClassLoaderResourcesCompiler.Input classloaderResources,
-        GetSourceFilesAdapterCompiler.Input getSourceFiles
+        ClassLoaderResourcesCompiler.Input classloaderResources
     ) {
         if(!referenceResolutionEnabled) return null;
         return referenceResolution
             .shared(shared)
             .adapterProject(adapterProject)
             .strategoRuntimeInput(strategoRuntimeInput)
-            .parseInput(parseInput)
             .constraintAnalyzerInput(constraintAnalyzerInput)
             .classLoaderResourcesInput(classloaderResources)
-            .sourceFilesInput(getSourceFiles)
             .build();
     }
 }

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/AdapterProjectCompilerInputBuilder.java
@@ -36,6 +36,9 @@ public class AdapterProjectCompilerInputBuilder {
     private boolean referenceResolutionEnabled = false;
     public final ReferenceResolutionAdapterCompiler.Input.Builder referenceResolution = ReferenceResolutionAdapterCompiler.Input.builder();
 
+    private boolean hoverEnabled = false;
+    public final HoverAdapterCompiler.Input.Builder hover = HoverAdapterCompiler.Input.builder();
+
     public AdapterProjectCompiler.Input.Builder project = AdapterProjectCompiler.Input.builder();
 
 
@@ -78,6 +81,11 @@ public class AdapterProjectCompilerInputBuilder {
         return referenceResolution;
     }
 
+    public HoverAdapterCompiler.Input.Builder withHover() {
+        hoverEnabled = true;
+        return hover;
+    }
+
 
     public AdapterProjectCompiler.Input build(LanguageProjectCompiler.Input languageProjectInput, Option<GradleDependency> languageProjectDependency, AdapterProject adapterProject) {
         final Shared shared = languageProjectInput.shared();
@@ -105,6 +113,9 @@ public class AdapterProjectCompilerInputBuilder {
 
         final ReferenceResolutionAdapterCompiler.@Nullable Input referenceResolution = buildReferenceResolution(shared, adapterProject, strategoRuntime, constraintAnalyzer, classLoaderResources);
         if(referenceResolution != null) project.referenceResolution(referenceResolution);
+
+        final HoverAdapterCompiler.@Nullable Input hover = buildHover(shared, adapterProject, strategoRuntime, constraintAnalyzer, classLoaderResources);
+        if(hover != null) project.hover(hover);
 
         final CompleterAdapterCompiler.@Nullable Input completer = buildCompleter(shared, adapterProject, languageProjectInput);
 
@@ -246,6 +257,23 @@ public class AdapterProjectCompilerInputBuilder {
     ) {
         if(!referenceResolutionEnabled) return null;
         return referenceResolution
+            .shared(shared)
+            .adapterProject(adapterProject)
+            .strategoRuntimeInput(strategoRuntimeInput)
+            .constraintAnalyzerInput(constraintAnalyzerInput)
+            .classLoaderResourcesInput(classloaderResources)
+            .build();
+    }
+
+    private HoverAdapterCompiler.@Nullable Input buildHover(
+        Shared shared,
+        AdapterProject adapterProject,
+        StrategoRuntimeAdapterCompiler.@Nullable Input strategoRuntimeInput,
+        ConstraintAnalyzerAdapterCompiler.@Nullable Input constraintAnalyzerInput,
+        ClassLoaderResourcesCompiler.Input classloaderResources
+    ) {
+        if(!hoverEnabled) return null;
+        return hover
             .shared(shared)
             .adapterProject(adapterProject)
             .strategoRuntimeInput(strategoRuntimeInput)

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/HoverAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/HoverAdapterCompiler.java
@@ -1,0 +1,108 @@
+package mb.spoofax.compiler.adapter;
+
+import mb.common.util.ListView;
+import mb.pie.api.ExecContext;
+import mb.pie.api.None;
+import mb.pie.api.TaskDef;
+import mb.resource.hierarchical.ResourcePath;
+import mb.spoofax.compiler.language.ClassLoaderResourcesCompiler;
+import mb.spoofax.compiler.util.*;
+import org.immutables.value.Value;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Optional;
+
+@Value.Enclosing
+public class HoverAdapterCompiler implements TaskDef<HoverAdapterCompiler.Input, None> {
+    private final TemplateWriter hoverTaskDefTemplate;
+
+    @Inject public HoverAdapterCompiler(TemplateCompiler templateCompiler) {
+        templateCompiler = templateCompiler.loadingFromClass(getClass());
+
+        this.hoverTaskDefTemplate = templateCompiler.getOrCompileToWriter("editor_services/HoverTaskDef.java.mustache");
+    }
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override public None exec(ExecContext context, Input input) throws IOException {
+        if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
+        final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
+
+        hoverTaskDefTemplate.write(context, input.hoverTaskDef().file(generatedJavaSourcesDirectory), input);
+
+        return None.instance;
+    }
+
+    @Override public Serializable key(Input input) {
+        return input.adapterProject().project().baseDirectory();
+    }
+
+
+    @Value.Immutable
+    public interface Input extends Serializable {
+        class Builder extends HoverAdapterCompilerData.Input.Builder {
+        }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        /// Configuration
+        String hoverStrategy();
+
+
+        /// Kinds of classes (generated/extended/manual)
+
+        @Value.Default default ClassKind classKind() {
+            return ClassKind.Generated;
+        }
+
+
+        /// Adapter project classes
+
+        default ResourcePath generatedJavaSourcesDirectory() {
+            return adapterProject().generatedJavaSourcesDirectory();
+        }
+
+        // Resolve task definitions
+
+        @Value.Default default TypeInfo baseHoverTaskDef() {
+            return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "Hover");
+        }
+
+        Optional<TypeInfo> extendHoverTaskDef();
+
+        default TypeInfo hoverTaskDef() {
+            return extendHoverTaskDef().orElseGet(this::baseHoverTaskDef);
+        }
+
+
+        /// Files information, known up-front for build systems with static dependencies such as Gradle.
+
+        default ListView<ResourcePath> javaSourceFiles() {
+            if(classKind().isManual()) {
+                return ListView.of();
+            }
+            final ResourcePath generatedJavaSourcesDirectory = generatedJavaSourcesDirectory();
+            return ListView.of(
+                hoverTaskDef().file(generatedJavaSourcesDirectory)
+            );
+        }
+
+        /// Automatically provided sub-inputs
+
+        @Value.Auxiliary Shared shared();
+
+        AdapterProject adapterProject();
+
+        StrategoRuntimeAdapterCompiler.Input strategoRuntimeInput();
+
+        ConstraintAnalyzerAdapterCompiler.Input constraintAnalyzerInput();
+
+        ClassLoaderResourcesCompiler.Input classLoaderResourcesInput();
+    }
+}

--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ReferenceResolutionAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ReferenceResolutionAdapterCompiler.java
@@ -36,7 +36,6 @@ public class ReferenceResolutionAdapterCompiler implements TaskDef<ReferenceReso
         if(input.classKind().isManual()) return None.instance; // Nothing to generate: return.
         final ResourcePath generatedJavaSourcesDirectory = input.generatedJavaSourcesDirectory();
 
-        // only generate resolve if we have a strategy
         resolveTaskDefTemplate.write(context, input.resolveTaskDef().file(generatedJavaSourcesDirectory), input);
 
         return None.instance;
@@ -98,20 +97,6 @@ public class ReferenceResolutionAdapterCompiler implements TaskDef<ReferenceReso
             );
         }
 
-        /// Automatically computed values
-
-        @Value.Derived default boolean isMultiFile() {
-            return constraintAnalyzerInput().languageProjectInput().multiFile();
-        }
-
-        @Value.Derived default TypeInfo analyzeTaskDef() {
-            if (this.isMultiFile()) {
-                return constraintAnalyzerInput().analyzeMultiTaskDef();
-            } else {
-                return constraintAnalyzerInput().analyzeTaskDef();
-            }
-        }
-
         /// Automatically provided sub-inputs
 
         @Value.Auxiliary Shared shared();
@@ -120,12 +105,8 @@ public class ReferenceResolutionAdapterCompiler implements TaskDef<ReferenceReso
 
         StrategoRuntimeAdapterCompiler.Input strategoRuntimeInput();
 
-        ParserAdapterCompiler.Input parseInput();
-
         ConstraintAnalyzerAdapterCompiler.Input constraintAnalyzerInput();
 
         ClassLoaderResourcesCompiler.Input classLoaderResourcesInput();
-
-        GetSourceFilesAdapterCompiler.Input getSourceFilesInput();
     }
 }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Instance.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/adapter_project/Instance.java.mustache
@@ -1,5 +1,6 @@
 package {{baseInstance.packageId}};
 
+import mb.common.editor.HoverResult;
 import mb.common.editor.ReferenceResolutionResult;
 import mb.common.message.KeyedMessages;
 import mb.common.message.Messages;
@@ -171,6 +172,16 @@ public class {{baseInstance.id}} implements LanguageInstance{{#parseInjection}},
 {{^hasResolveInjection}}
         return {{resolveInjection.name}}.createTask({{resolveInjection.type.qualifiedId}}.Args.Empty);
 {{/hasResolveInjection}}
+    }
+
+    @Override
+    public Task<Option<HoverResult>> createHoverTask(ResourcePath rootDirectory, ResourceKey file, Region region) {
+{{#hasHoverInjection}}
+        return {{hoverInjection.name}}.createTask(new {{hoverInjection.type.qualifiedId}}.Args(file, rootDirectory, region));
+{{/hasHoverInjection}}
+{{^hasHoverInjection}}
+        return {{hoverInjection.name}}.createTask({{hoverInjection.type.qualifiedId}}.Args.Empty);
+{{/hasHoverInjection}}
     }
 
 {{#parseInjection}}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/constraint_analyzer/AnalyzeFileTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/constraint_analyzer/AnalyzeFileTaskDef.java.mustache
@@ -1,0 +1,133 @@
+package {{baseAnalyzeFileTaskDef.packageId}};
+
+import mb.common.result.Result;
+import mb.common.util.ListView;
+import mb.constraint.common.ConstraintAnalyzerContext;
+import mb.constraint.pie.ConstraintAnalyzeMultiTaskDef;
+import mb.constraint.pie.ConstraintAnalyzeTaskDef;
+import mb.jsglr.common.JsglrParseException;
+import mb.pie.api.ExecContext;
+import mb.pie.api.Supplier;
+import mb.pie.api.TaskDef;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.ResourceKey;
+import mb.resource.hierarchical.ResourcePath;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import javax.inject.Inject;
+import java.io.Serializable;
+import java.util.Optional;
+
+@{{adapterProject.scope.qualifiedId}}
+public class {{baseAnalyzeFileTaskDef.id}} implements TaskDef<{{baseAnalyzeFileTaskDef.id}}.Input, Result<{{baseAnalyzeFileTaskDef.id}}.Output, ?>> {
+    public static final class Input implements Serializable {
+        public final ResourcePath rootDirectory;
+        public final ResourceKey file;
+        public Input(ResourcePath rootDirectory, ResourceKey file) {
+            this.rootDirectory = rootDirectory;
+            this.file = file;
+        }
+
+        @Override public boolean equals(Object o) {
+            if(this == o) return true;
+            if(o == null || getClass() != o.getClass()) return false;
+            Input input = (Input)o;
+            if(!rootDirectory.equals(input.rootDirectory)) return false;
+            return file.equals(input.file);
+        }
+
+        @Override public int hashCode() {
+            int result = rootDirectory.hashCode();
+            result = 31 * result + file.hashCode();
+            return result;
+        }
+
+        @Override public String toString() {
+            return "Input{" +
+                "rootDirectory=" + rootDirectory +
+                ", file=" + file +
+                '}';
+        }
+    }
+
+    public static final class Output implements Serializable {
+        public final ConstraintAnalyzerContext analyzerContext;
+        public final IStrategoTerm inputAst;
+        public final IStrategoTerm analyzedAst;
+        public Output(ConstraintAnalyzerContext analyzerContext, IStrategoTerm inputAst, IStrategoTerm analyzedAst) {
+            this.analyzerContext = analyzerContext;
+            this.inputAst = inputAst;
+            this.analyzedAst = analyzedAst;
+        }
+
+        @Override public boolean equals(Object o) {
+            if(this == o) return true;
+            if(o == null || getClass() != o.getClass()) return false;
+            Output output = (Output)o;
+            if(!analyzerContext.equals(output.analyzerContext)) return false;
+            if(!inputAst.equals(output.inputAst)) return false;
+            return analyzedAst.equals(output.analyzedAst);
+        }
+
+        @Override public int hashCode() {
+            int result = analyzerContext.hashCode();
+            result = 31 * result + inputAst.hashCode();
+            result = 31 * result + analyzedAst.hashCode();
+            return result;
+        }
+    }
+
+    private final {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources;
+    private final {{parseInput.parseTaskDef.qualifiedId}} parse;
+    private final {{runtimeAnalyzeTaskDef.qualifiedId}} analyze;
+    private final {{getSourceFilesInput.getSourceFilesTaskDef.qualifiedId}} getSourceFiles;
+
+    @Inject
+    public {{baseAnalyzeFileTaskDef.id}}(
+        {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources,
+        {{parseInput.parseTaskDef.qualifiedId}} parse,
+        {{runtimeAnalyzeTaskDef.qualifiedId}} analyze,
+        {{getSourceFilesInput.getSourceFilesTaskDef.qualifiedId}} getSourceFiles
+    ) {
+        this.classLoaderResources = classLoaderResources;
+        this.parse = parse;
+        this.analyze = analyze;
+        this.getSourceFiles = getSourceFiles;
+    }
+
+    @Override public String getId() {
+        return "{{baseAnalyzeFileTaskDef.qualifiedId}}";
+    }
+
+{{#isMultiFile}}
+    @Override public Result<Output, ?> exec(ExecContext context, Input input) throws Exception {
+        context.require(classLoaderResources.tryGetAsLocalResource(getClass()), ResourceStampers.hashFile());
+        final Result<ConstraintAnalyzeMultiTaskDef.SingleFileOutput, ?> analysis = context.require(
+            analyze.createSingleFileOutputSupplier(
+                new ConstraintAnalyzeMultiTaskDef.Input(
+                    input.rootDirectory,
+                    parse.createRecoverableMultiAstSupplierFunction(getSourceFiles.createFunction())
+                ),
+                input.file
+            )
+        );
+        return analysis.map(output -> new Output(output.context, output.result.ast, output.result.analysis));
+    }
+{{/isMultiFile}}
+{{^isMultiFile}}
+    @Override public Result<Output, ?> exec(ExecContext context, Input input) throws Exception {
+        context.require(classLoaderResources.tryGetAsLocalResource(getClass()), ResourceStampers.hashFile());
+        final Supplier<Result<IStrategoTerm, JsglrParseException>> astSupplier = parse
+            .inputBuilder()
+            .withFile(input.file)
+            .rootDirectoryHint(Optional.of(input.rootDirectory))
+            .fileHint(input.file)
+            .buildAstSupplier();
+        final Result<ConstraintAnalyzeTaskDef.Output, ?> analysis = context.require(
+            analyze,
+            new ConstraintAnalyzeTaskDef.Input(input.file, astSupplier)
+        );
+        return analysis.map(output -> new Output(output.context, output.result.ast, output.result.analysis));
+    }
+{{/isMultiFile}}
+}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/editor_services/HoverTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/editor_services/HoverTaskDef.java.mustache
@@ -1,0 +1,123 @@
+package {{baseHoverTaskDef.packageId}};
+
+import mb.aterm.common.TermToString;
+import mb.common.editor.HoverResult;
+import mb.common.option.Option;
+import mb.common.region.Region;
+import mb.common.result.Result;
+import mb.jsglr.common.TermTracer;
+import mb.pie.api.ExecContext;
+import mb.pie.api.None;
+import mb.pie.api.OutTransient;
+import mb.pie.api.TaskDef;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.ResourceKey;
+import mb.resource.hierarchical.ResourcePath;
+import mb.stratego.common.StrategoException;
+import mb.stratego.common.StrategoRuntime;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.io.Serializable;
+import java.util.Collection;
+
+@{{adapterProject.scope.qualifiedId}}
+public class {{baseHoverTaskDef.id}} implements TaskDef<{{baseHoverTaskDef.id}}.Args, Option<HoverResult>> {
+    public static class Args implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public final ResourceKey file;
+        public final ResourcePath rootDirectory;
+        public final Region position;
+        public Args(ResourceKey file, ResourcePath rootDirectory, Region position) {
+            this.file = file;
+            this.rootDirectory = rootDirectory;
+            this.position = position;
+        }
+
+        @Override public boolean equals(Object o) {
+            if(this == o) return true;
+            if(o == null || getClass() != o.getClass()) return false;
+            Args args = (Args)o;
+            if(!file.equals(args.file)) return false;
+            if(!rootDirectory.equals(args.rootDirectory)) return false;
+            if(!position.equals(args.position)) return false;
+            return true;
+        }
+
+        @Override public int hashCode() {
+            int result = file.hashCode();
+            result = 31 * result + rootDirectory.hashCode();
+            result = 31 * result + position.hashCode();
+            return result;
+        }
+
+        @Override public String toString() {
+            return "Args{" +
+                "file=" + file +
+                ", rootDirectory=" + rootDirectory +
+                ", offset=" + position +
+                '}';
+        }
+    }
+
+    private final {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources;
+    private final {{constraintAnalyzerInput.analyzeFileTaskDef.qualifiedId}} analyzeFile;
+    private final {{strategoRuntimeInput.getStrategoRuntimeProviderTaskDef.qualifiedId}} getStrategoRuntimeProvider;
+
+    @Inject
+    public {{baseHoverTaskDef.id}}(
+        {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources,
+        {{constraintAnalyzerInput.analyzeFileTaskDef.qualifiedId}} analyzeFile,
+        {{strategoRuntimeInput.getStrategoRuntimeProviderTaskDef.qualifiedId}} getStrategoRuntimeProvider
+    ) {
+        this.classLoaderResources = classLoaderResources;
+        this.analyzeFile = analyzeFile;
+        this.getStrategoRuntimeProvider = getStrategoRuntimeProvider;
+    }
+
+    @Override public String getId() {
+        return "{{baseHoverTaskDef.qualifiedId}}";
+    }
+
+    @Override public Option<HoverResult> exec(ExecContext context, Args args) throws Exception {
+        context.require(classLoaderResources.tryGetAsLocalResource(getClass()), ResourceStampers.hashFile());
+        final Result<{{constraintAnalyzerInput.analyzeFileTaskDef.qualifiedId}}.Output, ?> analysis = context.require(
+            analyzeFile,
+            new {{constraintAnalyzerInput.analyzeFileTaskDef.qualifiedId}}.Input(args.rootDirectory, args.file)
+        );
+
+        if(!analysis.isOk()) {
+            return Option.ofNone();
+        }
+
+        final OutTransient<Provider<StrategoRuntime>> strategoProvider = context.require(getStrategoRuntimeProvider, None.instance);
+        final StrategoRuntime strategoRuntime = strategoProvider.getValue().get().addContextObject(analysis.get().analyzerContext);
+
+        // find the AST nodes for the relevant offset (innermost first)
+        final Collection<IStrategoTerm> terms = TermTracer.getTermsEncompassingRegion(analysis.get().inputAst, args.position);
+
+        // attempt to run stratego strategy on every ast in turn
+        for(IStrategoTerm term : terms) {
+            try {
+                final IStrategoTerm input = strategoRuntime.getTermFactory().makeTuple(
+                    term,
+                    strategoRuntime.getTermFactory().makeList(),
+                    term,
+                    strategoRuntime.getTermFactory().makeString("."),
+                    strategoRuntime.getTermFactory().makeString(args.file.asString())
+                );
+                final IStrategoTerm result = strategoRuntime.invoke("{{hoverStrategy}}", input);
+
+                // Convert the result to a string.
+                return Option.ofSome(
+                    new HoverResult(TermTracer.getRegion(term), TermToString.toString(result))
+                );
+            } catch(StrategoException ex) {
+                // ignored
+            }
+        }
+
+        return Option.ofNone();
+    }
+}

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/editor_services/ResolveTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/editor_services/ResolveTaskDef.java.mustache
@@ -6,21 +6,14 @@ import mb.common.option.Option;
 import mb.common.region.Region;
 import mb.common.result.Result;
 import mb.common.util.ListView;
-import mb.constraint.pie.ConstraintAnalyzeMultiTaskDef;
-import mb.constraint.pie.ConstraintAnalyzeTaskDef;
-import mb.jsglr.common.JsglrParseException;
 import mb.jsglr.common.TermTracer;
 import mb.pie.api.ExecContext;
 import mb.pie.api.None;
 import mb.pie.api.OutTransient;
-import mb.pie.api.Supplier;
 import mb.pie.api.TaskDef;
 import mb.pie.api.stamp.resource.ResourceStampers;
 import mb.resource.ResourceKey;
 import mb.resource.hierarchical.ResourcePath;
-import mb.resource.hierarchical.match.ResourceMatcher;
-import mb.resource.hierarchical.match.path.PathMatcher;
-import mb.resource.hierarchical.walk.ResourceWalker;
 import mb.stratego.common.StrategoException;
 import mb.stratego.common.StrategoRuntime;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -34,7 +27,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @{{adapterProject.scope.qualifiedId}}
@@ -82,23 +74,17 @@ public class {{baseResolveTaskDef.id}} implements TaskDef<{{baseResolveTaskDef.i
     }
 
     private final {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources;
-    private final {{parseInput.parseTaskDef.qualifiedId}} parse;
-    private final {{analyzeTaskDef.qualifiedId}} analyze;
-    private final {{getSourceFilesInput.getSourceFilesTaskDef.qualifiedId}} getSourceFiles;
+    private final {{constraintAnalyzerInput.analyzeFileTaskDef.qualifiedId}} analyzeFile;
     private final {{strategoRuntimeInput.getStrategoRuntimeProviderTaskDef.qualifiedId}} getStrategoRuntimeProvider;
 
     @Inject
     public {{baseResolveTaskDef.id}}(
         {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources,
-        {{parseInput.parseTaskDef.qualifiedId}} parse,
-        {{analyzeTaskDef.qualifiedId}} analyze,
-        {{getSourceFilesInput.getSourceFilesTaskDef.qualifiedId}} getSourceFiles,
+        {{constraintAnalyzerInput.analyzeFileTaskDef.qualifiedId}} analyzeFile,
         {{strategoRuntimeInput.getStrategoRuntimeProviderTaskDef.qualifiedId}} getStrategoRuntimeProvider
     ) {
         this.classLoaderResources = classLoaderResources;
-        this.parse = parse;
-        this.analyze = analyze;
-        this.getSourceFiles = getSourceFiles;
+        this.analyzeFile = analyzeFile;
         this.getStrategoRuntimeProvider = getStrategoRuntimeProvider;
     }
 
@@ -109,48 +95,22 @@ public class {{baseResolveTaskDef.id}} implements TaskDef<{{baseResolveTaskDef.i
     @Override public Option<ReferenceResolutionResult> exec(ExecContext context, Args args) throws Exception {
         context.require(classLoaderResources.tryGetAsLocalResource(getClass()), ResourceStampers.hashFile());
 
-        final ResourceKey file = args.file;
-
-        // Step 1: get analysis
-{{#isMultiFile}}
-        final ListView<ResourceKey> sourceFiles = context.require(getSourceFiles, args.rootDirectory);
-
-        final Result<ConstraintAnalyzeMultiTaskDef.SingleFileOutput, ?> analysis = context.require(
-            analyze.createSingleFileOutputSupplier(
-                new ConstraintAnalyzeMultiTaskDef.Input(
-                    args.rootDirectory,
-                    parse.createRecoverableMultiAstSupplierFunction(getSourceFiles.createFunction())
-                ),
-                args.file
-            )
+        final Result<{{constraintAnalyzerInput.analyzeFileTaskDef.qualifiedId}}.Output, ?> analysis = context.require(
+            analyzeFile,
+            new {{constraintAnalyzerInput.analyzeFileTaskDef.qualifiedId}}.Input(args.rootDirectory, args.file)
         );
-{{/isMultiFile}}
-{{^isMultiFile}}
-        final Supplier<Result<IStrategoTerm, JsglrParseException>> astSupplier = parse
-            .inputBuilder()
-            .withFile(file)
-            .rootDirectoryHint(Optional.of(args.rootDirectory))
-            .fileHint(file)
-            .buildAstSupplier();
-
-        final Result<ConstraintAnalyzeTaskDef.Output, ?> analysis = context.require(
-            analyze,
-            new ConstraintAnalyzeTaskDef.Input(file, astSupplier)
-        );
-{{/isMultiFile}}
 
         if(!analysis.isOk()) {
             return Option.ofNone();
         }
 
-        // Step 2: get a stratego instance
         final OutTransient<Provider<StrategoRuntime>> strategoProvider = context.require(getStrategoRuntimeProvider, None.instance);
-        final StrategoRuntime strategoRuntime = strategoProvider.getValue().get().addContextObject(analysis.get().context);
+        final StrategoRuntime strategoRuntime = strategoProvider.getValue().get().addContextObject(analysis.get().analyzerContext);
 
-        // Step 3: find the AST nodes for the relevant offset (innermost first)
-        final Collection<IStrategoTerm> terms = TermTracer.getTermsEncompassingRegion(analysis.get().result.ast, args.position);
+        // find the AST nodes for the relevant offset (innermost first)
+        final Collection<IStrategoTerm> terms = TermTracer.getTermsEncompassingRegion(analysis.get().inputAst, args.position);
 
-        // Step 3: run our stratego strategy, finding the first term that doesn't fail
+        // attempt to run stratego strategy on every ast in turn
         for(IStrategoTerm term : terms) {
             try {
                 final IStrategoTerm input = strategoRuntime.getTermFactory().makeTuple(
@@ -158,7 +118,7 @@ public class {{baseResolveTaskDef.id}} implements TaskDef<{{baseResolveTaskDef.i
                     strategoRuntime.getTermFactory().makeList(),
                     term,
                     strategoRuntime.getTermFactory().makeString("."),
-                    strategoRuntime.getTermFactory().makeString(file.asString())
+                    strategoRuntime.getTermFactory().makeString(args.file.asString())
                 );
                 final IStrategoTerm result = strategoRuntime.invoke("{{resolveStrategy}}", input);
 

--- a/core/spoofax.core/src/main/java/mb/spoofax/core/language/LanguageInstance.java
+++ b/core/spoofax.core/src/main/java/mb/spoofax/core/language/LanguageInstance.java
@@ -1,5 +1,6 @@
 package mb.spoofax.core.language;
 
+import mb.common.editor.HoverResult;
 import mb.common.editor.ReferenceResolutionResult;
 import mb.common.message.KeyedMessages;
 import mb.common.option.Option;
@@ -52,6 +53,8 @@ public interface LanguageInstance {
 
 
     Task<Option<ReferenceResolutionResult>> createResolveTask(ResourcePath rootDirectory, ResourceKey file, Region region);
+
+    Task<Option<HoverResult>> createHoverTask(ResourcePath rootDirectory, ResourceKey file, Region region);
 
 
     CollectionView<CommandDef<?>> getCommandDefs();

--- a/core/spoofax.core/src/main/java/mb/spoofax/core/language/taskdef/NoneHoverTaskDef.java
+++ b/core/spoofax.core/src/main/java/mb/spoofax/core/language/taskdef/NoneHoverTaskDef.java
@@ -1,0 +1,18 @@
+package mb.spoofax.core.language.taskdef;
+
+import mb.common.editor.HoverResult;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.Serializable;
+
+public class NoneHoverTaskDef extends NoneTaskDef<NoneHoverTaskDef.Args, HoverResult> {
+    public static final class Args implements Serializable {
+        public static Args Empty = new Args();
+    }
+
+    @Inject
+    protected NoneHoverTaskDef(@Named("packageId") String idPrefix) {
+        super(idPrefix);
+    }
+}

--- a/core/spoofax.eclipse/src/main/java/mb/spoofax/eclipse/editor/SpoofaxSourceViewerConfiguration.java
+++ b/core/spoofax.eclipse/src/main/java/mb/spoofax/eclipse/editor/SpoofaxSourceViewerConfiguration.java
@@ -28,7 +28,7 @@ public class SpoofaxSourceViewerConfiguration extends TextSourceViewerConfigurat
     }
 
     @Override public ITextHover getTextHover(ISourceViewer sourceViewer, String contentType) {
-        return new SpoofaxTextHover(sourceViewer);
+        return new SpoofaxTextHover(sourceViewer, editorBase, languageComponent, pieComponent);
     }
 
     public IInformationControlCreator getInformationControlCreator(ISourceViewer sourceViewer) {

--- a/core/spoofax.eclipse/src/main/java/mb/spoofax/eclipse/editor/SpoofaxTextHover.java
+++ b/core/spoofax.eclipse/src/main/java/mb/spoofax/eclipse/editor/SpoofaxTextHover.java
@@ -1,12 +1,55 @@
 package mb.spoofax.eclipse.editor;
 
+import mb.common.editor.HoverResult;
+import mb.common.option.Option;
+import mb.pie.api.ExecException;
+import mb.pie.api.Interactivity;
+import mb.pie.api.MixedSession;
+import mb.pie.api.TopDownSession;
+import mb.pie.api.UncheckedExecException;
+import mb.pie.dagger.PieComponent;
+import mb.resource.ResourceKey;
+import mb.resource.hierarchical.ResourcePath;
+import mb.spoofax.core.language.LanguageComponent;
+import mb.spoofax.eclipse.resource.EclipseResourcePath;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.jface.text.DefaultTextHover;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.ISourceViewer;
 
+import java.util.Collections;
+
 public class SpoofaxTextHover extends DefaultTextHover {
-    public SpoofaxTextHover(ISourceViewer sourceViewer) {
+    private final SpoofaxEditorBase editorBase;
+    private final @Nullable LanguageComponent languageComponent;
+    private final @Nullable PieComponent pieComponent;
+
+    public SpoofaxTextHover(ISourceViewer sourceViewer, SpoofaxEditorBase editorBase, @Nullable LanguageComponent languageComponent, @Nullable PieComponent pieComponent) {
         super(sourceViewer);
+
+        this.editorBase = editorBase;
+        this.languageComponent = languageComponent;
+        this.pieComponent = pieComponent;
+    }
+
+    @Override public String getHoverInfo(ITextViewer textViewer, IRegion hoverRegion) {
+        final String baseAnnotation = super.getHoverInfo(textViewer, hoverRegion);
+        final Option<HoverResult> hover = resolveHover(hoverRegion);
+
+        if(!hover.isSome()) return baseAnnotation;
+
+        if(baseAnnotation != null) {
+            return baseAnnotation + "\n\n" + hover.unwrap().getText();
+        }
+
+        return hover.unwrap().getText();
+    }
+
+    @Override public IRegion getHoverRegion(ITextViewer textViewer, int offset) {
+        return new Region(offset, 1);
     }
 
     @Override protected boolean isIncluded(Annotation annotation) {
@@ -18,6 +61,34 @@ public class SpoofaxTextHover extends DefaultTextHover {
                 return false;
             default:
                 return true;
+        }
+    }
+
+    private Option<HoverResult> resolveHover(IRegion region) {
+        if(languageComponent == null || pieComponent == null) {
+            return Option.ofNone();
+        }
+
+        final ResourceKey file = new EclipseResourcePath(editorBase.file);
+        final @Nullable ResourcePath rootDirectory = editorBase.project != null ? new EclipseResourcePath(editorBase.project) : null;
+        final mb.common.region.Region targetRegion = mb.common.region.Region.fromOffsetLength(region.getOffset(), region.getLength());
+
+        // We cannot do hover if we're not in a project.
+        if(rootDirectory == null) {
+            return Option.ofNone();
+        }
+
+        try(final MixedSession mixedSession = pieComponent.newSession()) {
+            final TopDownSession topDownSession = mixedSession.updateAffectedBy(Collections.emptySet(), Collections.singleton(Interactivity.Interactive));
+
+            return topDownSession.requireWithoutObserving(
+                languageComponent.getLanguageInstance().createHoverTask(rootDirectory, file, targetRegion)
+            );
+        } catch(ExecException e) {
+            // bubble error up to eclipse, which will handle it and show a dialog
+            throw new UncheckedExecException("Retrieving hover text failed unexpectedly", e);
+        } catch(InterruptedException e) {
+            return Option.ofNone();
         }
     }
 }

--- a/example/calc/calc/spoofaxc.cfg
+++ b/example/calc/calc/spoofaxc.cfg
@@ -23,6 +23,9 @@ editor-services {
   reference-resolution = stratego {
     strategy = strategy editor-resolve
   }
+  hover = stratego {
+    strategy = strategy editor-hover
+  }
 }
 
 task-def mb.calc.task.CalcToJava

--- a/example/calc/calc/src/main.str2
+++ b/example/calc/calc/src/main.str2
@@ -19,3 +19,4 @@ rules
 
   editor-analyze = stx-editor-analyze(pre-analyze, post-analyze|"main", "programOk")
   editor-resolve = stx-editor-resolve
+  editor-hover   = stx-editor-hover

--- a/example/tiger/manual/tiger.spoofax/src/main/java/mb/tiger/spoofax/TigerInstance.java
+++ b/example/tiger/manual/tiger.spoofax/src/main/java/mb/tiger/spoofax/TigerInstance.java
@@ -1,5 +1,6 @@
 package mb.tiger.spoofax;
 
+import mb.common.editor.HoverResult;
 import mb.common.editor.ReferenceResolutionResult;
 import mb.common.message.KeyedMessages;
 import mb.common.option.Option;
@@ -28,6 +29,7 @@ import mb.spoofax.core.language.command.CommandDef;
 import mb.spoofax.core.language.command.arg.RawArgs;
 import mb.spoofax.core.language.menu.CommandAction;
 import mb.spoofax.core.language.menu.MenuItem;
+import mb.spoofax.core.language.taskdef.NoneHoverTaskDef;
 import mb.spoofax.core.language.taskdef.NoneResolveTaskDef;
 import mb.spt.api.parse.ParseResult;
 import mb.spt.api.parse.TestableParse;
@@ -61,6 +63,7 @@ public class TigerInstance implements LanguageInstance, TestableParse {
     private final TigerIdeTokenize tokenize;
     private final TigerCompleteTaskDef complete;
     private final NoneResolveTaskDef resolve;
+    private final NoneHoverTaskDef hover;
 
     private final TigerShowParsedAstCommand showParsedAstCommand;
     private final TigerShowPrettyPrintedTextCommand showPrettyPrintedTextCommand;
@@ -82,6 +85,7 @@ public class TigerInstance implements LanguageInstance, TestableParse {
         TigerIdeTokenize tokenize,
         TigerCompleteTaskDef complete,
         NoneResolveTaskDef resolve,
+        NoneHoverTaskDef hover,
 
         TigerShowParsedAstCommand showParsedAstCommand,
         TigerShowPrettyPrintedTextCommand showPrettyPrintedTextCommand,
@@ -101,6 +105,7 @@ public class TigerInstance implements LanguageInstance, TestableParse {
         this.tokenize = tokenize;
         this.complete = complete;
         this.resolve = resolve;
+        this.hover = hover;
 
         this.showParsedAstCommand = showParsedAstCommand;
         this.showPrettyPrintedTextCommand = showPrettyPrintedTextCommand;
@@ -153,6 +158,11 @@ public class TigerInstance implements LanguageInstance, TestableParse {
     @Override
     public Task<Option<ReferenceResolutionResult>> createResolveTask(ResourcePath rootDirectory, ResourceKey file, Region region) {
         return resolve.createTask(NoneResolveTaskDef.Args.Empty);
+    }
+
+    @Override
+    public Task<Option<HoverResult>> createHoverTask(ResourcePath rootDirectory, ResourceKey file, Region region) {
+        return hover.createTask(NoneHoverTaskDef.Args.Empty);
     }
 
     @Override public CollectionView<CommandDef<?>> getCommandDefs() {

--- a/lwb/metalang/cfg/cfg.spoofax2/syntax/part/language_adapter.sdf3
+++ b/lwb/metalang/cfg/cfg.spoofax2/syntax/part/language_adapter.sdf3
@@ -4,10 +4,11 @@ imports
 
   part
   expr
-  
+
 context-free sorts
   EditorServicesOption
   ReferenceResolutionVariant
+  HoverVariant
 
 context-free syntax
 
@@ -22,13 +23,18 @@ context-free syntax
 ]>
 
 context-free syntax
- 
+
   Part.EditorServicesSection = <editor-services {
     <{EditorServicesOption "\n"}*>
   }>
-  
+
   EditorServicesOption.EditorServicesReferenceResolutionOption = <reference-resolution = <ReferenceResolutionVariant>>
-  
+  EditorServicesOption.EditorServicesHoverOption = <hover = <HoverVariant>>
+
   ReferenceResolutionVariant.ReferenceResolutionStrategoVariant = <stratego {
+    strategy = <Expr>
+  }>
+
+  HoverVariant.HoverStrategoVariant = <stratego {
     strategy = <Expr>
   }>

--- a/lwb/metalang/cfg/cfg.spoofax2/trans/statsem/part/language_adapter.stx
+++ b/lwb/metalang/cfg/cfg.spoofax2/trans/statsem/part/language_adapter.stx
@@ -5,7 +5,7 @@ imports
   statsem/part
   statsem/expr
   statsem/expr/menu_item
-  
+
   signatures/part/language_adapter-sig
 
 rules
@@ -27,7 +27,14 @@ rules // Editor services section and options
 
   editorServicesOptionOk(s, EditorServicesReferenceResolutionOption(e)) :-
     referenceResolutionVariantOk(s, e).
-    
+
+  editorServicesOptionOk(s, EditorServicesHoverOption(e)) :-
+    hoverVariantOk(s, e).
+
   referenceResolutionVariantOk : scope * ReferenceResolutionVariant
   referenceResolutionVariantOk(s, ReferenceResolutionStrategoVariant(e)) :-
-    typeOfExpr(s, e) == STRATEGY() | error $[Expected Stratego strategy identifier].
+    typeOfExpr(s, e) == STRATEGY() | error $[Expected Stratego strategy identifier]@e.
+
+  hoverVariantOk : scope * HoverVariant
+  hoverVariantOk(s, HoverStrategoVariant(e)) :-
+    typeOfExpr(s, e) == STRATEGY() | error $[Expected Stratego strategy identifier]@e.

--- a/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/convert/CfgAstToObject.java
+++ b/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/convert/CfgAstToObject.java
@@ -19,6 +19,7 @@ import mb.spoofax.compiler.adapter.AdapterProject;
 import mb.spoofax.compiler.adapter.AdapterProjectCompiler;
 import mb.spoofax.compiler.adapter.AdapterProjectCompilerInputBuilder;
 import mb.spoofax.compiler.adapter.ConstraintAnalyzerAdapterCompiler;
+import mb.spoofax.compiler.adapter.HoverAdapterCompiler;
 import mb.spoofax.compiler.adapter.MultilangAnalyzerAdapterCompiler;
 import mb.spoofax.compiler.adapter.ParserAdapterCompiler;
 import mb.spoofax.compiler.adapter.ReferenceResolutionAdapterCompiler;
@@ -272,6 +273,12 @@ public class CfgAstToObject {
                 final ReferenceResolutionAdapterCompiler.Input.Builder builder = adapterBuilder.withReferenceResolution();
                 // todo: should probably actually look at the variant here
                 referenceResolutionSubParts.forOneSubtermAsString("StrategyId", builder::resolveStrategy);
+            });
+
+            // Hover
+            subParts.getAllSubTermsInListAsParts("EditorServicesHoverOption").ifSome(hoverSubParts -> {
+                final HoverAdapterCompiler.Input.Builder builder = adapterBuilder.withHover();
+                hoverSubParts.forOneSubtermAsString("StrategyId", builder::hoverStrategy);
             });
         });
 

--- a/lwb/spoofax.lwb.compiler/src/main/resources/mb/spoofax/lwb/compiler/generator/main.str2.mustache
+++ b/lwb/spoofax.lwb.compiler/src/main/resources/mb/spoofax/lwb/compiler/generator/main.str2.mustache
@@ -22,3 +22,4 @@ rules // Analysis
   editor-analyze = stx-editor-analyze(pre-analyze, post-analyze|"main", "programOk")
 {{/multiFileAnalysis}}
   editor-resolve = stx-editor-resolve
+  editor-hover   = stx-editor-hover

--- a/lwb/spoofax.lwb.compiler/src/main/resources/mb/spoofax/lwb/compiler/generator/spoofaxc.cfg.mustache
+++ b/lwb/spoofax.lwb.compiler/src/main/resources/mb/spoofax/lwb/compiler/generator/spoofaxc.cfg.mustache
@@ -30,4 +30,7 @@ editor-services {
   reference-resolution = stratego {
     strategy = strategy editor-resolve
   }
+  hover = stratego {
+    strategy = strategy editor-hover
+  }
 }

--- a/lwb/spoofax.lwb.dynamicloading/src/test/java/mb/spoofax/lwb/dynamicloading/CharsTestBase.java
+++ b/lwb/spoofax.lwb.dynamicloading/src/test/java/mb/spoofax/lwb/dynamicloading/CharsTestBase.java
@@ -86,6 +86,10 @@ class CharsTestBase extends TestBase {
         return report.hasTaskDefExecuted(language.getCompileInput().adapterProjectInput().checkTaskDef().qualifiedId());
     }
 
+    boolean hasHoverTaskExecuted(MetricsTracer.Report report, DynamicLanguage language) {
+        return report.hasTaskDefExecuted(language.getCompileInput().adapterProjectInput().hover().get().hoverTaskDef().qualifiedId());
+    }
+
 
     TopDownSession modifyStyler(MixedSession session, CompileLanguageInput input) throws IOException, ExecException, InterruptedException {
         final ResourcePath path = input.compileLanguageSpecificationInput().esv().get().mainFile();

--- a/lwb/spoofax.lwb.dynamicloading/src/test/resources/mb/spoofax/lwb/dynamicloading/chars/spoofaxc.cfg
+++ b/lwb/spoofax.lwb.dynamicloading/src/test/resources/mb/spoofax/lwb/dynamicloading/chars/spoofaxc.cfg
@@ -17,6 +17,14 @@ parser {
 styler {}
 constraint-analyzer {}
 stratego-runtime {}
+editor-services {
+  reference-resolution = stratego {
+    strategy = strategy editor-resolve
+  }
+  hover = stratego {
+    strategy = strategy editor-hover
+  }
+}
 
 task-def mb.chars.CharsRemoveA
 let showRemoveA = task-def mb.chars.CharsDebugRemoveA

--- a/lwb/spoofax.lwb.dynamicloading/src/test/resources/mb/spoofax/lwb/dynamicloading/chars/src/main.str2
+++ b/lwb/spoofax.lwb.dynamicloading/src/test/resources/mb/spoofax/lwb/dynamicloading/chars/src/main.str2
@@ -11,3 +11,5 @@ imports
 rules // Analysis boilerplate
 
   editor-analyze = stx-editor-analyze(id, id|"main", "programOk")
+  editor-resolve = stx-editor-resolve
+  editor-hover   = stx-editor-hover

--- a/lwb/spoofax.lwb.dynamicloading/src/test/resources/mb/spoofax/lwb/dynamicloading/chars/src/main.stx
+++ b/lwb/spoofax.lwb.dynamicloading/src/test/resources/mb/spoofax/lwb/dynamicloading/chars/src/main.stx
@@ -11,5 +11,5 @@ rules
 
   exprOk : Expr
   exprOk(Chars("")) :- false | error $[The character combination '' is not allowed].
-  exprOk(_).
+  exprOk(t) :- @t.type := "Chars".
   exprsOk maps exprOk(list(*))


### PR DESCRIPTION
This PR contains the following:
- A new AnalyzeFile task that abstracts out the parsing and analysis of a single file and returns the appropriate analysis context. This will do the right thing for both single- and multi-file analysis and use the `GetSourceFiles` task where appropriate.
- A new HoverAdapterCompiler responsible for compiling the HoverTaskDef, when configured.
- Eclipse support for the new hover task.
- Enable hover support by default for languages, enable it for calc.
- Various tests to ensure hover works.

Future things that still need to be addressed, but not as part of this PR:
- The initial analysis/hover action seems slower, even though the analysis should already be cached.
- AnalyzeFile duplicates information since it only exports an output created by a different task. Ideally we should have the ability in PIE to mark this task as such.
- Resolution seems to be broken at some point, but I confirmed that none of these changes were the cause.
- Hover/Resolution should be enabled for some of the meta languages (SDF3 and Statix in particular).