### PR TITLE
Add libstratego-aterm by default

### DIFF
--- a/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/metalang/CfgStrategoSource.java
+++ b/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/metalang/CfgStrategoSource.java
@@ -44,6 +44,7 @@ public abstract class CfgStrategoSource implements Serializable {
             final ArrayList<String> strategoBuiltinLibs = new ArrayList<>();
             strategoBuiltinLibs.add("stratego-gpp");
             strategoBuiltinLibs.add("libstratego-sglr");
+            strategoBuiltinLibs.add("libstratego-aterm");
             return strategoBuiltinLibs;
         }
 


### PR DESCRIPTION
This is a pre-built Stratego 1 library that's currently used in libspoofax. See #100