### PR TITLE
Add command for showing the Statix scope graph AST of a file

### DIFF
--- a/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
+++ b/core/spoofax.compiler/src/main/java/mb/spoofax/compiler/adapter/ConstraintAnalyzerAdapterCompiler.java
@@ -41,6 +41,7 @@ public class ConstraintAnalyzerAdapterCompiler {
     private final TemplateWriter showPreAnalyzeAstTaskDef;
     private final TemplateWriter showAnalyzedAstTaskDef;
     private final TemplateWriter showScopeGraphTaskDef;
+    private final TemplateWriter showScopeGraphAstTaskDef;
 
     @Inject public ConstraintAnalyzerAdapterCompiler(TemplateCompiler templateCompiler) {
         templateCompiler = templateCompiler.loadingFromClass(getClass());
@@ -50,6 +51,7 @@ public class ConstraintAnalyzerAdapterCompiler {
         this.showPreAnalyzeAstTaskDef = templateCompiler.getOrCompileToWriter("constraint_analyzer/ShowPreAnalyzeAstTaskDef.java.mustache");
         this.showAnalyzedAstTaskDef = templateCompiler.getOrCompileToWriter("constraint_analyzer/ShowAnalyzedAstTaskDef.java.mustache");
         this.showScopeGraphTaskDef = templateCompiler.getOrCompileToWriter("constraint_analyzer/ShowScopeGraphTaskDef.java.mustache");
+        this.showScopeGraphAstTaskDef = templateCompiler.getOrCompileToWriter("constraint_analyzer/ShowScopeGraphAstTaskDef.java.mustache");
     }
 
 
@@ -65,6 +67,7 @@ public class ConstraintAnalyzerAdapterCompiler {
         showAnalyzedAstTaskDef.write(context, input.baseShowAnalyzedAstTaskDef().file(generatedJavaSourcesDirectory), input);
         if(input.languageProjectInput().enableStatix()) {
             showScopeGraphTaskDef.write(context, input.baseShowScopeGraphTaskDef().file(generatedJavaSourcesDirectory), input);
+            showScopeGraphAstTaskDef.write(context, input.baseShowScopeGraphAstTaskDef().file(generatedJavaSourcesDirectory), input);
         }
         return None.instance;
     }
@@ -205,8 +208,31 @@ public class ConstraintAnalyzerAdapterCompiler {
             return CommandDefRepr.builder()
                 .type(adapterProject().commandPackageId(), shared().defaultClassPrefix() + "ShowScopeGraphCommand")
                 .taskDefType(showScopeGraphTaskDef())
-                .displayName("Show scope graph")
+                .displayName("Show formatted scope graph")
                 .description("Shows the scope graph")
+                .addParams("rootDirectory", TypeInfo.of(ResourcePath.class), true, Optional.empty(), Collections.singletonList(ArgProviderRepr.enclosingContext(EnclosingCommandContextType.Project)))
+                .addParams("file", TypeInfo.of(ResourcePath.class), true, Optional.empty(), Collections.singletonList(ArgProviderRepr.context(CommandContextType.ReadableResource)))
+                .build();
+        }
+
+        // Show scope graph AST task definition and command
+
+        @Value.Default default TypeInfo baseShowScopeGraphAstTaskDef() {
+            return TypeInfo.of(adapterProject().taskPackageId(), shared().defaultClassPrefix() + "ShowScopeGraphAst");
+        }
+
+        Optional<TypeInfo> extendShowScopeGraphAstTaskDef();
+
+        default TypeInfo showScopeGraphAstTaskDef() {
+            return extendShowScopeGraphAstTaskDef().orElseGet(this::baseShowScopeGraphAstTaskDef);
+        }
+
+        @Value.Default default CommandDefRepr showScopeGraphAstCommand() {
+            return CommandDefRepr.builder()
+                .type(adapterProject().commandPackageId(), shared().defaultClassPrefix() + "ShowScopeGraphAstCommand")
+                .taskDefType(showScopeGraphAstTaskDef())
+                .displayName("Show raw scope graph")
+                .description("Shows the scope graph in raw ATerm format")
                 .addParams("rootDirectory", TypeInfo.of(ResourcePath.class), true, Optional.empty(), Collections.singletonList(ArgProviderRepr.enclosingContext(EnclosingCommandContextType.Project)))
                 .addParams("file", TypeInfo.of(ResourcePath.class), true, Optional.empty(), Collections.singletonList(ArgProviderRepr.context(CommandContextType.ReadableResource)))
                 .build();
@@ -230,6 +256,8 @@ public class ConstraintAnalyzerAdapterCompiler {
             if(languageProjectInput().enableStatix()) {
                 menuItems.add(MenuItemRepr.commandAction(CommandActionRepr.builder().manualOnce(showScopeGraphCommand()).addRequiredResourceTypes(HierarchicalResourceType.File).enclosingProjectRequired().build()));
                 menuItems.add(MenuItemRepr.commandAction(CommandActionRepr.builder().manualContinuous(showScopeGraphCommand()).addRequiredResourceTypes(HierarchicalResourceType.File).enclosingProjectRequired().build()));
+                menuItems.add(MenuItemRepr.commandAction(CommandActionRepr.builder().manualOnce(showScopeGraphAstCommand()).addRequiredResourceTypes(HierarchicalResourceType.File).enclosingProjectRequired().build()));
+                menuItems.add(MenuItemRepr.commandAction(CommandActionRepr.builder().manualContinuous(showScopeGraphAstCommand()).addRequiredResourceTypes(HierarchicalResourceType.File).enclosingProjectRequired().build()));
             }
             return MenuItemRepr.menu("Debug", menuItems);
         }
@@ -245,6 +273,8 @@ public class ConstraintAnalyzerAdapterCompiler {
             if(languageProjectInput().enableStatix()) {
                 menuItems.add(MenuItemRepr.commandAction(CommandActionRepr.builder().manualOnce(showScopeGraphCommand()).addRequiredEditorFileTypes(EditorFileType.ReadableResource).enclosingProjectRequired().build()));
                 menuItems.add(MenuItemRepr.commandAction(CommandActionRepr.builder().manualContinuous(showScopeGraphCommand()).addRequiredEditorFileTypes(EditorFileType.ReadableResource).enclosingProjectRequired().build()));
+                menuItems.add(MenuItemRepr.commandAction(CommandActionRepr.builder().manualOnce(showScopeGraphAstCommand()).addRequiredEditorFileTypes(EditorFileType.ReadableResource).enclosingProjectRequired().build()));
+                menuItems.add(MenuItemRepr.commandAction(CommandActionRepr.builder().manualContinuous(showScopeGraphAstCommand()).addRequiredEditorFileTypes(EditorFileType.ReadableResource).enclosingProjectRequired().build()));
             }
             return MenuItemRepr.menu("Debug", menuItems);
         }
@@ -259,6 +289,7 @@ public class ConstraintAnalyzerAdapterCompiler {
             if(languageProjectInput().enableStatix()) {
                 taskDefs.add(showPreAnalyzeAstTaskDef(), baseShowPreAnalyzeAstTaskDef());
                 taskDefs.add(showScopeGraphTaskDef(), baseShowScopeGraphTaskDef());
+                taskDefs.add(showScopeGraphAstTaskDef(), baseShowScopeGraphAstTaskDef());
             }
             taskDefs.add(showAnalyzedAstTaskDef(), baseShowAnalyzedAstTaskDef());
         }
@@ -267,6 +298,7 @@ public class ConstraintAnalyzerAdapterCompiler {
             if(languageProjectInput().enableStatix()) {
                 commands.add(showPreAnalyzeAstCommand());
                 commands.add(showScopeGraphCommand());
+                commands.add(showScopeGraphAstCommand());
             }
             commands.add(showAnalyzedAstCommand());
         }
@@ -296,6 +328,7 @@ public class ConstraintAnalyzerAdapterCompiler {
             if(languageProjectInput().enableStatix()) {
                 javaSourceFiles.add(baseShowAnalyzedAstTaskDef().file(generatedJavaSourcesDirectory));
                 javaSourceFiles.add(baseShowScopeGraphTaskDef().file(generatedJavaSourcesDirectory));
+                javaSourceFiles.add(baseShowScopeGraphAstTaskDef().file(generatedJavaSourcesDirectory));
             }
             return ListView.of(javaSourceFiles);
         }

--- a/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/constraint_analyzer/ShowScopeGraphAstTaskDef.java.mustache
+++ b/core/spoofax.compiler/src/main/resources/mb/spoofax/compiler/adapter/constraint_analyzer/ShowScopeGraphAstTaskDef.java.mustache
@@ -1,0 +1,31 @@
+package {{baseShowScopeGraphAstTaskDef.packageId}};
+
+import mb.statix.pie.ShowScopeGraphAstTaskDef;
+import mb.pie.api.ExecContext;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.spoofax.core.language.command.CommandFeedback;
+
+import javax.inject.Inject;
+
+@{{adapterProject.scope.qualifiedId}}
+public class {{baseShowScopeGraphAstTaskDef.id}} extends ShowScopeGraphAstTaskDef {
+    private final {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources;
+
+    @Inject public {{baseShowScopeGraphAstTaskDef.id}}(
+        {{analyzeFileTaskDef.qualifiedId}} analyzeFile,
+        {{strategoRuntimeInput.getStrategoRuntimeProviderTaskDef.qualifiedId}} getStrategoRuntimeProvider,
+        {{classLoaderResourcesInput.classLoaderResources.qualifiedId}} classLoaderResources
+    ) {
+        super(analyzeFile, getStrategoRuntimeProvider);
+        this.classLoaderResources = classLoaderResources;
+    }
+
+    @Override public String getId() {
+        return "{{baseShowScopeGraphAstTaskDef.qualifiedId}}";
+    }
+
+    @Override public CommandFeedback exec(ExecContext context, Args args) throws Exception {
+        context.require(classLoaderResources.tryGetAsNativeResource(getClass()), ResourceStampers.hashFile());
+        return super.exec(context, args);
+    }
+}


### PR DESCRIPTION
I'm working on porting my scope graph visualization to Spoofax 3, which works on the raw scope graph AST. This allows users to easily get that AST, and should be in line with the other options that we already expose.