### PR TITLE
Initial scaffolding for Dynamix support

### DIFF
--- a/lwb.distrib/spoofax.lwb.eclipse/build.gradle.kts
+++ b/lwb.distrib/spoofax.lwb.eclipse/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   bundleImplementation(compositeBuild("esv.eclipse"))
   bundleImplementation(compositeBuild("stratego.eclipse"))
   bundleImplementation(compositeBuild("statix.eclipse"))
+  bundleImplementation(compositeBuild("dynamix.eclipse"))
   bundleImplementation(compositeBuild("sdf3_ext_statix.eclipse"))
   bundleImplementation(compositeBuild("spt.eclipse"))
 

--- a/lwb.distrib/spoofax.lwb.eclipse/build.gradle.kts
+++ b/lwb.distrib/spoofax.lwb.eclipse/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   bundleImplementation(compositeBuild("statix.eclipse"))
   bundleImplementation(compositeBuild("dynamix.eclipse"))
   bundleImplementation(compositeBuild("sdf3_ext_statix.eclipse"))
+  bundleImplementation(compositeBuild("sdf3_ext_dynamix.eclipse"))
   bundleImplementation(compositeBuild("spt.eclipse"))
 
   bundleImplementation(compositeBuild("strategolib.eclipse"))

--- a/lwb.distrib/spoofax.lwb.eclipse/src/main/java/mb/spoofax/lwb/eclipse/SpoofaxLwbLifecycleParticipant.java
+++ b/lwb.distrib/spoofax.lwb.eclipse/src/main/java/mb/spoofax/lwb/eclipse/SpoofaxLwbLifecycleParticipant.java
@@ -29,6 +29,8 @@ import mb.resource.dagger.ResourceServiceComponent;
 import mb.resource.fs.FSResource;
 import mb.sdf3.Sdf3Component;
 import mb.sdf3.eclipse.Sdf3LanguageFactory;
+import mb.sdf3_ext_dynamix.Sdf3ExtDynamixComponent;
+import mb.sdf3_ext_dynamix.eclipse.Sdf3ExtDynamixLanguageFactory;
 import mb.sdf3_ext_statix.Sdf3ExtStatixComponent;
 import mb.sdf3_ext_statix.eclipse.Sdf3ExtStatixLanguageFactory;
 import mb.spoofax.compiler.dagger.DaggerSpoofaxCompilerComponent;
@@ -161,6 +163,7 @@ public class SpoofaxLwbLifecycleParticipant implements EclipseLifecycleParticipa
                 final DynamixComponent dynamixComponent = DynamixLanguageFactory.getLanguage().getComponent();
 
                 final Sdf3ExtStatixComponent sdf3ExtStatixComponent = Sdf3ExtStatixLanguageFactory.getLanguage().getComponent();
+                final Sdf3ExtDynamixComponent sdf3ExtDynamixComponent = Sdf3ExtDynamixLanguageFactory.getLanguage().getComponent();
 
                 final StrategoLibComponent strategoLibComponent = StrategoLibLanguageFactory.getLanguage().getComponent();
                 final StrategoLibResourcesComponent strategoLibResourcesComponent = StrategoLibLanguageFactory.getLanguage().getResourcesComponent();
@@ -183,6 +186,7 @@ public class SpoofaxLwbLifecycleParticipant implements EclipseLifecycleParticipa
                     .dynamixComponent(dynamixComponent)
 
                     .sdf3ExtStatixComponent(sdf3ExtStatixComponent)
+                    .sdf3ExtDynamixComponent(sdf3ExtDynamixComponent)
 
                     .strategoLibComponent(strategoLibComponent)
                     .strategoLibResourcesComponent(strategoLibResourcesComponent)
@@ -204,7 +208,10 @@ public class SpoofaxLwbLifecycleParticipant implements EclipseLifecycleParticipa
                     strategoComponent,
                     esvComponent,
                     statixComponent,
+                    dynamixComponent,
+
                     sdf3ExtStatixComponent,
+                    sdf3ExtDynamixComponent,
 
                     strategoLibComponent,
                     strategoLibResourcesComponent,

--- a/lwb.distrib/spoofax.lwb.eclipse/src/main/java/mb/spoofax/lwb/eclipse/SpoofaxLwbLifecycleParticipant.java
+++ b/lwb.distrib/spoofax.lwb.eclipse/src/main/java/mb/spoofax/lwb/eclipse/SpoofaxLwbLifecycleParticipant.java
@@ -2,6 +2,8 @@ package mb.spoofax.lwb.eclipse;
 
 import mb.cfg.CfgComponent;
 import mb.cfg.eclipse.CfgLanguageFactory;
+import mb.dynamix.DynamixComponent;
+import mb.dynamix.eclipse.DynamixLanguageFactory;
 import mb.esv.eclipse.EsvEclipseComponent;
 import mb.esv.eclipse.EsvLanguageFactory;
 import mb.gpp.GppComponent;
@@ -156,6 +158,7 @@ public class SpoofaxLwbLifecycleParticipant implements EclipseLifecycleParticipa
                 final StrategoEclipseComponent strategoComponent = StrategoLanguageFactory.getLanguage().getComponent();
                 final EsvEclipseComponent esvComponent = EsvLanguageFactory.getLanguage().getComponent();
                 final StatixEclipseComponent statixComponent = StatixLanguageFactory.getLanguage().getComponent();
+                final DynamixComponent dynamixComponent = DynamixLanguageFactory.getLanguage().getComponent();
 
                 final Sdf3ExtStatixComponent sdf3ExtStatixComponent = Sdf3ExtStatixLanguageFactory.getLanguage().getComponent();
 
@@ -177,6 +180,7 @@ public class SpoofaxLwbLifecycleParticipant implements EclipseLifecycleParticipa
                     .strategoComponent(strategoComponent)
                     .esvComponent(esvComponent)
                     .statixComponent(statixComponent)
+                    .dynamixComponent(dynamixComponent)
 
                     .sdf3ExtStatixComponent(sdf3ExtStatixComponent)
 

--- a/lwb.distrib/spoofax.lwb.eclipse/src/main/java/mb/spoofax/lwb/eclipse/compiler/EclipseSpoofax3CompilerComponent.java
+++ b/lwb.distrib/spoofax.lwb.eclipse/src/main/java/mb/spoofax/lwb/eclipse/compiler/EclipseSpoofax3CompilerComponent.java
@@ -13,6 +13,7 @@ import mb.libstatix.LibStatixResourcesComponent;
 import mb.log.dagger.LoggerComponent;
 import mb.resource.dagger.ResourceServiceComponent;
 import mb.sdf3.Sdf3Component;
+import mb.sdf3_ext_dynamix.Sdf3ExtDynamixComponent;
 import mb.sdf3_ext_statix.Sdf3ExtStatixComponent;
 import mb.spoofax.lwb.compiler.dagger.Spoofax3CompilerComponent;
 import mb.spoofax.lwb.compiler.dagger.Spoofax3CompilerModule;
@@ -39,6 +40,7 @@ import mb.strategolib.StrategoLibResourcesComponent;
         DynamixComponent.class,
 
         Sdf3ExtStatixComponent.class,
+        Sdf3ExtDynamixComponent.class,
 
         StrategoLibComponent.class,
         StrategoLibResourcesComponent.class,

--- a/lwb.distrib/spoofax.lwb.eclipse/src/main/java/mb/spoofax/lwb/eclipse/compiler/EclipseSpoofax3CompilerComponent.java
+++ b/lwb.distrib/spoofax.lwb.eclipse/src/main/java/mb/spoofax/lwb/eclipse/compiler/EclipseSpoofax3CompilerComponent.java
@@ -2,6 +2,7 @@ package mb.spoofax.lwb.eclipse.compiler;
 
 import dagger.Component;
 import mb.cfg.CfgComponent;
+import mb.dynamix.DynamixComponent;
 import mb.esv.EsvComponent;
 import mb.gpp.GppComponent;
 import mb.gpp.GppResourcesComponent;
@@ -35,6 +36,7 @@ import mb.strategolib.StrategoLibResourcesComponent;
         StrategoComponent.class,
         EsvComponent.class,
         StatixComponent.class,
+        DynamixComponent.class,
 
         Sdf3ExtStatixComponent.class,
 

--- a/lwb/metalang/cfg/cfg.spoofax2/syntax/part/language.sdf3
+++ b/lwb/metalang/cfg/cfg.spoofax2/syntax/part/language.sdf3
@@ -16,19 +16,19 @@ context-free syntax
   <{Sdf3Option "\n"}*>
 }>
   Sdf3Option.Sdf3Source = <source = <Sdf3Source>>
-  
+
   Sdf3Source.Sdf3Files  = <files {
   <{Sdf3FilesOption "\n"}*>
 }>
   Sdf3FilesOption.Sdf3FilesMainSourceDirectory       = <main-source-directory = <Expr>>
   Sdf3FilesOption.Sdf3FilesMainFile                  = <main-file = <Expr>>
-  
+
   Sdf3Source.Sdf3Prebuilt = <prebuilt {
   <{Sdf3PrebuiltOption "\n"}*>
 }>
   Sdf3PrebuiltOption.Sdf3PrebuiltParseTableAtermFile     = <parse-table-aterm-file = <Expr>>
   Sdf3PrebuiltOption.Sdf3PrebuiltParseTablePersistedFile = <parse-table-persisted-file = <Expr>>
-  
+
   // TODO: move into source after CC lab.
   Sdf3Option.Sdf3ParseTableGeneratorSection = <parse-table-generator {
   <{Sdf3ParseTableGeneratorOption "\n"}*>
@@ -50,7 +50,7 @@ context-free syntax
   <{EsvOption "\n"}*>
 }>
   EsvOption.EsvSource = <source = <EsvSource>>
-  
+
   EsvSource.EsvFiles  = <files {
   <{EsvFilesOption "\n"}*>
 }>
@@ -58,7 +58,7 @@ context-free syntax
   EsvFilesOption.EsvFilesMainFile                  = <main-file = <Expr>>
   EsvFilesOption.EsvFilesIncludeDirectory          = <include-directory = <Expr>>
   EsvFilesOption.EsvFilesIncludeLibspoofax2Exports = <include-libspoofax2-exports = <Expr>>
-  
+
   EsvSource.EsvPrebuilt = <prebuilt {
   <{EsvPrebuiltOption "\n"}*>
 }>
@@ -74,14 +74,14 @@ context-free syntax
   <{StatixOption "\n"}*>
 }>
   StatixOption.StatixSource = <source = <StatixSource>>
-  
+
   StatixSource.StatixFiles  = <files {
   <{StatixFilesOption "\n"}*>
 }>
   StatixFilesOption.StatixFilesMainSourceDirectory = <main-source-directory = <Expr>>
   StatixFilesOption.StatixFilesMainFile            = <main-file = <Expr>>
   StatixFilesOption.StatixFilesIncludeDirectory    = <include-directory = <Expr>>
-  
+
   StatixSource.StatixPrebuilt = <prebuilt {
   <{StatixPrebuiltOption "\n"}*>
 }>
@@ -100,16 +100,38 @@ context-free syntax
   <{StrategoOption "\n"}*>
 }>
   StrategoOption.StrategoSource = <source = <StrategoSource>>
-  
+
   StrategoSource.StrategoFiles  = <files {
   <{StrategoFilesOption "\n"}*>
 }>
   StrategoFilesOption.StrategoFilesMainSourceDirectory      = <main-source-directory = <Expr>>
   StrategoFilesOption.StrategoFilesMainFile                 = <main-file = <Expr>>
   StrategoFilesOption.StrategoFilesIncludeDirectory         = <include-directory = <Expr>>
-  
+
   // TODO: move into source after CC lab.
   StrategoOption.StrategoSdf3StatixExplicationGen = <sdf3-statix-explication-generation = <Expr>>
-  
+
   StrategoOption.StrategoLanguageStrategyAffix = <language-strategy-affix = <Expr>>
   StrategoOption.StrategoOutputJavaPackageId = <output-java-package = <Expr>>
+
+context-free sorts
+
+  DynamixOption DynamixSource DynamixFilesOption DynamixPrebuiltOption
+
+context-free syntax
+
+  Part.DynamixSection = <dynamix {
+  <{DynamixOption "\n"}*>
+}>
+  DynamixOption.DynamixSource = <source = <DynamixSource>>
+
+  DynamixSource.DynamixFiles  = <files {
+  <{DynamixFilesOption "\n"}*>
+}>
+  DynamixFilesOption.DynamixFilesMainSourceDirectory = <main-source-directory = <Expr>>
+  DynamixFilesOption.DynamixFilesMainFile            = <main-file = <Expr>>
+
+  DynamixSource.DynamixPrebuilt = <prebuilt {
+  <{DynamixPrebuiltOption "\n"}*>
+}>
+  DynamixPrebuiltOption.DynamixPrebuiltSpecAtermDirectory = <spec-aterm-directory = <Expr>>

--- a/lwb/metalang/cfg/cfg.spoofax2/trans/statsem/part/language.stx
+++ b/lwb/metalang/cfg/cfg.spoofax2/trans/statsem/part/language.stx
@@ -4,23 +4,23 @@ imports
 
   statsem/part
   statsem/expr
-  
+
   signatures/part/language-sig
 
 rules // Sdf3 section and options
 
   partOk(s, Sdf3Section(options)) :- sdf3OptionsOk(s, options).
-  
+
   sdf3OptionOk : scope * Sdf3Option
   sdf3OptionsOk maps sdf3OptionOk(*, list(*))
-  
+
   sdf3OptionOk(s, Sdf3Source(source)) :-
     sdf3SourceOk(s, source).
-    
+
   sdf3SourceOk : scope * Sdf3Source
   sdf3SourceOk(s, Sdf3Files(options)) :- sdf3FilesOptionsOk(s, options).
   sdf3SourceOk(s, Sdf3Prebuilt(options)) :- sdf3PrebuiltOptionsOk(s, options).
-  
+
   sdf3FilesOptionOk : scope * Sdf3FilesOption
   sdf3FilesOptionsOk maps sdf3FilesOptionOk(*, list(*))
   sdf3FilesOptionOk(s, Sdf3FilesMainSourceDirectory(e)) :-
@@ -37,37 +37,37 @@ rules // Sdf3 section and options
 
   sdf3OptionOk(s, Sdf3ParseTableGeneratorSection(options)) :-
     sdf3ParseTableGeneratorOptionsOk(s, options).
-  
+
   sdf3ParseTableGeneratorOptionOk : scope * Sdf3ParseTableGeneratorOption
   sdf3ParseTableGeneratorOptionsOk maps sdf3ParseTableGeneratorOptionOk(*, list(*))
-  
-  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorDynamic(e)) :- 
+
+  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorDynamic(e)) :-
     typeOfExpr(s, e) == BOOL() | error $[Expected boolean]@e.
-  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorDataDependent(e)) :- 
+  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorDataDependent(e)) :-
     typeOfExpr(s, e) == BOOL() | error $[Expected boolean]@e.
-  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorLayoutSensitive(e)) :- 
+  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorLayoutSensitive(e)) :-
     typeOfExpr(s, e) == BOOL() | error $[Expected boolean]@e.
-  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorSolveDeepConflicts(e)) :- 
+  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorSolveDeepConflicts(e)) :-
     typeOfExpr(s, e) == BOOL() | error $[Expected boolean]@e.
-  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorCheckOverlap(e)) :- 
+  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorCheckOverlap(e)) :-
     typeOfExpr(s, e) == BOOL() | error $[Expected boolean]@e.
-  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorCheckPriorities(e)) :- 
+  sdf3ParseTableGeneratorOptionOk(s, Sdf3ParseTableGeneratorCheckPriorities(e)) :-
     typeOfExpr(s, e) == BOOL() | error $[Expected boolean]@e.
 
 rules // Esv section and options
 
   partOk(s, EsvSection(options)) :- esvOptionsOk(s, options).
-  
+
   esvOptionOk : scope * EsvOption
   esvOptionsOk maps esvOptionOk(*, list(*))
 
   esvOptionOk(s, EsvSource(source)) :-
     esvSourceOk(s, source).
-    
+
   esvSourceOk : scope * EsvSource
   esvSourceOk(s, EsvFiles(options)) :- esvFilesOptionsOk(s, options).
   esvSourceOk(s, EsvPrebuilt(options)) :- esvPrebuiltOptionsOk(s, options).
-  
+
   esvFilesOptionOk : scope * EsvFilesOption
   esvFilesOptionsOk maps esvFilesOptionOk(*, list(*))
   esvFilesOptionOk(s, EsvFilesMainSourceDirectory(e)) :-
@@ -87,17 +87,17 @@ rules // Esv section and options
 rules // Statix section and options
 
   partOk(s, StatixSection(options)) :- statixOptionsOk(s, options).
-  
+
   statixOptionOk : scope * StatixOption
   statixOptionsOk maps statixOptionOk(*, list(*))
-  
+
   statixOptionOk(s, StatixSource(source)) :-
     statixSourceOk(s, source).
-    
+
   statixSourceOk : scope * StatixSource
   statixSourceOk(s, StatixFiles(options)) :- statixFilesOptionsOk(s, options).
   statixSourceOk(s, StatixPrebuilt(options)) :- statixPrebuiltOptionsOk(s, options).
-  
+
   statixFilesOptionOk : scope * StatixFilesOption
   statixFilesOptionsOk maps statixFilesOptionOk(*, list(*))
   statixFilesOptionOk(s, StatixFilesMainSourceDirectory(e)) :-
@@ -113,21 +113,21 @@ rules // Statix section and options
     typeOfExpr(s, e) == PATH() | error $[Expected path]@e.
 
   statixOptionOk(s, StatixSdf3SignatureGen(e)) :-
-    typeOfExpr(s, e) == BOOL() | error $[Expected boolean]@e. 
-      
+    typeOfExpr(s, e) == BOOL() | error $[Expected boolean]@e.
+
 rules // Stratego section and options
 
   partOk(s, StrategoSection(options)) :- strategoOptionsOk(s, options).
-  
+
   strategoOptionOk : scope * StrategoOption
   strategoOptionsOk maps strategoOptionOk(*, list(*))
 
   strategoOptionOk(s, StrategoSource(source)) :-
     strategoSourceOk(s, source).
-    
+
   strategoSourceOk : scope * StrategoSource
   strategoSourceOk(s, StrategoFiles(options)) :- strategoFilesOptionsOk(s, options).
-  
+
   strategoFilesOptionOk : scope * StrategoFilesOption
   strategoFilesOptionsOk maps strategoFilesOptionOk(*, list(*))
   strategoFilesOptionOk(s, StrategoFilesMainSourceDirectory(e)) :-
@@ -143,3 +143,30 @@ rules // Stratego section and options
     typeOfExpr(s, e) == STRATEGY() | error $[Expected Stratego strategy identifier]@e.
   strategoOptionOk(s, StrategoOutputJavaPackageId(e)) :-
     typeOfExpr(s, e) == STRING() | error $[Expected string]@e.
+
+rules // Dynamix section and options
+
+  partOk(s, DynamixSection(options)) :- dynamixOptionsOk(s, options).
+
+  dynamixOptionOk : scope * DynamixOption
+  dynamixOptionsOk maps dynamixOptionOk(*, list(*))
+
+  dynamixOptionOk(s, DynamixSource(source)) :-
+    dynamixSourceOk(s, source).
+
+  dynamixSourceOk : scope * DynamixSource
+  dynamixSourceOk(s, DynamixFiles(options)) :- dynamixFilesOptionsOk(s, options).
+  dynamixSourceOk(s, DynamixPrebuilt(options)) :- dynamixPrebuiltOptionsOk(s, options).
+
+  dynamixFilesOptionOk : scope * DynamixFilesOption
+  dynamixFilesOptionsOk maps dynamixFilesOptionOk(*, list(*))
+  dynamixFilesOptionOk(s, DynamixFilesMainSourceDirectory(e)) :-
+    typeOfExpr(s, e) == PATH() | error $[Expected path]@e.
+  dynamixFilesOptionOk(s, DynamixFilesMainFile(e)) :-
+    typeOfExpr(s, e) == PATH() | error $[Expected path]@e.
+
+  dynamixPrebuiltOptionOk : scope * DynamixPrebuiltOption
+  dynamixPrebuiltOptionsOk maps dynamixPrebuiltOptionOk(*, list(*))
+  dynamixPrebuiltOptionOk(s, DynamixPrebuiltSpecAtermDirectory(e)) :-
+    typeOfExpr(s, e) == PATH() | error $[Expected path]@e.
+

--- a/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/CompileLanguageSpecificationInput.java
+++ b/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/CompileLanguageSpecificationInput.java
@@ -1,5 +1,6 @@
 package mb.cfg;
 
+import mb.cfg.metalang.CfgDynamixConfig;
 import mb.cfg.metalang.CfgEsvConfig;
 import mb.cfg.metalang.CfgSdf3Config;
 import mb.cfg.metalang.CfgStatixConfig;
@@ -32,6 +33,8 @@ public interface CompileLanguageSpecificationInput extends Serializable {
     Optional<CfgEsvConfig> esv();
 
     Optional<CfgStatixConfig> statix();
+
+    Optional<CfgDynamixConfig> dynamix();
 
     Optional<CfgStrategoConfig> stratego();
 
@@ -76,5 +79,6 @@ public interface CompileLanguageSpecificationInput extends Serializable {
         esv().ifPresent(i -> i.syncTo(builder.styler));
         statix().ifPresent(i -> i.syncTo(builder.constraintAnalyzer));
         stratego().ifPresent(i -> i.syncTo(builder.strategoRuntime));
+        // todo: dynamix sync?
     }
 }

--- a/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/CompileLanguageSpecificationInputBuilder.java
+++ b/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/CompileLanguageSpecificationInputBuilder.java
@@ -1,5 +1,7 @@
 package mb.cfg;
 
+import mb.cfg.metalang.CfgDynamixConfig;
+import mb.cfg.metalang.CfgDynamixSource;
 import mb.cfg.metalang.CfgEsvConfig;
 import mb.cfg.metalang.CfgSdf3Config;
 import mb.cfg.metalang.CfgStatixConfig;
@@ -20,6 +22,9 @@ public class CompileLanguageSpecificationInputBuilder {
 
     private boolean statixEnabled = false;
     public CfgStatixConfig.Builder statix = CfgStatixConfig.builder();
+
+    private boolean dynamixEnabled = false;
+    public CfgDynamixConfig.Builder dynamix = CfgDynamixConfig.builder();
 
     private boolean strategoEnabled = false;
     public CfgStrategoConfig.Builder stratego = CfgStrategoConfig.builder();
@@ -42,6 +47,11 @@ public class CompileLanguageSpecificationInputBuilder {
         return statix;
     }
 
+    public CfgDynamixConfig.Builder withDynamix() {
+        dynamixEnabled = true;
+        return dynamix;
+    }
+
     public CfgStrategoConfig.Builder withStratego() {
         strategoEnabled = true;
         return stratego;
@@ -57,6 +67,9 @@ public class CompileLanguageSpecificationInputBuilder {
 
         final @Nullable CfgStatixConfig statix = buildStatix(compileLanguageSpecificationShared);
         if(statix != null) compileLanguage.statix(statix);
+
+        final @Nullable CfgDynamixConfig dynamix = buildDynamix(compileLanguageSpecificationShared);
+        if(dynamix != null) compileLanguage.dynamix(dynamix);
 
         final @Nullable CfgStrategoConfig stratego = buildStratego(persistentProperties, shared, compileLanguageSpecificationShared);
         if(stratego != null) compileLanguage.stratego(stratego);
@@ -90,6 +103,15 @@ public class CompileLanguageSpecificationInputBuilder {
     ) {
         if(!statixEnabled) return null;
         return statix
+            .compileLanguageShared(compileLanguageSpecificationShared)
+            .build();
+    }
+
+    private @Nullable CfgDynamixConfig buildDynamix(
+        CompileLanguageSpecificationShared compileLanguageSpecificationShared
+    ) {
+        if(!dynamixEnabled) return null;
+        return dynamix
             .compileLanguageShared(compileLanguageSpecificationShared)
             .build();
     }

--- a/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/metalang/CfgDynamixConfig.java
+++ b/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/metalang/CfgDynamixConfig.java
@@ -1,0 +1,36 @@
+package mb.cfg.metalang;
+
+import mb.cfg.CompileLanguageSpecificationShared;
+import mb.resource.hierarchical.ResourcePath;
+import org.immutables.value.Value;
+
+import java.io.Serializable;
+
+/**
+ * Configuration for Dynamix in the context of CFG.
+ */
+@Value.Immutable
+public interface CfgDynamixConfig extends Serializable {
+    class Builder extends ImmutableCfgDynamixConfig.Builder {}
+
+    static Builder builder() {return new Builder();}
+
+    @Value.Default default CfgDynamixSource source() {
+        return CfgDynamixSource.files(CfgDynamixSource.Files.builder()
+            .compileLanguageShared(compileLanguageShared())
+            .build()
+        );
+    }
+
+    @Value.Default default ResourcePath generatedSourcesDirectory() {
+        return compileLanguageShared().generatedSourcesDirectory().appendRelativePath("dynamix");
+    }
+
+    default ResourcePath outputSpecAtermDirectory() {
+        return compileLanguageShared().generatedResourcesDirectory() // Generated resources directory, so that Gradle includes the aterm format file in the JAR file.
+            .appendRelativePath(compileLanguageShared().languageProject().packagePath()) // Append package path to make location unique, enabling JAR files to be merged.
+            ;
+    }
+
+    CompileLanguageSpecificationShared compileLanguageShared();
+}

--- a/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/metalang/CfgDynamixSource.java
+++ b/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/metalang/CfgDynamixSource.java
@@ -1,0 +1,86 @@
+package mb.cfg.metalang;
+
+import mb.cfg.CompileLanguageSpecificationShared;
+import mb.common.util.ADT;
+import mb.resource.hierarchical.ResourcePath;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * enum CfgDynamixSource {
+ *     files(string, string),
+ *     prebuilt(string)
+ * }
+ */
+
+/**
+ * Configuration for Dynamix sources in the context of CFG.
+ */
+@ADT @Value.Enclosing
+public abstract class CfgDynamixSource implements Serializable {
+    @Value.Immutable
+    public interface Files extends Serializable {
+        class Builder extends ImmutableCfgDynamixSource.Files.Builder {
+            public static ResourcePath getDefaultMainSourceDirectory(CompileLanguageSpecificationShared shared) {
+                return shared.languageProject().project().srcDirectory();
+            }
+        }
+
+        static Builder builder() {return new Builder();}
+
+
+        @Value.Default default ResourcePath mainSourceDirectory() {
+            return Builder.getDefaultMainSourceDirectory(compileLanguageShared());
+        }
+
+        @Value.Default default ResourcePath mainFile() {
+            return mainSourceDirectory().appendRelativePath("main.stx");
+        }
+
+        List<ResourcePath> includeDirectories();
+
+        /// Automatically provided sub-inputs
+
+        CompileLanguageSpecificationShared compileLanguageShared();
+    }
+
+    interface Cases<R> {
+        R files(Files files);
+
+        R prebuilt(ResourcePath specAtermDirectory);
+    }
+
+    public static CfgDynamixSource files(Files files) {
+        return CfgDynamixSource.files(files);
+    }
+
+    public static CfgDynamixSource prebuilt(ResourcePath specAtermDirectory) {
+        return CfgDynamixSource.prebuilt(specAtermDirectory);
+    }
+
+
+    public abstract <R> R match(Cases<R> cases);
+
+    public static CfgDynamixSources.CasesMatchers.TotalMatcher_Files cases() {
+        return CfgDynamixSource.cases();
+    }
+
+    public CfgDynamixSources.CaseOfMatchers.TotalMatcher_Files caseOf() {
+        return CfgDynamixSources.caseOf(this);
+    }
+
+    public Optional<Files> getFiles() {
+        return CfgDynamixSources.getFiles(this);
+    }
+
+
+    @Override public abstract int hashCode();
+
+    @Override public abstract boolean equals(@Nullable Object obj);
+
+    @Override public abstract String toString();
+}

--- a/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/metalang/CfgDynamixSource.java
+++ b/lwb/metalang/cfg/cfg/src/main/java/mb/cfg/metalang/CfgDynamixSource.java
@@ -11,13 +11,6 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * enum CfgDynamixSource {
- *     files(string, string),
- *     prebuilt(string)
- * }
- */
-
-/**
  * Configuration for Dynamix sources in the context of CFG.
  */
 @ADT @Value.Enclosing
@@ -41,6 +34,10 @@ public abstract class CfgDynamixSource implements Serializable {
             return mainSourceDirectory().appendRelativePath("main.stx");
         }
 
+        @Value.Default default ResourcePath generatedSourcesDirectory() {
+            return compileLanguageShared().generatedSourcesDirectory().appendRelativePath("dynamix");
+        }
+
         List<ResourcePath> includeDirectories();
 
         /// Automatically provided sub-inputs
@@ -55,11 +52,11 @@ public abstract class CfgDynamixSource implements Serializable {
     }
 
     public static CfgDynamixSource files(Files files) {
-        return CfgDynamixSource.files(files);
+        return CfgDynamixSources.files(files);
     }
 
     public static CfgDynamixSource prebuilt(ResourcePath specAtermDirectory) {
-        return CfgDynamixSource.prebuilt(specAtermDirectory);
+        return CfgDynamixSources.prebuilt(specAtermDirectory);
     }
 
 

--- a/lwb/metalang/dynamix/dynamix.cli/build.gradle.kts
+++ b/lwb/metalang/dynamix/dynamix.cli/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.cli")
+}
+
+languageCliProject {
+  adapterProject.set(project(":dynamix"))
+}
+
+tasks {
+  // Disable currently unused distribution tasks.
+  distZip.configure { enabled = false }
+  distTar.configure { enabled = false }
+  startScripts.configure { enabled = false }
+}

--- a/lwb/metalang/dynamix/dynamix.eclipse/build.gradle.kts
+++ b/lwb/metalang/dynamix/dynamix.eclipse/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.eclipse")
+}
+
+fun compositeBuild(name: String) = "$group:$name:$version"
+
+dependencies {
+  // Required because @Nullable has runtime retention (which includes classfile retention), and the Java compiler requires access to it.
+  compileOnly("com.google.code.findbugs:jsr305")
+
+  // Depend on `spoofax.compiler.eclipsebundle` because `cfg` uses `spoofax.compiler` and `spoofax.compiler.dagger`.
+  bundleApi(compositeBuild("spoofax.compiler.eclipsebundle"))
+}
+
+languageEclipseProject {
+  adapterProject.set(project(":dynamix"))
+  compilerInput {
+    languageGroup("mb.spoofax.lwb")
+  }
+}

--- a/lwb/metalang/dynamix/dynamix.intellij/build.gradle.kts
+++ b/lwb/metalang/dynamix/dynamix.intellij/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.intellij")
+}
+
+languageIntellijProject {
+  adapterProject.set(project(":dynamix"))
+}

--- a/lwb/metalang/dynamix/dynamix.spoofax2/.gitignore
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/.gitignore
@@ -1,0 +1,2 @@
+*.aterm
+example/*.resolved.cfg

--- a/lwb/metalang/dynamix/dynamix.spoofax2/build.gradle.kts
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+  id("org.metaborg.devenv.spoofax.gradle.langspec")
+  `maven-publish`
+}
+
+val spoofax2DevenvVersion: String by ext
+spoofaxLanguageSpecification {
+  addSourceDependenciesFromMetaborgYaml.set(false)
+  addCompileDependenciesFromMetaborgYaml.set(false)
+}
+dependencies {
+  compileLanguage("org.metaborg.devenv:org.metaborg.meta.lang.esv:$spoofax2DevenvVersion")
+  compileLanguage("org.metaborg.devenv:org.metaborg.meta.lang.template:$spoofax2DevenvVersion")
+  compileLanguage("org.metaborg.devenv:statix.lang:$spoofax2DevenvVersion")
+  compileLanguage("org.metaborg.devenv:sdf3.ext.statix:$spoofax2DevenvVersion")
+
+  sourceLanguage("org.metaborg.devenv:meta.lib.spoofax:$spoofax2DevenvVersion")
+  sourceLanguage("org.metaborg.devenv:statix.runtime:$spoofax2DevenvVersion")
+}

--- a/lwb/metalang/dynamix/dynamix.spoofax2/editor/Analysis.esv
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/editor/Analysis.esv
@@ -1,0 +1,24 @@
+module Analysis
+
+imports
+
+  statix/Menus
+
+language
+
+  // see README.md for details on how to switch to multi-file analysis
+
+  observer : editor-analyze (constraint) // (multifile)
+
+references
+
+  reference _ : editor-resolve
+
+  hover _ : editor-hover
+
+menus
+
+  menu: "Analysis" (openeditor)
+
+    action: "Show pre-analyzed AST" = debug-show-pre-analyzed (source)
+    action: "Show analyzed AST"     = debug-show-analyzed

--- a/lwb/metalang/dynamix/dynamix.spoofax2/editor/Analysis.esv
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/editor/Analysis.esv
@@ -8,7 +8,7 @@ language
 
   // see README.md for details on how to switch to multi-file analysis
 
-  observer : editor-analyze (constraint) // (multifile)
+  observer : editor-analyze (constraint) (multifile)
 
 references
 
@@ -19,6 +19,10 @@ references
 menus
 
   menu: "Analysis" (openeditor)
-
     action: "Show pre-analyzed AST" = debug-show-pre-analyzed (source)
     action: "Show analyzed AST"     = debug-show-analyzed
+
+  menu: "Debug" (openeditor)
+    action: "Qualify module"        = debug-qualify-usages
+    action: "Merge module"          = debug-merge-specs
+    action: "Evaluate examples"     = debug-evaluate-specs

--- a/lwb/metalang/dynamix/dynamix.spoofax2/editor/Colors.esv
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/editor/Colors.esv
@@ -1,0 +1,67 @@
+module Colors
+
+colorer Default, token-based highlighting
+                                  
+  keyword    : 127 0 85 bold      
+  identifier : default            
+  string     : blue               
+  number     : darkgreen          
+  var        : 139 69 19 italic   
+  operator   : 0 0 230        
+  layout     : 63 127 95 italic  
+  
+colorer Constants
+  INT        : blue
+  STRING     : blue   
+  
+colorer Identifiers
+
+  LID               : 30 30 30 italic     
+  UID               : 50 50 50 bold    
+  RID               : 0 0 0
+  
+colorer Identifiers
+
+  MExpr.MExprSourceIntToTargetInt : darkorange
+  MExpr.MExprSourceStrToTargetStr : darkorange
+  MExpr.MExprSourceVarToTargetVar : darkorange
+  MExpr.MExprContinueAt : darkorange
+  MExpr.MExprCallPrimitive : darkorange
+  MExpr.MExprConditionalPrimitive : darkorange
+  MExpr.MExprTLet : darkorange
+  MTFun.MTFun : darkorange
+  MExpr.MExprTFix : darkorange
+  MExpr.MExprQuoteTarget : darkorange
+
+colorer System colors
+                                  
+  darkblue   = 0 0 128 italic     
+  blue       = 0 0 255     
+  mediumblue = 0 0 200 
+  
+  darkred   = 128 0 0       
+  red       = 255 0 0       
+  red2      = 240 0 0       
+  red3      = 225 0 0       
+  red4      = 210 0 0   
+   
+  flred     = 255 10 0       
+  flred2    = 240 10 0       
+  flred3    = 225 10 0       
+  flred4    = 210 10 0       
+  
+  darkgreen = 0 128 0       
+  green     = 0 255 0       
+  
+  cyan      = 0 255 255     
+  magenta   = 255 0 255     
+  yellow    = 255 255 0     
+  white     = 255 255 255   
+  black     = 0 0 0         
+  gray      = 128 128 128   
+  grey      = gray          
+  orange            = 255 165 0     
+  darkorange    = 255 10 0     
+  pink      = 255 105 180   
+  brown     = 139 69 19     
+  default   = _   

--- a/lwb/metalang/dynamix/dynamix.spoofax2/editor/Main.esv
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/editor/Main.esv
@@ -1,0 +1,14 @@
+module Main
+
+imports
+
+  Syntax
+  Analysis
+  Refactoring
+
+language
+
+  extensions : dx
+
+  provider : target/metaborg/stratego.ctree
+  provider : target/metaborg/stratego.jar

--- a/lwb/metalang/dynamix/dynamix.spoofax2/editor/Main.esv
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/editor/Main.esv
@@ -2,6 +2,7 @@ module Main
 
 imports
 
+  Colors
   Syntax
   Analysis
   Refactoring

--- a/lwb/metalang/dynamix/dynamix.spoofax2/editor/Refactoring.esv
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/editor/Refactoring.esv
@@ -1,0 +1,7 @@
+module Refactoring
+
+menus
+
+  menu: "Refactoring"
+
+  action: "Rename" = rename-menu-action

--- a/lwb/metalang/dynamix/dynamix.spoofax2/editor/Syntax.esv
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/editor/Syntax.esv
@@ -1,0 +1,27 @@
+module Syntax
+
+imports 
+
+  libspoofax/color/default
+  completion/colorer/dynamix-cc-esv
+
+language
+
+  table         : target/metaborg/sdf.tbl
+  start symbols : Start
+
+  line comment  : "//"
+  block comment : "/*" * "*/"
+  fences        : [ ] ( ) { }
+
+menus
+  
+  menu: "Syntax" (openeditor)
+    
+    action: "Format"          = editor-format (source)
+    action: "Show parsed AST" = debug-show-aterm (source)
+
+views
+  
+  outline view: editor-outline (source)
+    expand to level: 3

--- a/lwb/metalang/dynamix/dynamix.spoofax2/metaborg.yaml
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/metaborg.yaml
@@ -1,0 +1,42 @@
+---
+id: org.metaborg:dynamix:0.1.0-SNAPSHOT
+name: dynamix
+dependencies:
+  compile:
+  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:statix.lang:${metaborgVersion}
+  - org.metaborg:sdf3.ext.statix:${metaborgVersion}
+  source:
+  - org.metaborg:meta.lib.spoofax:${metaborgVersion}
+  - org.metaborg:statix.runtime:${metaborgVersion}
+pardonedLanguages:
+- EditorService
+- Stratego-Sugar
+- SDF
+language:
+  sdf:
+    pretty-print: dynamix
+    sdf2table: java
+    placeholder:
+      prefix: "$"
+  stratego:
+    format: ctree
+    args:
+    - -la
+    - stratego-lib
+    - -la
+    - stratego-sglr
+    - -la
+    - stratego-gpp
+    - -la
+    - stratego-xtc
+    - -la
+    - stratego-aterm
+    - -la
+    - stratego-sdf
+    - -la
+    - strc
+exports:
+- language: ATerm
+  directory: src-gen/statix

--- a/lwb/metalang/dynamix/dynamix.spoofax2/metaborg.yaml
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/metaborg.yaml
@@ -21,7 +21,6 @@ language:
     placeholder:
       prefix: "$"
   stratego:
-    format: ctree
     args:
     - -la
     - stratego-lib
@@ -40,3 +39,11 @@ language:
 exports:
 - language: ATerm
   directory: src-gen/statix
+- language: Stratego-Sugar
+  directory: trans
+- language: Stratego-Sugar
+  directory: src-gen
+  includes:
+  - "completion/dynamix/**/*.str"
+  - "pp/dynamix/**/*.str"
+  - "signatures/**/*.str"

--- a/lwb/metalang/dynamix/dynamix.spoofax2/pom.xml
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>dynamix</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>spoofax-language</packaging>
+
+  <parent>
+    <groupId>org.metaborg</groupId>
+    <artifactId>parent.language</artifactId>
+    <version>2.5.16</version>
+  </parent>
+  
+  <repositories>
+    <repository>
+      <id>metaborg-release-repo</id>
+      <url>https://artifacts.metaborg.org/content/repositories/releases/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>metaborg-snapshot-repo</id>
+      <url>https://artifacts.metaborg.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  
+  <pluginRepositories>
+    <pluginRepository>
+      <id>metaborg-release-repo</id>
+      <url>https://artifacts.metaborg.org/content/repositories/releases/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <id>metaborg-snapshot-repo</id>
+      <url>https://artifacts.metaborg.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/lwb/metalang/dynamix/dynamix.spoofax2/src/main/strategies/dynamix/strategies/InteropRegisterer.java
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/src/main/strategies/dynamix/strategies/InteropRegisterer.java
@@ -1,0 +1,10 @@
+package dynamix.strategies;
+
+import org.strategoxt.lang.JavaInteropRegisterer;
+import org.strategoxt.lang.Strategy;
+
+public class InteropRegisterer extends JavaInteropRegisterer {
+    public InteropRegisterer() {
+        super(new Strategy[] { });
+    }
+}

--- a/lwb/metalang/dynamix/dynamix.spoofax2/src/main/strategies/dynamix/strategies/Main.java
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/src/main/strategies/dynamix/strategies/Main.java
@@ -1,0 +1,9 @@
+package dynamix.strategies;
+
+import org.strategoxt.lang.Context;
+
+public class Main {    
+    public static void init(Context context) {
+        
+    }
+}

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/Common.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/Common.sdf3
@@ -1,0 +1,44 @@
+module Common
+
+lexical sorts
+  ID INT STRING
+  STRING_CHAR BACKSLASH_CHAR
+  COMMENT_CHAR INSIDE_COMMENT
+  NEWLINE_EOF EOF
+
+lexical syntax
+
+  ID               = [a-zA-Z] [a-zA-Z0-9]*
+  INT              = "-"? [0-9]+
+  STRING           = "\"" STRING_CHAR* "\""
+  STRING_CHAR      = ~[\\\"\n]
+  STRING_CHAR      = "\\" [\\\"]
+  LAYOUT           = [\ \t\n\r]
+  COMMENT_CHAR     = [\*]
+  LAYOUT           = "/*" INSIDE_COMMENT* "*/"
+  INSIDE_COMMENT   = ~[\*]
+  INSIDE_COMMENT   = COMMENT_CHAR
+  LAYOUT           = "//" ~[\n\r]* NEWLINE_EOF
+  NEWLINE_EOF      = [\n\r]
+  NEWLINE_EOF      = EOF
+  EOF              =
+
+lexical restrictions
+
+  // Ensure greedy matching for lexicals
+  
+  COMMENT_CHAR    -/- [\/]
+  INT             -/- [0-9]
+  ID              -/- [a-zA-Z0-9\_]
+  
+  // EOF may not be followed by any char
+  
+  EOF             -/- ~[]
+
+context-free restrictions
+
+  // Ensure greedy matching for comments
+  
+  LAYOUT? -/- [\ \t\n\r]
+  LAYOUT? -/- [\/].[\/]
+  LAYOUT? -/- [\/].[\*]

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/Common.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/Common.sdf3
@@ -1,18 +1,24 @@
-module Common
-
+module common
+  
 lexical sorts
-  ID INT STRING
+  ID LID UID MID PID INT STRING
   STRING_CHAR BACKSLASH_CHAR
   COMMENT_CHAR INSIDE_COMMENT
-  NEWLINE_EOF EOF
+  NEWLINE_EOF EOF RID
 
 lexical syntax
-
-  ID               = [a-zA-Z] [a-zA-Z0-9]*
+  MID              = [a-zA-Z] [a-zA-Z0-9\_\-\/]* // module id
+  RID              = LID // rule id
+  ID               = [a-zA-Z] [a-zA-Z0-9\_]*
+  LID              = [a-z] [a-zA-Z0-9\_]*
+  UID              = [A-Z] [a-zA-Z0-9\_\-]*
+  PID              = [\+\-\*\/A-Za-z0-9\_]+ // primitive id
   INT              = "-"? [0-9]+
   STRING           = "\"" STRING_CHAR* "\""
-  STRING_CHAR      = ~[\\\"\n]
-  STRING_CHAR      = "\\" [\\\"]
+  STRING_CHAR      = ~[\"\n]
+  STRING_CHAR      = "\\\""
+  STRING_CHAR      = BACKSLASH_CHAR
+  BACKSLASH_CHAR   = "\\"
   LAYOUT           = [\ \t\n\r]
   COMMENT_CHAR     = [\*]
   LAYOUT           = "/*" INSIDE_COMMENT* "*/"
@@ -24,21 +30,22 @@ lexical syntax
   EOF              =
 
 lexical restrictions
-
   // Ensure greedy matching for lexicals
-  
   COMMENT_CHAR    -/- [\/]
   INT             -/- [0-9]
   ID              -/- [a-zA-Z0-9\_]
+  LID             -/- [a-zA-Z0-9\_]
+  UID             -/- [a-zA-Z0-9\_\-]
+  MID             -/- [a-zA-Z0-9\_\-\/]
   
   // EOF may not be followed by any char
-  
   EOF             -/- ~[]
+  
+  // Backslash chars in strings may not be followed by " 
+  BACKSLASH_CHAR  -/- [\"]
 
 context-free restrictions
-
   // Ensure greedy matching for comments
-  
   LAYOUT? -/- [\ \t\n\r]
   LAYOUT? -/- [\/].[\/]
   LAYOUT? -/- [\/].[\*]

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/dynamix.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/dynamix.sdf3
@@ -1,20 +1,18 @@
 module dynamix
 
 imports
-  
-  Common
+  common
+  meta
 
-context-free start-symbols
-  
-  Start
-
-context-free sorts
-
-  Start
-
+context-free start-symbols Start
+context-free sorts Start
 context-free syntax
+  Start.Program = <
+    module <MID>
+    
+    <{MSection "\n\n"}*>
+  >
   
-  Start.Empty = <>
-  Start.Hello = <hello>
-  Start.World = <world>
-  Start.String = <<STRING>>
+  Start.MultiProgram = <
+    multiple-files-syntax-for-testing-only <{Start "\n"}+>
+  >

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/dynamix.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/dynamix.sdf3
@@ -1,0 +1,20 @@
+module dynamix
+
+imports
+  
+  Common
+
+context-free start-symbols
+  
+  Start
+
+context-free sorts
+
+  Start
+
+context-free syntax
+  
+  Start.Empty = <>
+  Start.Hello = <hello>
+  Start.World = <world>
+  Start.String = <<STRING>>

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/meta.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/meta.sdf3
@@ -1,0 +1,156 @@
+module meta
+
+imports
+  common
+  source
+  type
+  tim/exp
+  
+context-free sorts MSection
+context-free syntax
+  MSection.MSectionImports = <
+    imports
+      <{MID "\n"}*>
+  >
+  
+  MSection.MSectionSignature = <
+    signature
+      <{MSignatureDecl "\n\n"}*>
+  >
+  
+  MSection.MSectionRules = <
+    rules
+      <{MRuleDecl "\n\n"}*>
+  >
+  
+  MSection.MSectionExample = <
+    example
+      <MExpr>
+  >
+  
+  MSection.MSectionPrimitives = <
+    primitives
+      <{MPrimitiveDecl "\n\n"}*>
+  >
+
+context-free sorts MPrimitiveDecl
+context-free syntax
+  MPrimitiveDecl.MPrimitiveDeclExpression = <expression #<PID>(<{MType ", "}*>)>
+  MPrimitiveDecl.MPrimitiveDeclStatement = <statement #<PID>(<{MType ", "}*>)>
+  MPrimitiveDecl.MPrimitiveDeclConditional = <conditional #<PID>(<{MType ", "}*>)>
+  
+context-free sorts MSignatureDecl
+context-free syntax
+  MSignatureDecl.MSignatureSortsDecl = <
+    sorts
+      <{UID "\n"}*>
+  >
+  
+  MSignatureDecl.MSignatureConstructorsDecl = <
+    constructors
+      <{MConstructorDecl "\n\n"}*>
+  >
+  
+context-free sorts MConstructorDecl
+context-free syntax
+  MConstructorDecl.MConstructorDeclSingleton = <
+    <UID> : <UID>
+  >
+  
+  MConstructorDecl.MConstructorDeclInjection = [
+    : [MConstructorArgument] -> [UID]
+  ]
+  
+  MConstructorDecl.MConstructorDecl = [
+    [UID] : [{MConstructorArgument " * "}+] -> [UID]
+  ]
+  
+context-free sorts MRuleDecl
+context-free syntax
+  MRuleDecl.MRuleDeclSignature = <<RID> :: <MRuleSignature>>
+  MRuleDecl.MRuleDecl = <<RID>(<{MPattern ", "}*>) = <MExpr>>
+
+context-free sorts MPattern
+context-free syntax
+  MPattern.MPatternWildcard = <_>
+  MPattern.MPatternVariable = <<LID>>
+  MPattern.MPatternConstructor = <<UID>(<{MPattern ", "}*>)>
+  MPattern.MPatternList = <[<{MPattern ", "}*>]>
+  MPattern.MPatternString = <<STRING>>
+  MPattern.MPatternInt = <<INT>>
+  MPattern.MPatternListCons = <[<{MPattern ", "}*>|<MPattern>]>
+  MPattern.MPatternBound = <<LID>@<MPattern>>
+
+context-free sorts MExpr MStatement MTFun
+context-free syntax
+  // source language operations
+  MExpr.MExprQuote = <'<STerm>>
+  
+  // meta language operations
+  MExpr.MExprVar = <<LID>>
+  MExpr.MExprBlock = <
+    {
+      <{MStatement "\n"}+>
+    }
+  >
+  MExpr.MExprLabeled1 = <
+    <MExpr>
+    label <LID>/1:
+  >
+  MExpr.MExprLabeled0 = <
+    <MExpr>
+    label <LID>/0:
+  > // todo: some kind of named argument binding here? currently only 0 or 1 is supported
+  MExpr.MExprCall = <<RID>(<{MExpr ", "}*>)>
+  MExpr.MExprSourceIntToTargetInt = <int(<MExpr>)>
+  MExpr.MExprSourceStrToTargetStr = <str(<MExpr>)>
+  MExpr.MExprSourceVarToTargetVar = <var(<MExpr>)>
+  MExpr.MExprConcatenateStr = <<MExpr> + <MExpr>>
+  MExpr.MExprFreshNamedTargetVar = <fresh-var(<ID>)>
+  MExpr.MExprContinueAt = <<MExpr>@(<MExpr>)>
+  
+  MExpr.MExprList = <[<{MExpr ", "}*>]>
+  MExpr.MExprListCons = <[<{MExpr ", "}*>|<MExpr>]>
+  MExpr.MExprConcatList = <<MExpr> ++ <MExpr>> {left}
+  // TODO:
+  // MExpr.MExprWith = ...
+  // MExpr.MExprSplice/Code?
+  
+  MStatement.MStatementAssign = [[LID] <- [MExpr]]
+  MStatement.MStatementExpr = [[MExpr]]
+  
+  // target language operations
+  MExpr.MExprCallPrimitive = <#<PID>(<{MExpr ", "}*>)>
+  MExpr.MExprQuoteTarget = <@<TExp>>
+  
+  MExpr.MExprTLet = [
+    let [MExpr] = [MExpr] in
+      [MExpr]
+  ]
+  
+  MExpr.MExprHole = [hole]
+  
+  MTFun.MTFun = <
+    fun <MExpr>(<MExpr>) =
+      <MExpr>
+  >
+  MExpr.MExprTFix = [
+    fix {
+      [{MTFun "\n"}+]
+    }
+  ]
+  MExpr.MExprConditionalPrimitive = [
+    if #[PID]([{MExpr ", "}*]) then
+      [MExpr]
+    else
+      [MExpr]
+  ] 
+  
+template options
+  LID = keyword {reject}
+  UID = keyword {reject}
+  ID = keyword {reject}
+  PID = keyword {reject}
+  
+context-free priorities
+  MExpr.MExprContinueAt > MExpr.MExprTLet

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/source.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/source.sdf3
@@ -1,0 +1,30 @@
+module source
+
+imports
+  common
+  
+lexical sorts SConstructorName
+lexical syntax
+  SConstructorName = [A-Z] [a-zA-Z0-9\_\-]*
+  
+lexical restrictions
+  SConstructorName -/- [a-zA-Z0-9\_\-]
+  
+// source language (modeled after ATerms)
+context-free sorts STerm
+context-free syntax
+  STerm.STermInt = <<INT>>
+  STerm.STermString = <<STRING>>
+  STerm.STermApp = <<SConstructorName>(<{STerm ", "}*>)>
+  STerm.STermList = <[<{STerm ", "}*>]>
+  
+// source language types (modeled after statix/stratego syntax)
+context-free sorts SType SConstructorType
+context-free syntax
+  SType.STypeNamed = <<UID>>
+  SType.STypeInt = <int>
+  SType.STypeString = <string>
+  SType.STypeList = <list(<SType>)>
+  
+  SConstructorType.SConstructorTypeSingleton = <<UID>>
+  SConstructorType.SConstructorTypeParams = <<{SType " * "}+> -\> <UID>>

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/tests.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/tests.sdf3
@@ -1,0 +1,5 @@
+module tests
+
+imports
+  common
+  meta

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/tim/common.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/tim/common.sdf3
@@ -1,0 +1,44 @@
+module tim/common
+  
+lexical sorts
+  TID TINT TSTRING TPRIM
+  TSTRING_CHAR TBACKSLASH_CHAR
+  TCOMMENT_CHAR TINSIDE_COMMENT
+  TNEWLINE_EOF TEOF
+
+lexical syntax
+  TID               = [\$a-zA-Z\_] [a-zA-Z0-9\_]*
+  TPRIM             = [\+\-\*\/A-Za-z0-9\_]+ // primitive id
+  TINT              = "-"? [0-9]+
+  TSTRING           = "\"" TSTRING_CHAR* "\""
+  TSTRING_CHAR      = ~[\"\n]
+  TSTRING_CHAR      = "\\\""
+  TSTRING_CHAR      = TBACKSLASH_CHAR
+  TBACKSLASH_CHAR   = "\\"
+  LAYOUT           = [\ \t\n\r]
+  TCOMMENT_CHAR     = [\*]
+  LAYOUT           = "/*" TINSIDE_COMMENT* "*/"
+  TINSIDE_COMMENT   = ~[\*]
+  TINSIDE_COMMENT   = TCOMMENT_CHAR
+  LAYOUT           = "//" ~[\n\r]* TNEWLINE_EOF
+  TNEWLINE_EOF      = [\n\r]
+  TNEWLINE_EOF      = TEOF
+  TEOF              =
+
+lexical restrictions
+  // Ensure greedy matching for lexicals
+  TCOMMENT_CHAR    -/- [\/]
+  TINT             -/- [0-9]
+  TID              -/- [a-zA-Z0-9\_]
+  
+  // EOF may not be followed by any char
+  TEOF             -/- ~[]
+  
+  // Backslash chars in strings may not be followed by " 
+  TBACKSLASH_CHAR  -/- [\"]
+
+context-free restrictions
+  // Ensure greedy matching for comments
+  LAYOUT? -/- [\ \t\n\r]
+  LAYOUT? -/- [\/].[\/]
+  LAYOUT? -/- [\/].[\*]

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/tim/exp.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/tim/exp.sdf3
@@ -1,0 +1,62 @@
+module tim/exp
+
+imports
+  tim/common
+  tim/type
+  
+context-free sorts TValue
+context-free syntax
+  TValue.TValueInt = <<TINT>>
+  TValue.TValueString = <<TSTRING>>
+  TValue.TValueVar = <<TID>>
+
+context-free sorts TExp TFun
+context-free syntax
+  TExp.THole = [hole]
+
+  TExp.TExpApp = [
+    [TValue]([{TValue ", "}*])
+  ]
+  
+  TExp.TExpFix = [
+    fix {
+      [{TFun "\n"}*]
+    } in
+      [TExp]
+  ]
+  
+  TFun.TFun = [
+    fun [TID]([{TID ", "}*]) =
+      [TExp]
+  ]
+    
+context-free syntax // primitive operations
+  TExp.TExpPrimOp = [
+    #[TPRIM]([{TValue ", "}*]) => [TID];
+    [TExp]
+  ]
+  
+  // does not produce a value and tail-calls (or terminates)
+  TExp.TExpTerminatingPrimOp = [
+    #[TPRIM]([{TValue ", "}*])
+  ]
+  
+  TExp.TExpConditionalPrimOp = [
+    if #[TPRIM]([{TValue ", "}*]) then
+      [TExp]
+    else
+      [TExp]
+  ]
+  
+context-free sorts TBind
+context-free syntax // sugar
+  TExp.TExpLet = [
+    let [{TBind ","}*] in
+      [TExp]
+  ]
+  
+  TBind.TBind = [[TID] = [TValue]]
+  
+template options
+  TID = keyword {reject} // ensure print and friends are parsed as primops and not calls
+  TPRIM = keyword {reject}

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/tim/type.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/tim/type.sdf3
@@ -1,0 +1,14 @@
+module tim/type
+
+imports
+  tim/common
+  
+context-free sorts TType
+context-free syntax
+  TType.TTypeInt = <int>
+  TType.TTypeVal = <cval>
+  TType.TTypeNoVal = <cnoval>
+  TType.TTypeCDone = <cdone>
+  TType.TTypeCExp = <cexp>
+  TType.TTypeCFun = <cfun>
+  TType.TTypeCFuns = <cfuns>

--- a/lwb/metalang/dynamix/dynamix.spoofax2/syntax/type.sdf3
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/syntax/type.sdf3
@@ -1,0 +1,53 @@
+module type
+
+imports
+  common
+  source
+  tim/exp
+  
+context-free sorts MSourceType
+context-free syntax
+  MSourceType.MSourceTypeSortID = [[UID]]
+  MSourceType.MSourceTypeString = [string]
+  MSourceType.MSourceTypeInt = [int]
+  
+// these differ from MSourceType in that they mirror
+// the exact syntax of the stratego generated signatures
+//
+// we do not use the same syntax since it would mean having
+// both source lists and meta lists, which is too confusing
+// for no good reason. instead, we transparently convert
+// any lists in a quoted expression into meta lists containing
+// the quoted source types
+context-free sorts MConstructorArgument
+context-free syntax
+  MConstructorArgument.MConstructorArgumentSortID = [[UID]]
+  MConstructorArgument.MConstructorArgumentString = [string]
+  MConstructorArgument.MConstructorArgumentInt = [int]
+  MConstructorArgument.MConstructorArgumentList = [List([MConstructorArgument])]
+
+context-free sorts MType
+context-free syntax
+  MType.MTypeSourceType = <'<MSourceType>>
+  MType.MTypeTargetType = <@<MTargetType>>
+  // todo: this currently doesn't align with the interpreter
+  // as the interpreter only supports lists of CPS values
+  MType.MTypeList = <List(<MType>)> 
+
+  // the type argument represents the type of the variable used
+  // when bound within a body using the <- operator, and does not
+  // necessarily represent the "return value" of the AST node that
+  // contains the hole
+  MType.MTypeHoly1 = <Holy(<MType>)>
+  MType.MTypeHoly0 = <Holy>
+  
+context-free sorts MTargetType
+context-free syntax
+  MTargetType.MTargetTypeValue = <value>
+  // represents a finalized AST node (aka tail calling)
+  MTargetType.MTargetTypeCPSFinalized = <statement>
+  
+context-free sorts MRuleSignature
+context-free syntax
+  MRuleSignature.MRuleSignature = [[{MType " * "}+] -> [MType]]
+  MRuleSignature.MRuleZeroSignature = [() -> [MType]] // function that takes no arguments

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/analysis.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/analysis.str
@@ -1,0 +1,52 @@
+module analysis
+
+imports
+
+  statixruntime
+  statix/api
+  statix/runtime/renaming
+
+  pp
+  injections/-
+
+  libspoofax/term/origin
+
+rules // Analysis
+
+  // single-file analysis
+  editor-analyze = stx-editor-analyze(pre-analyze, post-analyze|"statics", "programOk")
+
+  // see README.md for details on how to switch to multi-file analysis
+  // multi-file analysis
+//  editor-analyze = stx-editor-analyze(pre-analyze, post-analyze|"statics", "projectOk", "fileOk")
+
+  pre-analyze  = origin-track-forced(explicate-injections-dynamix-Start)
+  post-analyze = origin-track-forced(implicate-injections-dynamix-Start)
+
+rules // Editor Services
+
+  editor-resolve = stx-editor-resolve
+
+  editor-hover = stx-editor-hover
+
+rules // Debugging
+
+  // Prints the abstract syntax ATerm of a selection.
+  debug-show-aterm: (selected, _, _, path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"aterm")> path
+       ; result   := selected
+
+  // Prints the pre-analyzed abstract syntax ATerm of a selection.
+  debug-show-pre-analyzed: (selected, _, _, path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"pre-analyzed.aterm")> path
+       ; result   := <pre-analyze> selected
+
+  // Prints the analyzed annotated abstract syntax ATerm of a selection.
+  debug-show-analyzed: (selected, _, _, path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"analyzed.aterm")> path
+       ; result   := selected
+
+rules // Rename refactoring
+
+  // change last strategy argument to id if multi-file analysis is enabled
+  rename-menu-action = rename-action(construct-textual-change, editor-analyze, fail)

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/analysis.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/analysis.str
@@ -8,17 +8,16 @@ imports
 
   pp
   injections/-
+  
+  compilation/compile
+  
+  evaluation/eval
 
   libspoofax/term/origin
 
 rules // Analysis
-
-  // single-file analysis
-  editor-analyze = stx-editor-analyze(pre-analyze, post-analyze|"statics", "programOk")
-
-  // see README.md for details on how to switch to multi-file analysis
   // multi-file analysis
-//  editor-analyze = stx-editor-analyze(pre-analyze, post-analyze|"statics", "projectOk", "fileOk")
+  editor-analyze = stx-editor-analyze(pre-analyze, post-analyze|"statics", "projectOk", "fileOk")
 
   pre-analyze  = origin-track-forced(explicate-injections-dynamix-Start)
   post-analyze = origin-track-forced(implicate-injections-dynamix-Start)
@@ -45,6 +44,18 @@ rules // Debugging
   debug-show-analyzed: (selected, _, _, path, project-path) -> (filename, result)
     with filename := <guarantee-extension(|"analyzed.aterm")> path
        ; result   := selected
+       
+  debug-qualify-usages: (_, _, p@Program(mid, _), path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"qualified.dx")> path
+       ; result   := <dx--qualify-module(|mid); pp-dynamix-string> p
+       
+  debug-merge-specs: (_, _, p, path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"merged.dx")> path
+       ; result := <dx--to-merged; pp-dynamix-string> p
+       
+  debug-evaluate-specs: (_, _, p, path, project-path) -> (filename, result)
+    with filename := <guarantee-extension(|"out")> path
+       ; result := <dx--to-merged; dx--eval-program> p
 
 rules // Rename refactoring
 

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/compilation/compile.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/compilation/compile.str
@@ -1,0 +1,44 @@
+module compilation/compile
+
+imports
+  signatures/dynamix-sig
+  statix/api
+
+rules
+  // during compilation, we fully qualify all references to rules by prefixing
+  // them with "<modname>!" (e.g. exprs!compileExpr). This allows us to merge
+  // all specifications together without worrying about ambiguity about which
+  // specific rule was selected.
+  dx--generate-aterm: (_, _, p@Program(mid, _), path, project-path) -> ($[[mid].aterm], p')
+    where
+      p' := <dx--qualify-module(|mid); strip-annos> p
+  
+  dx--qualify-module(|mid) = topdown(try(dx--fully-qualify(|mid)))
+  dx--fully-qualify(|mid): MRuleDeclSignature(name, sig) -> MRuleDeclSignature($[[mid]![name]], sig)
+  dx--fully-qualify(|mid): MRuleDecl(name, pats, body) -> MRuleDecl($[[mid]![name]], pats, body)
+  dx--fully-qualify(|mid): n@MExprCall(name, args) -> MExprCall(qualifiedName, args)
+    where
+      a := <stx-get-ast-analysis> n;
+      ref := <stx-get-ast-ref(|a)> name;
+      refMod := <stx-get-ast-property(|a, "declaringModule")> ref;
+      qualifiedName := $[[refMod]![name]]
+
+  // merging simply combines together all of the rule sections
+  // from the input asts. it is assumed that each of the specs
+  // has already been fully qualified (and as a result, we can
+  // throw away any signatures, primitives and import sections
+  // without worrying that we lose information)
+  dx--merge-specifications: specs -> Program("merged", mergedSpecs)
+    where
+      sections := <map({ s:
+        ?Program(_, s);
+        <filter(?MSectionRules(_) <+ ?MSectionExample(_))> s
+      })> specs;
+      mergedSpecs := <flatten-list> sections
+
+  // helper function during testing, will merge a MultiProgram
+  // assumes the input is analyzed, because it needs to qualify
+  dx--to-merged: p@Program(_, _) -> p
+  dx--to-merged: MultiProgram(programs) -> result
+    with parts := <map({ mid: ?Program(mid, _); dx--qualify-module(|mid) })> programs
+       ; result := <dx--merge-specifications> parts

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/dynamix.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/dynamix.str
@@ -1,0 +1,16 @@
+module dynamix
+
+imports
+  
+  completion/completion
+  pp
+  outline
+  analysis
+
+rules // Debugging
+  
+  debug-show-aterm:
+    (node, _, _, path, project-path) -> (filename, result)
+    with
+      filename := <guarantee-extension(|"aterm")> path
+    ; result   := node

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/dynamix.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/dynamix.str
@@ -1,14 +1,19 @@
 module dynamix
 
 imports
-  
+
   completion/completion
+
+  compilation/-
+  evaluation/-
+  dynamix/-
+
   pp
   outline
   analysis
 
 rules // Debugging
-  
+
   debug-show-aterm:
     (node, _, _, path, project-path) -> (filename, result)
     with

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/dynamix/api.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/dynamix/api.str
@@ -1,0 +1,27 @@
+module dynamix/api
+
+imports
+  compilation/compile
+  evaluation/eval
+  
+rules
+  // compile the program by applying the input term to the qualified
+  // rule with the given name
+  dx-compile-program(|rule) = dx-compile-program(id|rule)
+  
+  // compile the program by applying the input term to the qualified
+  // rule with the given name, but transform the input term using
+  // the given stratego strategy first
+  dx-compile-program(pre-compile|rule): input -> result
+    with processed := <pre-compile> input
+       ; spec := <dx--compiled-spec>
+       ; result := <dx--eval-input-term> (spec, rule, processed)
+       
+rules
+  dx--compiled-spec =
+    language-resources(dx--compiled-spec-location, ![]);
+    debug(!"Compiled spec: ");
+    ?[(_, <id>)]
+
+  dx--compiled-spec-location: _ -> $[[srcgen]/dynamix.merged.aterm]
+    with srcgen := <project-srcgen-dir> "dynamix"

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/evaluation/eval.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/evaluation/eval.str
@@ -1,0 +1,488 @@
+module evaluation/eval
+
+imports
+  signatures/common-sig
+  signatures/dynamix-sig
+  signatures/source-sig
+  signatures/meta-sig
+  signatures/tim/common-sig
+  signatures/tim/exp-sig
+  
+  libspoofax/stratego/debug
+  libstratego-gpp
+  
+  pp
+  
+  evaluation/scope
+  
+// Sort used to represent the value of some entry at runtime.
+// Roughly equivalent to TValue, except that functions are first-class
+// and that we do not support references to labels.
+signature
+  sorts MRuntimeValue
+  constructors
+    // a source term
+    MRuntimeQuote : STerm -> MRuntimeValue
+    
+    // a delayed CPS instantiation of the given term
+    // the first argument is a list of either a single argument
+    // (in the cases that there exists some value), or an empty list
+    // only valid runtime values here are MRuntimeValues and MRuntimeMetaLists
+    MRuntimeHoly : List(MRuntimeValue) * TExp -> MRuntimeValue
+    
+    // a directly accessible CPS value. the value may not be legal
+    // in all contexts (such as when the value represents a variable)
+    MRuntimeValue : TValue -> MRuntimeValue
+    
+    // a CPS expression that has now been finalized, because we have
+    // filled in the last hole with a tail call or some other expression
+    // that causes control flow to continue at a separate place
+    MRuntimeCPSFinalized : TExp -> MRuntimeValue
+    
+    // A list at the meta level of the language.
+    MRuntimeMetaList : List(TValue) -> MRuntimeValue
+    
+// pp bugfix, need to insert an injection
+// as the default typings are wrong
+signature
+  sorts BoxLiteral
+  constructors
+    : string -> BoxLiteral
+  
+// Program evaluation
+rules
+  dx--eval-program = eval-program
+  dx--eval-input-term = eval-input-term
+  
+  // evaluate the given term as the sole input to the 
+  // rule with the given (qualified) name
+  // eval-input-term: Start * string * ? -> string
+  eval-input-term: (program, rule, term) -> ret
+    where {| MRule, MStackTrace:
+      <init-trace> ();
+      stripped := <strip-annos> program;
+      <declare-mrules> stripped;
+      evaluated := <eval-expr(|<scope-new>)> MExprCall(rule, [term]);
+      ret := <finalize> evaluated
+    |}
+
+  // evaluate the examples inside the input file
+  // eval-program :: Start -> string
+  eval-program: term -> ret
+    where {| MRule, MStackTrace:
+      <init-trace> ();
+      stripped := <strip-annos> term;
+      <declare-mrules> stripped;
+      ret := <eval-examples; concat-strings; debug> stripped
+    |}
+  
+  // declare-mrules :: Start -> Start
+  declare-mrules: p@Program(_, decls) -> p
+    with <
+      reverse;
+      map(try(declare-rules))
+    > decls
+    
+  // declare-rules :: MSection -> MSection
+  declare-rules: n@MSectionRules(r) -> n
+    where <reverse; filter(declare-rule)> r
+    
+  // declare-rule :: MRuleDecl -> MRuleDecl
+  declare-rule: p@MRuleDecl(n, _, _) -> p
+    where rules(MRule :+ n -> p)
+
+  // eval-examples :: Start -> List(string)
+  eval-examples = ?Program(_, x); !x; filter(eval-example)
+  
+  // eval-example :: MSection -> string
+  eval-example: MSectionExample(expr) -> <strcat> (<pp-partial-dynamix-string> exp, "\n\n")
+    with ret := <eval-expr(|<scope-new>)> expr
+    with exp := <finalize> ret
+    
+// Finalizing example
+rules
+  // finalize :: MRuntimeValue -> TExp
+  finalize: MRuntimeHoly(_, ctx) -> <plug(|TExpTerminatingPrimOp("exit", []))> ctx
+  finalize: MRuntimeCPSFinalized(ctx) -> ctx
+  // finalize: MRuntimeValue(v) -> TExpPrimOp0(TPrimOpPrint(), [v])
+  finalize = fail-msg(|"Unable to represent this value as a CPS term: ")
+  
+// Expression evaluation
+rules
+  // eval-expr(|MScope) :: MExpr -> MRuntimeValue
+  
+  // source language operations
+  eval-expr(|scope): MExprQuote(term) -> MRuntimeQuote(term)
+  
+  // meta language operations
+  eval-expr(|scope): MExprVar(x) -> <scope-get(|x)> scope
+  eval-expr(|scope): MExprBlock(exprs) -> <eval-block-stmts(|scope')> exprs
+    with scope' := <scope-push> scope
+      
+  // todo: do arguments to a function call need to be composed
+  // or be values in order for the call to be valid?
+  eval-expr(|scope): MExprCall(name, args) -> ret
+    with
+      args' := <map(eval-expr(|scope))> args;
+      (scope', MRuleDecl(fnname, _, body)) := <find-rule> (name, args');
+      <push-trace> fnname;
+      ret := <eval-expr(|scope')> body;
+      <pop-trace> ()
+      
+  // todo: arity for label?
+  eval-expr(|scope): MExprLabeled1(body, labelName) -> ret
+    with
+      continuationName := <newname> "k";
+      argumentName := <newname> "a";
+      
+      // bind continuation label in body
+      scope' := <scope-push> scope;
+      <scope-set(|labelName, MRuntimeValue(TValueVar(continuationName)))> scope';
+      bodye := <eval-expr(|scope')> body;
+      
+      // check if we received a tail-calling expression
+      if <?MRuntimeCPSFinalized(fin)> bodye then
+        ret := MRuntimeHoly([MRuntimeValue(TValueVar(argumentName))], TExpFix([
+          TFun(continuationName, [argumentName], THole())
+        ], fin))
+      else
+        <fail-msg(|"Expected the pre-body of a label to always tail-call, but got: ")> bodye
+      end
+      
+  eval-expr(|scope): MExprLabeled0(body, labelName) -> ret
+    with
+      continuationName := <newname> "k";
+      
+      // bind continuation label in body
+      scope' := <scope-push> scope;
+      <scope-set(|labelName, MRuntimeValue(TValueVar(continuationName)))> scope';
+      bodye := <eval-expr(|scope')> body;
+      
+      // check if we received a tail-calling expression
+      if <?MRuntimeCPSFinalized(fin)> bodye then
+        ret := MRuntimeHoly([], TExpFix([
+          TFun(continuationName, [], THole())
+        ], fin))
+      else
+        <fail-msg(|"Expected the pre-body of a label to always tail-call, but got: ")> bodye
+      end
+      
+  eval-expr(|scope): MExprSourceIntToTargetInt(v) -> MRuntimeValue(tv')
+    with MRuntimeQuote(tv) := <eval-expr(|scope)> v
+    with tv' := <coerce-source-to-tint> tv
+  eval-expr(|scope): MExprSourceVarToTargetVar(v) -> MRuntimeValue(TValueVar(tv'))
+    with tv := <eval-expr(|scope); assert-source-string(|"var() argument must be a string")> v
+    with tv' := <unquote(?'"')> tv // typed stratego bug, doesn't think UID and TID are the same
+  eval-expr(|scope): MExprSourceStrToTargetStr(v) -> MRuntimeValue(TValueString(tv))
+    with tv := <eval-expr(|scope); assert-source-string(|"str() argument must be a string")> v
+  eval-expr(|scope): MExprConcatenateStr(l, r) -> MRuntimeQuote(STermString(out))
+    with l' := <eval-expr(|scope); assert-source-string(|"left-hand of string concatenation must be a string")> l
+    with r' := <eval-expr(|scope); assert-source-string(|"right-hand of string concatenation must be a string")> r
+    with out := $["[<unquote(?'"')> l'][<unquote(?'"')> r']"]
+  eval-expr(|scope): MExprFreshNamedTargetVar(p) -> MRuntimeValue(TValueVar(<newname> p))
+  
+  eval-expr(|scope): MExprList(args) -> MRuntimeMetaList(args')
+    with args' := <map(eval-expr(|scope); assert-runtime-value(|"Meta-list must be constructed from a value, not: "))> args
+  eval-expr(|scope): MExprListCons(args, list) -> MRuntimeMetaList(<conc> (args', list'))
+    with args' := <map(eval-expr(|scope); assert-runtime-value(|"Meta-list must be constructed from a value, not: "))> args
+    with list' := <eval-expr(|scope); assert-target-metalist(|"Second argument to cons must be a meta-list, not: ")> list
+  eval-expr(|scope): MExprConcatList(l, r) -> MRuntimeMetaList(<conc> (left', right'))
+    with left' := <eval-expr(|scope); assert-target-metalist(|"Left argument to concat must be a meta-list, not: ")> l
+    with right' := <eval-expr(|scope); assert-target-metalist(|"Right argument to concat must be a meta-list, not: ")> r
+  
+  // todo: continuation argument composition? currently force values
+  eval-expr(|scope): MExprContinueAt(tgt, args) -> MRuntimeCPSFinalized(TExpApp(tgtf, argvs))
+    with
+      tgtf := <eval-expr(|scope); assert-runtime-value(|"Can only call named functions: ")> tgt;
+      argvs := <eval-expr(|scope); assert-target-metalist(|"Arguments to a continuation invocation must be a meta-list: ")> args      
+      
+  eval-continuation-arg(s): a -> ret
+    with
+      v := <s> a;
+      ret := <assert-runtime-value(|"Expected continuation argument to be a value: ")> v
+  
+  // target language ops
+  eval-expr(|scope): MExprCallPrimitive(op, args) -> MRuntimeHoly([MRuntimeValue(TValueVar(y))], TExpPrimOp(op, v, y, THole()))
+    with v := <map(eval-expr(|scope)); assert-runtime-values-or-metalists> args
+    with <newname> "y" => y
+  eval-expr(|scope): MExprConditionalPrimitive(primop, args, then, else) -> MRuntimeCPSFinalized(
+    TExpConditionalPrimOp(primop, args', then', else')
+  )
+    with
+      args' := <map(eval-expr(|scope)); assert-runtime-values-or-metalists> args;
+      then' := <eval-expr(|scope); assert-tail-call(|"If statement body must be a tail-call: ")> then;
+      else' := <eval-expr(|scope); assert-tail-call(|"If statement body must be a tail-call: ")> else
+  eval-expr(|scope): MExprTLet(name, val, body) -> <compose-cps-values> (
+    MRuntimeHoly([], TExpLet([TBind(x, val')], THole())), 
+    res
+  ) 
+    with
+      x := <eval-expr(|scope); assert-target-var(|"Name of a let binding must be a target var, not: ")> name;
+      val' := <eval-expr(|scope); assert-runtime-value(|"Value of let-stmt must be a value: ")> val;
+      res := <eval-expr(|scope)> body
+  eval-expr(|scope): MExprHole() -> MRuntimeHoly([], THole())
+  eval-expr(|scope): MExprTFix(funs) -> MRuntimeHoly([], TExpFix(tfuns, THole()))
+    with
+      tfuns := <map(eval-tfun(|scope))> funs
+  eval-expr(|scope): MExprQuoteTarget(lit) -> MRuntimeHoly([], lit)
+    with <oncetd(?THole()) <+ fail-msg(|"Must have a hole in a target language literal.")> lit
+      
+  // eval-tfun(|MScope) :: MTFun -> TFun
+  eval-tfun(|scope): MTFun(name, args, body) -> TFun(name', args', body')
+    with
+      name' := <eval-expr(|scope); assert-target-var(|"Function name must be a value: ")> name;
+      args' := <
+        eval-expr(|scope);
+        assert-target-metalist(|"Function args must be a meta-list: ");
+        map(assert-tvar(|"Argument must be a var name: "))
+      > args;
+      body' := <eval-expr(|scope); assert-tail-call(|"Body of a function must end with a tail call: ")> body
+  
+  
+  
+  
+// Evaluation helpers
+rules 
+  // evaluate a list of block statements in the given scope
+  // and make sure to take care of output composition
+  // eval-block-stmts(|MScope) :: List(MStatement) -> MRuntimeValue
+  eval-block-stmts(|scope): [stmt] -> <eval-block-stmt(|scope)> stmt
+  eval-block-stmts(|scope): [s | rest@[_ | _]] -> res
+    with <debug(!"0: ")> s
+    with s' := <eval-block-stmt(|scope)> s // eval first
+    with <debug(!"0->: ")> s'
+    with <debug(!"1: ")> rest
+    with rest' := <eval-block-stmts(|scope)> rest
+    with <debug(!"1->: ")> rest'
+    with res := <compose-cps-values> (s', rest')
+    
+  // eval-block-stmt(|MScope) :: MStatement -> MRuntimeValue
+  eval-block-stmt(|scope): MStatementExpr(e) -> <eval-expr(|scope)> e
+  eval-block-stmt(|scope): MStatementAssign(name, val) -> e
+    with e := <eval-expr(|scope)> val
+    with <assign-bind(|name, scope)> e
+    
+  // assert-runtime-values-or-metalists :: List(MRuntimeValue) -> List(TValue)
+  assert-runtime-values-or-metalists = map({ x, y:
+    (?MRuntimeValue(x); ![x])
+      <+ (?MRuntimeMetaList(y); !y)
+      <+ fail-msg(|"Expected runtime values or meta-lists")
+  }); flatten-list
+    
+  // assert-runtime-value(|string) :: MRuntimeValue -> TValue
+  assert-runtime-value(|msg): MRuntimeValue(tval) -> tval
+  assert-runtime-value(|msg) = fail-msg(|msg)
+    
+  // assert-tail-call(|string) :: MRuntimeValue -> TExp
+  assert-tail-call(|_): MRuntimeCPSFinalized(e) -> e
+  assert-tail-call(|msg) = fail-msg(|msg)
+    
+  // assert-target-var(|string) :: MRuntimeValue -> TID
+  assert-target-var(|_): MRuntimeValue(TValueVar(tvar)) -> tvar
+  assert-target-var(|msg) = fail-msg(|msg)
+  
+  // assert-source-string(|string) :: MRuntimeValue -> string
+  assert-source-string(|_): MRuntimeQuote(STermString(tvar)) -> tvar
+  assert-source-string(|msg) = fail-msg(|msg)
+  
+  // assert-target-metalist(|string) :: MRuntimeValue -> List(TValue)
+  assert-target-metalist(|_): MRuntimeMetaList(vs) -> vs
+  assert-target-metalist(|msg) = fail-msg(|msg)
+  
+  // assert-tvar(|string) :: TValue -> TID
+  assert-tvar(|_): TValueVar(vs) -> vs
+  assert-tvar(|msg) = fail-msg(|msg)
+  
+  // coerce-source-to-tint :: STerm -> TValue
+  coerce-source-to-tint: STermString(s) -> TValueInt(<unquote(?'"')> s)
+  coerce-source-to-tint: STermInt(s) -> TValueInt(s)
+  coerce-source-to-tint = fail-msg(|"Cannot convert this term to a CPS integer: ")
+      
+// CPS value composition
+// TODO: Check if this is sound now that we've introduced
+// meta-lists into the language.
+rules
+  // compose-cps-values :: MRuntimeValue * MRuntimeValue -> MRuntimeValue
+  
+  // plug(|TExp) :: TExp -> TExp
+  plug(|x) = oncetd(\THole() -> x\)
+      
+  // a partially done CSP combined with a done CSP results in a done CSP
+  // no need to forward the values since we can no longer access them from
+  // the body anyway
+  compose-cps-values: (
+    MRuntimeHoly(vals, exp),
+    MRuntimeCPSFinalized(rest)
+  ) -> MRuntimeCPSFinalized(<plug(|rest)> exp)
+  
+  // todo: verify
+  compose-cps-values: (
+    a@MRuntimeCPSFinalized(_),
+    _
+  ) -> a
+  
+  // a partial term combined with a partial term yields a new partial term
+  // with the second expression inserted in the hole of the first expression
+  compose-cps-values: (
+    MRuntimeHoly(vals1, exp1),
+    MRuntimeHoly(vals2, exp2)
+  ) -> MRuntimeHoly(vals2, <plug(|exp2)> exp1)
+  
+  // a partial term combined with an immediate value is simply still the
+  // partial term, but now linked with the value
+  compose-cps-values: (
+    MRuntimeHoly(vals, exp),
+    v@MRuntimeValue(_)
+  ) -> MRuntimeHoly([v], exp)
+  compose-cps-values: (
+    MRuntimeHoly(vals, exp),
+    v@MRuntimeMetaList(_)
+  ) -> MRuntimeHoly([v], exp)
+  
+  // combining a runtime value with a holy value simply results in the holy
+  // value
+  compose-cps-values: (
+    MRuntimeValue(_),
+    holy@MRuntimeHoly(_, _)
+  ) -> holy
+  compose-cps-values: (
+    MRuntimeMetaList(_),
+    holy@MRuntimeHoly(_, _)
+  ) -> holy
+  
+  // A finalized term has no holes to be filled, and since we
+  // don't need to fill any, we're all good.
+  compose-cps-values: (
+    MRuntimeValue(_),
+    fin@MRuntimeCPSFinalized(_)
+  ) -> fin
+  compose-cps-values: (
+    MRuntimeMetaList(_),
+    fin@MRuntimeCPSFinalized(_)
+  ) -> fin
+  
+  // all of these are side-effect free
+  compose-cps-values: (
+    MRuntimeValue(_),
+    v@MRuntimeValue(_)
+  ) -> v
+  compose-cps-values: (
+    MRuntimeValue(_),
+    v@MRuntimeMetaList(_)
+  ) -> v
+  compose-cps-values: (
+    MRuntimeMetaList(_),
+    v@MRuntimeValue(_)
+  ) -> v
+  compose-cps-values: (
+    MRuntimeMetaList(_),
+    v@MRuntimeMetaList(_)
+  ) -> v
+  
+  // the rest of the combinations are illegal
+  // TODO: check if this is correct if we also have source terms
+  compose-cps-values: (
+    a,
+    b
+  ) -> <fail-msg(|"Invalid composition of CPS values: ")> (a, b)
+      
+  // assign-bind(|string, MScope) :: MRuntimeValue -> ?
+  assign-bind(|name, scope): MRuntimeHoly([x], _) -> ()
+    with <scope-set(|name, x)> scope
+  assign-bind(|name, scope): v@MRuntimeValue(_) -> ()
+    with <scope-set(|name, v)> scope
+  assign-bind(|name, scope): v@MRuntimeMetaList(_) -> ()
+    with <scope-set(|name, v)> scope
+  assign-bind(|name, scope): v@MRuntimeQuote(_) -> ()
+    with <scope-set(|name, v)> scope
+  assign-bind(|name, scope): v@MRuntimeCPSFinalized(_) -> ()
+    with <fail-msg(|"Cannot bind term that has already been finalized: ")> v
+  assign-bind(|name, scope): v -> ()
+    with <fail-msg(|"Do not know how to assign value of type: ")> v
+      
+// Rule selection
+rules
+  // same as find-rule but will exit if not found
+  // find-rule :: string * List(MRuntimeValue) -> MScope * MRuleDecl
+  find-rule = ?(x, _); (try-find-rule <+ fail-msg(|$[Unable to find a matching [x] rule declaration.]))
+
+  // try-find-rule :: string * List(MRuntimeValue) -> MScope * MRuleDecl
+  try-find-rule: (name, args) -> matched
+    where
+      options := <bagof-MRule> name;
+      matched := <getfirst(match-rule(|args))> options
+      
+  // match-rule(|List(MRuntimeValue)) :: MRuleDecl -> MScope * MRuleDecl
+  match-rule(|args): r@MRuleDecl(_, argPats, _) -> (scope, r)
+    where
+      scope-new => scope;
+      <zip(match-pattern(|scope))> (argPats, args)
+      
+  // match-pattern(|MScope) :: MPattern * MRuntimeValue -> ?
+  match-pattern(|_): (MPatternWildcard(), _) -> ()
+  match-pattern(|scope): (MPatternVariable(x), v) -> ()
+    where
+      existing := <scope-get(|x)> scope;
+      <eq> (existing, v)
+  match-pattern(|scope): (MPatternVariable(x), v) -> ()
+    where <not(scope-get(|x))> scope
+    with <scope-set(|x, v)> scope
+  match-pattern(|scope): (MPatternString(s), MRuntimeQuote(STermString(sv))) -> ()
+    where <eq> (s, sv)
+  match-pattern(|scope): (MPatternConstructor(name, args), MRuntimeQuote(STermApp(name', argvs))) -> ()
+    where <eq> (name, name')
+    where <zip(match-pattern(|scope))> (args, <map(!MRuntimeQuote(<id>))> argvs)
+  match-pattern(|scope): (MPatternList(argpats), MRuntimeQuote(STermList(argvs))) -> ()
+    where <zip(match-pattern(|scope))> (argpats, <map(!MRuntimeQuote(<id>))> argvs)
+  match-pattern(|scope): (MPatternListCons(argpats, restpat), MRuntimeQuote(STermList(args))) -> ()
+    where (argvs, restv) := <split-at(|<length> argpats)> args
+    where <zip(match-pattern(|scope))> (argpats, <map(!MRuntimeQuote(<id>))> argvs)
+    where <match-pattern(|scope)> (restpat, MRuntimeQuote(STermList(restv)))
+  match-pattern(|scope): (MPatternBound(x, p), v) -> ()
+    where <match-pattern(|scope)> (p, v)
+    where <not(scope-get(|x))> scope // ensure not already bound in sub-pattern or adjacent pattern
+    with <scope-set(|x, v)> scope
+//  match-pattern(|_): (a, b) -> ()
+//    where <ppdebug(|"Cannot unify these two patterns: ")> (a, b)
+//    where <fail> ()
+    
+// Utils
+rules
+  // Pretty print the input term and write out the given message, then exit.
+  // fail-msg(|string) :: ? -> ?
+  fail-msg(|msg) =
+    // error message
+    ?x; err-msg(|msg); !x;
+    
+    // term
+    ppdebug(|"== On term: ==\n");
+    
+    // trace
+    MStackTrace;
+    join-to-string(id|"\n");
+    debug(!"== Stack trace: ==\n   ");
+    
+    // exit
+    !1; exit
+  
+  // init-trace :: a -> a
+  init-trace: a -> a
+    with rules(MStackTrace := [])
+    
+  // push-trace :: string -> string
+  push-trace: s -> s
+    with x := <MStackTrace> ()
+    with rules(MStackTrace := [s|x])
+    
+  // pop-trace :: a -> a
+  pop-trace: a -> a
+    with [_|x] := <MStackTrace> ()
+    with rules(MStackTrace := x)
+    
+  // join-to-string(a -> string|string) :: List(a) -> string
+  join-to-string(s|sep) = map(s); !(<id>, ""); foldl(conc(|sep))
+  
+  // conc(|string) :: Tuple(string, string) -> string
+  conc(|sep): (a, "") -> a
+  conc(|sep): (a, b) -> $[[b][sep][a]]
+  

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/evaluation/scope.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/evaluation/scope.str
@@ -1,0 +1,30 @@
+module evaluation/scope
+
+imports  
+  evaluation/eval
+  
+signature
+  sorts MScope
+  constructors MScope : List(Hashtable) -> MScope
+  
+rules
+  // scope-new :: ? -> MScope
+  scope-new = !MScope([<new-hashtable>])
+  
+  // scope-set(|string, MRuntimeValue) :: MScope -> MScope
+  scope-set(|k, v): s@MScope([cur|_]) -> s
+    with <hashtable-put(|k, v)> cur
+    
+  // scope-get(|string) :: MScope -> MRuntimeValue
+  scope-get(|k): MScope(vals) -> <getfirst(hashtable-get(|k))> vals
+  
+  // scope-push :: MScope -> MScope
+  scope-push: MScope(v) -> MScope([<new-hashtable>|v])
+  
+  // scope-debug :: MScope -> List(?)
+  scope-debug: MScope(v) -> <map(hashtable-getlist); concat> v
+  
+  // scope-pop :: MScope -> MScope
+  scope-pop: MScope([_|v]) -> MScope(v)
+  
+  

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/outline.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/outline.str
@@ -1,0 +1,15 @@
+module outline
+
+imports
+  
+  signatures/dynamix-sig
+  libspoofax/editor/outline
+
+rules
+  
+  editor-outline:
+    (_, _, ast, path, project-path) -> outline
+    where
+      outline := <simple-label-outline(to-outline-label)> ast
+  
+  to-outline-label = fail

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/pp.str
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/pp.str
@@ -1,0 +1,49 @@
+module pp
+
+imports
+
+  libstratego-gpp
+  libspoofax/sdf/pp
+  libspoofax/editor/refactoring/-
+  pp/dynamix-parenthesize
+  pp/dynamix-pp
+
+rules
+
+  editor-format:
+    (node, _, ast, path, project-path) -> (filename, result)
+    with
+      ext      := <get-extension> path
+    ; filename := <guarantee-extension(|$[pp.[ext]])> path
+    ; result   := <pp-debug> node
+
+rules
+  
+  pp-dynamix-string =
+    parenthesize-dynamix
+    ; prettyprint-dynamix-start-symbols
+    ; !V([], <id>)
+    ; box2text-string(|120)
+      
+  pp-partial-dynamix-string =
+    parenthesize-dynamix
+    ; prettyprint-dynamix
+    ; !V([], <id>)
+    ; box2text-string(|120)
+    
+  pp-partial-dynamix-string(|sort) =
+    parenthesize-dynamix
+    ; prettyprint-dynamix(|sort)
+    ; !V([], <id>)
+    ; box2text-string(|120)  
+      
+  pp-debug :
+    ast -> result
+    with
+       result := <pp-dynamix-string> ast
+    <+ <bottomup(try(not(is-string); not(is-list); not(pp-dynamix-string); debug(!"cannot pp ")))> ast
+    ;  result := ""
+
+rules
+  
+  construct-textual-change = construct-textual-change(pp-partial-dynamix-string, parenthesize, override-reconstruction, resugar)

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/statics.stx
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/statics.stx
@@ -1,0 +1,24 @@
+module statics
+
+// see README.md for details on how to switch to multi-file analysis
+
+rules // single-file entry point
+
+  programOk : Start
+
+  programOk(Empty()).
+
+rules // multi-file entry point
+
+  projectOk : scope
+
+  projectOk(s).
+
+  fileOk : scope * Start
+
+  fileOk(s, Empty()).
+
+signature
+
+  sorts Start constructors
+    Empty : Start

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/statics.stx
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/statics.stx
@@ -1,24 +1,383 @@
 module statics
 
-// see README.md for details on how to switch to multi-file analysis
-
-rules // single-file entry point
-
-  programOk : Start
-
-  programOk(Empty()).
-
-rules // multi-file entry point
-
+imports
+  signatures/dynamix-sig
+  
+  statics/names
+  statics/type
+  
+rules
   projectOk : scope
-
   projectOk(s).
 
   fileOk : scope * Start
+  fileOk(globalS, Program(modname, sections)) :- {modS}
+    new modS,
+    insertModuleName(modS, modname),
+    declareModule(globalS, modname, modS),
+    sectionsOk(globalS, modS, sections).
+  fileOk(globalS, MultiProgram(programs)) :- 
+    filesOk(globalS, programs).
+  filesOk maps fileOk(*, list(*))
+  
+rules
+  sectionOk : scope * scope * MSection
+  sectionsOk maps sectionOk(*, *, list(*))
+  
+  sectionOk(globalS, s, MSectionImports(imports)) :- importsOk(globalS, s, imports).
+  sectionOk(_, s, MSectionSignature(decls)) :- signatureDeclsOk(s, decls).
+  sectionOk(_, s, MSectionRules(rules)) :- ruleDeclsOk(s, rules).
+  sectionOk(_, s, MSectionExample(exp)) :- typeOfExp(s, exp) == _.
+  sectionOk(_, s, MSectionPrimitives(decls)) :- primitiveDeclsOk(s, decls).
 
-  fileOk(s, Empty()).
+  importOk : scope * scope * MID
+  importsOk maps importOk(*, *, list(*))
+  importOk(globalS, modS, import) :- {importS}
+    resolveModule(globalS, import) == importS,
+    modS -I-> importS.
+  
+// primitives section
+rules
+  primitiveDeclOk : scope * MPrimitiveDecl
+  primitiveDeclsOk maps primitiveDeclOk(*, list(*))
+  
+  primitiveDeclOk(s, MPrimitiveDeclExpression(name, tys)) :- {AT}
+    mTypesToMTYPEs(s, tys) == AT,
+    primitiveArgumentTypesOk(AT) | error $[Primitives may only take @value or List(@value) as argument type.],
+    declarePrimitive(s, name, MPRIMITIVEEXPR(AT)).
+  primitiveDeclOk(s, MPrimitiveDeclStatement(name, tys)) :- {AT}
+    mTypesToMTYPEs(s, tys) == AT,
+    primitiveArgumentTypesOk(AT) | error $[Primitives may only take @value or List(@value) as argument type.],
+    declarePrimitive(s, name, MPRIMITIVESTMT(AT)).
+  primitiveDeclOk(s, MPrimitiveDeclConditional(name, tys)) :- {AT}
+    mTypesToMTYPEs(s, tys) == AT,
+    primitiveArgumentTypesOk(AT) | error $[Primitives may only take @value or List(@value) as argument type.],
+    declarePrimitive(s, name, MPRIMITIVECOND(AT)).
+  
+  primitiveArgumentTypeOk : MTYPE
+  primitiveArgumentTypesOk maps primitiveArgumentTypeOk(list(*))
+  
+  primitiveArgumentTypeOk(MTTYPE(TVALUE())).
+  primitiveArgumentTypeOk(MLIST(MTTYPE(TVALUE()))).
+  
+// signatures section
+rules
+  signatureDeclOk : scope * MSignatureDecl
+  signatureDeclsOk maps signatureDeclOk(*, list(*))
+  
+  signatureDeclOk(s, MSignatureSortsDecl(sorts)) :- defineSorts(s, sorts).
+  signatureDeclOk(s, MSignatureConstructorsDecl(cons)) :- constructorDeclsOk(s, cons).
+  
+  constructorDeclOk : scope * MConstructorDecl
+  constructorDeclsOk maps constructorDeclOk(*, list(*))
+  
+  constructorDeclOk(s, MConstructorDeclSingleton(consname, sortname)) :-
+    declareConstructor(s, consname, SCONS([], resolveSort(s, sortname))).
+  constructorDeclOk(s, MConstructorDeclInjection(from, to)) :- {S}
+    resolveSort(s, to) == S,
+    declareInjection(
+      s,
+      constructorArgumentToType(s, from),
+      S
+    ).
+  constructorDeclOk(s, MConstructorDecl(consname, args, sortname)) :-
+    declareConstructor(s, consname, SCONS(
+      constructorArgumentsToTypes(s, args),
+      resolveSort(s, sortname)
+    )).
+  
+  defineSort : scope * UID
+  defineSort(s, x) :- declareSort(s, x, SSORT(x, s)).
+  defineSorts maps defineSort(*, list(*))
 
-signature
+// rules section
+rules
+  ruleDeclOk : scope * MRuleDecl
+  ruleDeclsOk maps ruleDeclOk(*, list(*))
+  
+  ruleDeclOk(s, MRuleDeclSignature(name, sig)) :-
+    declareRule(s, name, ruleSignatureToMRULE(s, sig)),
+    assignModuleName(s, astId(name)).
+  ruleDeclOk(s, MRuleDecl(name, pats, body)) :- {as bs AT RT BT}
+    new as, as -P-> s, new bs, bs -P-> as,
+    assertRuleDefinedInLocalModule(s, name),
+    resolveRule(s, name) == MRULE(AT, RT),
+    declareZipPatterns(s, as, pats, AT) == _, // | error $[The argument pattern for [name] does not agree with its definition.],
+    typeOfExp(bs, body) == BT,
+    typeCoercibleTo(BT, RT) | error $[The return type of this rule, [BT], is not compatible with the declared return type, [RT].].
+  
+  ruleSignatureToMRULE : scope * MRuleSignature -> MRULE
+  ruleSignatureToMRULE(s, MRuleSignature(args, ret)) = MRULE(mTypesToMTYPEs(s, args), mTypeToMTYPE(s, ret)).
+  ruleSignatureToMRULE(s, MRuleZeroSignature(ret)) = MRULE([], mTypeToMTYPE(s, ret)).  
 
-  sorts Start constructors
-    Empty : Start
+// rule patterns
+rules
+  declareZipPatterns maps declarePattern(*, *, list(*), list(*)) = list(*)
+  declarePatterns maps declarePattern(*, *, list(*), *) = list(*)
+  
+  //               s       defS    pat        expectedType    actualType
+  declarePattern : scope * scope * MPattern * MTYPE        -> MTYPE
+  declarePattern(_, _, MPatternWildcard(), T) = T.
+  declarePattern(_, _, MPatternString(_), T) = MSTYPE(SSTRING()) :-
+    typeCoercibleTo(MSTYPE(SSTRING()), T) | error $[A string pattern cannot be used to match values of type [T].].
+  declarePattern(_, _, MPatternInt(_), T) = MSTYPE(SINT()) :-
+    typeCoercibleTo(MSTYPE(SINT()), T) | error $[An integer pattern cannot be used to match values of type [T].].
+  declarePattern(_, ds, p@MPatternVariable(name), ty) = ty :-
+    declareVar(ds, name, ty),
+    @p.type := ty.
+  declarePattern(s, ds, MPatternList(pats), ty) = ty :- {ET}
+    ty == MLIST(ET) | error $[Cannot list-pattern match on a non-list type [ty].],
+    declarePatterns(s, ds, pats, ET) == _.
+  declarePattern(s, ds, MPatternListCons(pats, retpat), ty) = ty :- {ET}
+    ty == MLIST(ET) | error $[Cannot list-pattern match on a non-list type [ty].],
+    declarePatterns(s, ds, pats, ET) == _,
+    declarePattern(s, ds, retpat, ty) == _.
+  declarePattern(s, ds, MPatternConstructor(name, argpats), ty) = MSTYPE(ST) :- {sn AT}
+    resolveConstructor(s, name) == SCONS(AT, ST),    
+    declareZipPatterns(s, ds, argpats, AT) == _,    
+    typeCoercibleTo(MSTYPE(ST), ty) | error $[This pattern matches values of sort [ST], which is not compatible with the expected type of this pattern [ty].].
+  declarePattern(s, ds, MPatternBound(name, pat), ty) = PT :-
+    declarePattern(s, ds, pat, ty) == PT,
+    declareVar(ds, name, PT),
+    @name.type := PT.
+    
+// expressions
+rules
+  typeOfExp : scope * MExpr -> MTYPE
+  typesOfExps maps typeOfExp(*, list(*)) = list(*)
+  typeOfExp(s, e) = T :-
+    typeOfExp_(s, e) == T,
+    @e.type := T.
+  
+  typeOfExp_ : scope * MExpr -> MTYPE
+  typeOfExp_(s, MExprVar(x)) = resolveVar(s, x).
+  typeOfExp_(s, MExprQuote(t)) = typeOfQuote(s, t).
+  typeOfExp_(s, MExprBlock(stmts)) = typeOfBlockStmts(s, stmts).
+  typeOfExp_(s, MExprCall(ruleName, args)) = RT :- {AT}
+    resolveRule(s, ruleName) == MRULE(AT, RT),
+    callTypesCompatible(typesOfExps(s, args), AT).
+  typeOfExp_(s, MExprLabeled0(body, labelName)) = MHOLY0() :- {s' RT}
+    new s', s' -P-> s,
+    declareVar(s', labelName, MTTYPE(TVALUE())),
+    typeOfExp(s', body) == RT,
+    try { RT == MTTYPE(TSTATEMENT()) } | error $[The body of a labeled expression must always result in a tail-call (value of type @statement).].
+  typeOfExp_(s, MExprLabeled1(body, labelName)) = MHOLY1(MTTYPE(TVALUE())) :- {s' RT}
+    new s', s' -P-> s,
+    declareVar(s', labelName, MTTYPE(TVALUE())),
+    typeOfExp(s', body) == RT,
+    try { RT == MTTYPE(TSTATEMENT()) } | error $[The body of a labeled expression must always result in a tail-call (value of type @statement).].
+  typeOfExp_(s, MExprSourceIntToTargetInt(v)) = MTTYPE(TVALUE()) :- {T}
+    typeOfExp(s, v) == T,
+    try { coercibleToInt(T) } | error $[Can only coerce strings and integers to target integers.].
+  typeOfExp_(s, MExprSourceVarToTargetVar(v)) = MTTYPE(TVALUE()) :- {T}
+    typeOfExp(s, v) == T,
+    try { typeCoercibleTo(MSTYPE(SSTRING()), T) } | error $[Can only coerce strings to target variables.].
+  typeOfExp_(s, MExprSourceStrToTargetStr(v)) = MTTYPE(TVALUE()) :- {T}
+    typeOfExp(s, v) == T,
+    try { typeCoercibleTo(MSTYPE(SSTRING()), T) } | error $[Can only coerce strings to target strings.].
+  typeOfExp_(s, MExprFreshNamedTargetVar(_)) = MTTYPE(TVALUE()).
+  typeOfExp_(s, MExprList([])) = MLIST(MAUTO(_)).
+  typeOfExp_(s, MExprList(es)) = MLIST(ET) :-
+    lub(typesOfExps(s, es)) == ET | error $[List literal does not have a common type.].
+  typeOfExp_(s, MExprListCons(es, rest)) = MLIST(ET) :-
+    lub(typesOfExps(s, es)) == ET | error $[List literal does not have a common type.],
+    typeCoercibleTo(typeOfExp(s, rest), MLIST(ET)) | error $[List rest literal does not share a type with the given elements.].
+  typeOfExp_(s, MExprConcatList(left, right)) = MLIST(LET) :- {RET}
+    typeOfExp(s, left) == MLIST(LET) | error $[List concatenation performed on non-list value.],
+    typeOfExp(s, right) == MLIST(RET) | error $[List concatenation performed on non-list value.],
+    try { LET == RET } | error $[List concatenation types are not compatible with each other.].
+  typeOfExp_(s, MExprContinueAt(tgt, args)) = MTTYPE(TSTATEMENT()) :-
+    typeCoercibleTo(typeOfExp(s, tgt), MTTYPE(TVALUE())) | error $[Can only continue on target values.],
+    typeCoercibleTo(typeOfExp(s, args), MLIST(MTTYPE(TVALUE()))) | error $[Continuation arguments must be a list of target values.].
+  typeOfExp_(s, MExprCallPrimitive(name, args)) = primitiveReturnType(P) :- {AT EAT}
+    typesOfExps(s, args) == AT,
+    resolvePrimitive(s, name) == P,
+    primitiveArgumentsType(P) == EAT | error $[Primitive [name] is not defined or not an expression or statement primitive.],
+    callTypesCompatible(AT, EAT).
+  typeOfExp_(s, MExprConditionalPrimitive(name, args, ift, ife)) = RT :- {AT IT ET EAT}
+    typesOfExps(s, args) == AT,
+    resolvePrimitive(s, name) == MPRIMITIVECOND(EAT) | error $[Primitive [name] is not defined or is not a conditional primitive.],
+    callTypesCompatible(AT, EAT),
+    typeOfExp(s, ift) == IT,
+    typeOfExp(s, ife) == ET,
+    lub([IT, ET]) == RT | error $[[IT] and [ET] have no common type.].
+  typeOfExp_(s, MExprTLet(name, val, body)) = RT :-
+    typeOfExp(s, name) == MTTYPE(TVALUE()) | error $[`let` name must be a @value.]@name,
+    typeOfExp(s, val) == MTTYPE(TVALUE()) | error $[`let` value must be a @value.]@val,
+    RT == composeTypes(MHOLY0(), typeOfExp(s, body)).
+  typeOfExp_(s, MExprHole()) = MHOLY0().
+  typeOfExp_(s, MExprTFix(funs)) = MHOLY0() :-
+    funDefsOk(s, funs).
+  typeOfExp_(s, MExprConcatenateStr(left, right)) = MSTYPE(SSTRING()) :-
+    typeCoercibleTo(MSTYPE(SSTRING()), typeOfExp(s, left)) | error $[The left-hand side of the `+` operator must be a source string. Runtime addition is done through primitives, not the + operator.]@left,
+    typeCoercibleTo(MSTYPE(SSTRING()), typeOfExp(s, right)) | error $[The right-hand side of the `+` operator must be a source string. Runtime addition is done through primitives, not the + operator.]@right.
+  typeOfExp_(s, MExprQuoteTarget(_)) = MHOLY0() :-
+    try { false } | warning $[Quoted target blocks are deprecated and will be removed.].
+    
+  coercibleToInt : MTYPE
+  coercibleToInt(MSTYPE(SSTRING())).
+  coercibleToInt(MSTYPE(SINT())).
+  coercibleToInt(T) :- typeCoercibleTo(MSTYPE(SSTRING()), T).
+  
+  primitiveArgumentsType : MPRIMITIVE -> list(MTYPE)
+  primitiveArgumentsType(MPRIMITIVEEXPR(A)) = A.
+  primitiveArgumentsType(MPRIMITIVESTMT(A)) = A.
+  
+  primitiveReturnType : MPRIMITIVE -> MTYPE
+  primitiveReturnType(MPRIMITIVEEXPR(_)) = MTTYPE(TVALUE()).
+  primitiveReturnType(MPRIMITIVESTMT(_)) = MTTYPE(TSTATEMENT()).
+  
+  callTypesCompatible : list(MTYPE) * list(MTYPE)
+  callTypesCompatible([], []).
+  callTypesCompatible(_, []) :- false | error $[Too many arguments supplied to this call.].
+  callTypesCompatible([], _) :- false | error $[Not enough arguments supplied to this call.].
+  callTypesCompatible([A|ar], [B|br]) :-
+    typeCoercibleTo(A, B) | error $[The given parameter type [A] is not compatible with the expected parameter type [B].],
+    callTypesCompatible(ar, br).
+  
+  funDefOk : scope * MTFun
+  funDefsOk maps funDefOk(*, list(*))
+  funDefOk(s, MTFun(name, args, body)) :- {s'}
+    typeCoercibleTo(typeOfExp(s, name), MTTYPE(TVALUE())) | error $[The name of a function must be a value.],
+    typeCoercibleTo(typeOfExp(s, args), MLIST(MTTYPE(TVALUE()))) | error $[The arguments of a function must be a list of values.],
+    new s', s' -P-> s,
+    typeOfExp(s', body) == _.
+  
+// quoted expressions
+rules
+  typeOfQuote : scope * STerm -> MTYPE
+  typeOfQuote_ : scope * STerm -> MTYPE
+  typesOfQuotes maps typeOfQuote(*, list(*)) = list(*)
+  
+  typeOfQuote(s, e) = T :-
+    typeOfQuote_(s, e) == T,
+    @e.type := T.
+  
+  typeOfQuote_(_, STermInt(_)) = MSTYPE(SINT()).
+  typeOfQuote_(_, STermString(_)) = MSTYPE(SSTRING()).
+  typeOfQuote_(_, STermList([])) = MLIST(MAUTO(_)).
+  typeOfQuote_(s, STermList(els)) = MLIST(lub(typesOfQuotes(s, els))).
+  typeOfQuote_(s, STermApp(name, args)) = MSTYPE(ST) :- {AT}
+    resolveConstructor(s, name) == SCONS(AT, ST),
+    quoteTypesCompatible(s, args, AT) | error $[Mismatched number of arguments.].
+    
+  quoteTypeCompatible : scope * STerm * MTYPE
+  quoteTypesCompatible maps quoteTypeCompatible(*, list(*), list(*))
+  
+  quoteTypeCompatible(s, term, T) :- {TT}
+    typeOfQuote(s, term) == TT,
+    typeCoercibleTo(TT, T) | error $[The type [TT] is not compatible with the expected type [T].].
+   
+rules // statements and composition
+  typeOfBlockStmts : scope * list(MStatement) -> MTYPE
+  typeOfBlockStmts(s, [stmt]) = typeOfBlockStmt(s, stmt).
+  typeOfBlockStmts(s, [stmt|rest@[_|_]]) = composeTypes(ST, RT) :- 
+    typeOfBlockStmt(s, stmt) == ST,
+    typeOfBlockStmts(s, rest) == RT.
+  
+  typeOfBlockStmt : scope * MStatement -> MTYPE
+  typeOfBlockStmt(s, MStatementExpr(e)) = typeOfExp(s, e).
+  typeOfBlockStmt(s, MStatementAssign(name, e)) = T :-
+    typeOfExp(s, e) == T,
+    performAssignment(s, name, T).
+    
+  performAssignment : scope * string * MTYPE
+  performAssignment(s, n, MHOLY1(x)) :- declareVar(s, n, x).
+  performAssignment(s, n, x@MTTYPE(TVALUE())) :- declareVar(s, n, x).
+  performAssignment(s, n, x@MLIST(_)) :- declareVar(s, n, x).
+  performAssignment(s, n, x@MSTYPE(_)) :- declareVar(s, n, x).
+  performAssignment(s, n, x) :-
+    try { false } | error $[Cannot assign variables of type [x] since it does not have a concrete value.],
+    false.
+   
+rules // primitives
+  assertExprPrimitive : string * list(MTYPE) -> MTYPE
+  assertExprPrimitive("int-add", [MTTYPE(TVALUE()), MTTYPE(TVALUE())]) = MTTYPE(TVALUE()).
+  
+  assertConditionalPrimitive : string * list(MTYPE)
+   
+/*
+  typeOfExp_(s, MExprBlock(stmts)) = typeOfBlockStmts(s, stmts).
+  typeOfExp_(s, MExprCall(ruleName, args)) = _ :- {RT}
+    resolveRule(s, ruleName) == MRULE(RT),
+    typesCoercibleToSTypes(typesOfExps(s, args), RT),
+    try { false } | warning $[TODO].
+  // todo: Labeled0
+  typeOfExp_(s, MExprLabeled1(body, labelName)) = THOLY1(TVALUE()) :- {s' RT}
+    new s', s' -P-> s,
+    declareVar(s', labelName, TVALUE()),
+    typeOfExp(s', body) == RT,
+    try { RT == TFIN() } | error $[The body of a labeled expression must diverge (tail-call a continuation).].
+  typeOfExp_(s, MExprSourceIntToTargetInt(v)) = TVALUE() :- {T}
+    typeOfExp(s, v) == T,
+    try { coercibleToInt(T) } | error $[Can only coerce strings and integers to target integers.].
+  typeOfExp_(s, MExprSourceVarToTargetVar(v)) = TVALUE() :- {T}
+    typeOfExp(s, v) == T,
+    try { T == SQUOTE(SSTRING()) } | error $[Can only coerce strings to target variables.].
+  typeOfExp_(s, MExprSourceStrToTargetStr(v)) = TVALUE() :- {T}
+    typeOfExp(s, v) == T,
+    try { T == SQUOTE(SSTRING()) } | error $[Can only coerce strings to target strings.].
+  typeOfExp_(s, MExprFreshNamedTargetVar(_)) = TVALUE().
+  typeOfExp_(s, MExprList(es)) = MLIST(ET) :-
+    lub(typesOfExps(s, es)) == ET | error $[List literal does not have a common type.].
+  typeOfExp_(s, MExprListCons(es, rest)) = MLIST(ET) :-
+    lub(typesOfExps(s, es)) == ET | error $[List literal does not have a common type.],
+    typeCoercibleTo(typeOfExp(s, rest), MLIST(ET)) | error $[List rest literal does not share a type with the given elements.].
+  typeOfExp_(s, MExprConcatList(left, right)) = MLIST(LET) :- {RET}
+    typeOfExp(s, left) == MLIST(LET) | error $[List concatenation performed on non-list value.],
+    typeOfExp(s, right) == MLIST(RET) | error $[List concatenation performed on non-list value.],
+    try { LET == RET } | error $[List concatenation types are not compatible with each other.].
+  typeOfExp_(s, MExprContinueAt(tgt, args)) = TFIN() :-
+    typeOfExp(s, tgt) == TVALUE() | error $[Can only continue on target values.],
+    typeOfExp(s, args) == MLIST(TVALUE()) | error $[Continuation arguments must be a list of target values.].
+  typeOfExp_(s, MExprCallPrimitive(name, args)) = T :- {AT}
+    typesOfExps(s, args) == AT,
+    assertExprPrimitive(name, AT) == T | error $[Illegal or unknown primitive call.].
+  typeOfExp_(s, MExprConditionalPrimitive(name, args, ift, ife)) = RT :- {AT IT ET}
+    typesOfExps(s, args) == AT,
+    assertConditionalPrimitive(name, AT) | error $[Illegal or unknown primitive call.],
+    typeOfExp(s, ift) == IT,
+    typeOfExp(s, ife) == ET,
+    lub([IT, ET]) == RT | error $[[IT] and [ET] have no common type.].
+  typeOfExp_(s, MExprTFix(funs)) = THOLY0() :-
+    funDefsOk(s, funs).
+      
+  funDefOk : scope * MTFun
+  funDefsOk maps funDefOk(*, list(*))
+  funDefOk(s, MTFun(name, args, body)) :-
+    typeOfExp(s, name) == TVALUE() | error $[The name of a function must be a value.],
+    typeOfExp(s, args) == MLIST(TVALUE()) | error $[The arguments of a function must be a list of values.],
+    typeOfExp(s, body) == _.
+      
+  coercibleToInt : TYPE
+  coercibleToInt(SQUOTE(SINT())).
+  coercibleToInt(SQUOTE(SSTRING())).
+  
+rules // statements and composition
+  typeOfBlockStmts : scope * list(MStatement) -> TYPE
+  typeOfBlockStmts(s, [stmt]) = typeOfBlockStmt(s, stmt).
+  typeOfBlockStmts(s, [stmt|rest@[_|_]]) = T :- {ST RT}
+    typeOfBlockStmt(s, stmt) == ST,
+    typeOfBlockStmts(s, rest) == RT,
+    composeTypes(ST, RT) == T.
+  
+  typeOfBlockStmt : scope * MStatement -> TYPE
+  typeOfBlockStmt(s, MStatementExpr(e)) = typeOfExp(s, e).
+  typeOfBlockStmt(s, MStatementAssign(name, e)) = T :-
+    typeOfExp(s, e) == T,
+    performAssignment(s, name, T).
+    
+  performAssignment : scope * string * TYPE
+  performAssignment(s, n, THOLY1(x)) :- declareVar(s, n, x).
+  performAssignment(s, n, x@TVALUE()) :- declareVar(s, n, x).
+  performAssignment(s, n, x@MLIST(_)) :- declareVar(s, n, x).
+  performAssignment(s, n, x@SQUOTE(_)) :- declareVar(s, n, x).
+  performAssignment(s, n, x) :-
+    try { false } | error $[Cannot assign variables of type [x] since it does not have a concrete value.],
+    false.
+    
+rules // primitives
+  assertExprPrimitive : string * list(TYPE) -> TYPE
+  assertExprPrimitive("int+", [TVALUE(), TVALUE()]) = TVALUE().
+  
+  assertConditionalPrimitive : string * list(TYPE)*/

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/statics/names.stx
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/statics/names.stx
@@ -1,0 +1,127 @@
+module statics/names
+
+imports
+  signatures/common-sig
+  statics/type
+  
+signature
+  name-resolution labels
+    P // parent-child, only used in rules
+    I // import
+    
+  relations
+    rule : string -> MRULE
+    primitive : string -> MPRIMITIVE
+    var : string -> MTYPE
+    mod : string -> scope // module
+    curmod : -> string // name of current module
+    
+  sorts MRULE MPRIMITIVE
+  constructors
+    //      arguments     return type
+    MRULE : list(MTYPE) * MTYPE -> MRULE
+    
+    MPRIMITIVEEXPR : list(MTYPE) -> MPRIMITIVE
+    MPRIMITIVESTMT : list(MTYPE) -> MPRIMITIVE
+    MPRIMITIVECOND : list(MTYPE) -> MPRIMITIVE
+    
+rules
+  // lookup var in current scope or parent scopes
+  lookupVar : scope * string -> list((path * (string * MTYPE)))
+  lookupVar(s, x) = ps :-
+    query var filter P* and { x' :- x == x' } min $ < P and true in s |-> ps.
+    
+  // resolve var to the given ID
+  resolveVar : scope * string -> MTYPE
+  resolveVar(s, x) = T :- {x'}
+    lookupVar(s, x) == [(_, (x', T))|_] | error $[Undefined variable [x].]@x,
+    @x.ref := x'.
+    
+  // declare new var, assert it is not shadowed in the current scope
+  declareVar : scope * string * MTYPE
+  declareVar(s, x, T) :- {ps}
+    !var[x, T] in s,
+    query var filter e and { x' :- x' == x } min and false in s |-> ps,
+    try { ps == [_] } | error $[Duplicate declaration of [x] in the same scope.]@x,
+    @x.type := T.
+    
+rules
+  // lookup module in scope, must be global scope
+  lookupModule : scope * string -> list((path * (string * scope)))
+  lookupModule(s, x) = ps :-
+    query mod filter e and { x' :- x == x' } min $ < P and true in s |-> ps.
+    
+  // resolve module to its top-level scope
+  resolveModule : scope * string -> scope
+  resolveModule(s, x) = T :- {x'}
+    lookupModule(s, x) == [(_, (x', T))|_] | error $[Undefined module [x].]@x,
+    @x.ref := x'.
+    
+  // declare new module, assert it is unique
+  declareModule : scope * string * scope
+  declareModule(s, x, ms) :- {ps}
+    !mod[x, ms] in s,
+    query mod filter e and { x' :- x' == x } min and false in s |-> ps,
+    try { ps == [_] } | error $[Duplicate declaration of module [x].]@x.
+    
+rules
+  // insert current module name in scope
+  insertModuleName : scope * string
+  insertModuleName(s, x) :-
+    !curmod[x] in s.
+  
+  // lookup module in scope, must be global scope
+  assignModuleName : scope * astId
+  assignModuleName(s, node) :- {modname}
+    query curmod filter P* and true min and true in s |-> [(_, modname)],
+    @node.declaringModule := modname.
+    
+rules
+  // lookup rule in current scope or parent scopes
+  lookupRule : scope * string -> list((path * (string * MRULE)))
+  lookupRule(s, x) = ps :-
+    // go through any number of P/I, prefer closer declarations
+    query rule filter (P | I)* and { x' :- x == x' } min $ < P, $ < I and true in s |-> ps.
+    
+  // resolve rule to the given ID
+  resolveRule : scope * string -> MRULE
+  resolveRule(s, x) = T :- {x'}
+    lookupRule(s, x) == [(_, (x', T))|_] | error $[Undeclared rule [x].]@x,
+    @x.ref := x'.
+    
+  // declare new rule, assert it is not shadowed in the current scope
+  declareRule : scope * string * MRULE
+  declareRule(s, x, T) :- {ps}
+    !rule[x, T] in s,
+    // allow shadowing by only checking for duplicate declarations in the current program scope
+    query rule filter e and { x' :- x' == x } min and false in s |-> ps,
+    try { ps == [_] } | error $[Duplicate declaration of rule [x].]@x.
+    
+  // raises an error if a user attempts to declare a new rule for
+  // something declared in an imported module. doing so ensures
+  // that we always have a consistent order in which patterns 
+  // should be attempted
+  assertRuleDefinedInLocalModule : scope * string
+  assertRuleDefinedInLocalModule(s, x) :- {ps}
+    query rule filter P* and { x' :- x' == x } min and false in s |-> ps,
+    try { ps == [_] } | error $[New implementations may not be added to the imported rule [x].].
+    
+rules
+  // lookup primitive in current scope or parent scopes
+  lookupPrimitive : scope * string -> list((path * (string * MPRIMITIVE)))
+  lookupPrimitive(s, x) = ps :-
+    query primitive filter (P | I)* and { x' :- x == x' } min $ < P and true in s |-> ps.
+    
+  // resolve primitive to the given ID
+  resolvePrimitive : scope * string -> MPRIMITIVE
+  resolvePrimitive(s, x) = T :- {x'}
+    lookupPrimitive(s, x) == [(_, (x', T))|_] | error $[Undeclared primitive [x].]@x,
+    @x.ref := x'.
+    
+  // declare new primitive, assert it is not shadowed in the current scope
+  declarePrimitive : scope * string * MPRIMITIVE
+  declarePrimitive(s, x, T) :- {ps}
+    !primitive[x, T] in s,
+    // do not allow primitive shadowing as there's no good use for doing so
+    query primitive filter (P | I)* and { x' :- x' == x } min and false in s |-> ps,
+    try { ps == [_] } | error $[Duplicate declaration of primitive [x].]@x.

--- a/lwb/metalang/dynamix/dynamix.spoofax2/trans/statics/type.stx
+++ b/lwb/metalang/dynamix/dynamix.spoofax2/trans/statics/type.stx
@@ -1,0 +1,194 @@
+module statics/type
+
+imports
+  signatures/dynamix-sig
+  statics/names
+  
+// actual types
+signature
+  sorts
+    STYPE // source type (' prefix)
+    MTYPE // meta type (no prefix)
+    TTYPE // target type (@ prefix)
+  
+  constructors
+    // Source types
+    SINT : STYPE // literal int
+    SSTRING : STYPE // literal string
+    SSORT : string * scope -> STYPE // reference to a sort, scope is the global scope (for injections)
+    
+    // Meta types
+    MSTYPE : STYPE -> MTYPE // '<stype>
+    MTTYPE : TTYPE -> MTYPE // @<ttype>
+    MLIST : MTYPE -> MTYPE // List(...)
+    MHOLY0 : MTYPE // Holy
+    MHOLY1 : MTYPE -> MTYPE // Holy(T)
+    MAUTO : MTYPE -> MTYPE // automatic derivation of type, used for empty list literal
+    
+    // Target types
+    TVALUE : TTYPE // value
+    TSTATEMENT : TTYPE // statement
+    
+// constructor management
+signature
+  sorts
+    SCONS
+    
+  constructors
+    // represents a defined constructor. note that we
+    // use MTYPE instead of STYPE to prevent having to
+    // have two concepts of lists (source and meta lists)
+    //
+    // A rule like
+    //   Call : Exp * list(Exp) -> Exp
+    // is represented as
+    //   SCONS([MSTYPE(SSORTID("Exp")), MLIST(MSTYPE(SSORTID("Exp")))], SSORTID("Exp"))
+    //
+    // Note that the second argument is always an SSORT
+    SCONS : list(MTYPE) * STYPE -> SCONS
+    
+// source types are represented as a list of sorts and
+// constructors in the global scope. Each sort additionally
+// has a list of injections defined on it
+signature
+  relations
+    sort : string -> STYPE // SSORT only
+    constructor : string -> SCONS
+    injection : MTYPE * STYPE // can convert the type to other type
+    
+rules
+  constructorArgumentToType : scope * MConstructorArgument -> MTYPE
+  constructorArgumentsToTypes maps constructorArgumentToType(*, list(*)) = list(*)
+  
+  constructorArgumentToType(_, MConstructorArgumentString()) = MSTYPE(SSTRING()).
+  constructorArgumentToType(_, MConstructorArgumentInt()) = MSTYPE(SINT()).
+  constructorArgumentToType(s, MConstructorArgumentList(el)) = MLIST(constructorArgumentToType(s, el)).
+  constructorArgumentToType(s, MConstructorArgumentSortID(sid)) = MSTYPE(resolveSort(s, sid)).
+ 
+rules
+  mTypeToMTYPE : scope * MType -> MTYPE
+  mTypesToMTYPEs maps mTypeToMTYPE(*, list(*)) = list(*)
+  
+  sourceTypeToSTYPE : scope * MSourceType -> STYPE
+  targetTypeToTTYPE : scope * MTargetType -> TTYPE
+  
+  mTypeToMTYPE(s, MTypeSourceType(st)) = MSTYPE(sourceTypeToSTYPE(s, st)).
+  mTypeToMTYPE(s, MTypeTargetType(st)) = MTTYPE(targetTypeToTTYPE(s, st)).
+  mTypeToMTYPE(s, MTypeList(el)) = MLIST(mTypeToMTYPE(s, el)).
+  mTypeToMTYPE(s, MTypeHoly1(el)) = MHOLY1(mTypeToMTYPE(s, el)).
+  mTypeToMTYPE(s, MTypeHoly0()) = MHOLY0().
+  
+  sourceTypeToSTYPE(s, MSourceTypeSortID(x)) = resolveSort(s, x). 
+  sourceTypeToSTYPE(s, MSourceTypeString()) = SSTRING().
+  sourceTypeToSTYPE(s, MSourceTypeInt()) = SINT().
+  
+  targetTypeToTTYPE(s, MTargetTypeValue()) = TVALUE().
+  targetTypeToTTYPE(s, MTargetTypeCPSFinalized()) = TSTATEMENT().
+  
+rules
+  composeTypes : MTYPE * MTYPE -> MTYPE
+  
+  // holy + fin
+  composeTypes(MHOLY1(_), MTTYPE(TSTATEMENT())) = MTTYPE(TSTATEMENT()).
+  composeTypes(MHOLY0(), MTTYPE(TSTATEMENT())) = MTTYPE(TSTATEMENT()).
+  
+  // holy + holy
+  composeTypes(MHOLY1(_), MHOLY1(x)) = MHOLY1(x).
+  composeTypes(MHOLY1(_), MHOLY0()) = MHOLY0().
+  composeTypes(MHOLY0(), MHOLY1(x)) = MHOLY1(x).
+  composeTypes(MHOLY0(), MHOLY0()) = MHOLY0().
+  
+  // holy + value
+  composeTypes(MHOLY1(_), MTTYPE(TVALUE())) = MHOLY1(MTTYPE(TVALUE())).
+  composeTypes(MHOLY0(), MTTYPE(TVALUE())) = MHOLY1(MTTYPE(TVALUE())).
+  
+  // holy + list (todo: check for non value list)
+  composeTypes(MHOLY1(_), t@MLIST(MTTYPE(TVALUE()))) = MHOLY1(t).
+  composeTypes(MHOLY0(), t@MLIST(MTTYPE(TVALUE()))) = MHOLY1(t).
+  
+  // value + holy
+  composeTypes(MTTYPE(TVALUE()), t@MHOLY1(_)) = t.
+  composeTypes(MTTYPE(TVALUE()), t@MHOLY0()) = t.
+  
+  // list + holy (todo: check for non-value lists)
+  composeTypes(MLIST(MTTYPE(TVALUE())), t@MHOLY1(_)) = t.
+  composeTypes(MLIST(MTTYPE(TVALUE())), t@MHOLY0()) = t.
+  
+  // value/meta list + fin
+  composeTypes(MTTYPE(TVALUE()), MTTYPE(TSTATEMENT())) = MTTYPE(TSTATEMENT()).
+  composeTypes(MLIST(MTTYPE(TVALUE())), MTTYPE(TSTATEMENT())) = MTTYPE(TSTATEMENT()).
+  
+  // direct replacements
+  composeTypes(MTTYPE(TVALUE()), t@MTTYPE(TVALUE())) = t.
+  composeTypes(MTTYPE(TVALUE()), t@MLIST(MTTYPE(TVALUE()))) = t.
+  composeTypes(MLIST(MTTYPE(TVALUE())), t@MTTYPE(TVALUE())) = t.
+  composeTypes(MLIST(MTTYPE(TVALUE())), t@MLIST(MTTYPE(TVALUE()))) = t.
+  
+  composeTypes(A, B) = _ :-
+    try { false } | error $[Cannot compose [A] and [B].],
+    false.
+ 
+rules
+  // holds if we can convert the first type to the second
+  typeCoercibleTo : MTYPE * MTYPE
+  typesCoercibleTo maps typeCoercibleTo(list(*), list(*))
+  
+  typeCoercibleTo(T, T).
+  typeCoercibleTo(MAUTO(A), B) :- A == B.
+  typeCoercibleTo(MHOLY1(_), MHOLY0()).
+  typeCoercibleTo(MTTYPE(TSTATEMENT()), MHOLY0()).
+  typeCoercibleTo(MTTYPE(TVALUE()), MHOLY1(MTTYPE(TVALUE()))).
+  typeCoercibleTo(MLIST(MTTYPE(TVALUE())), MHOLY1(MLIST(MTTYPE(TVALUE())))).
+  typeCoercibleTo(MLIST(MAUTO(_)), MHOLY1(MLIST(MTTYPE(TVALUE())))).
+  typeCoercibleTo(MLIST(A), MLIST(B)) :-
+    typeCoercibleTo(A, B).
+  typeCoercibleTo(T, MSTYPE(TT@SSORT(_, s))) :-
+    hasInjection(s, T, TT),
+    try { false } | note $[Coercing [T] to [TT].].
+    
+  // todo: better lub using injections?
+  lub : list(MTYPE) -> MTYPE
+  lub([T]) = T.
+  lub([T, T|r]) = lub([T|r]).
+    
+rules
+  lookupSort : scope * string -> list((path * (string * STYPE)))
+  lookupSort(s, x) = ps :-
+    query sort filter (P | I)* and { x' :- x == x' } min $ < P, $ < I and true in s |-> ps.
+    
+  resolveSort : scope * string -> STYPE
+  resolveSort(s, x) = T :- {x'}
+    lookupSort(s, x) == [(_, (x', T))|_] | error $[Undefined sort [x].],
+    @x.ref := x'.
+    
+  declareSort : scope * string * STYPE
+  declareSort(s, x, T) :- {ps}
+    !sort[x, T] in s,
+    // todo: does it make sense to make this e instead?
+    query sort filter (I | P)* and { x' :- x' == x } min and false in s |-> ps,
+    try { ps == [_] } | error $[Sort [x] is already declared in this module or an imported module.].
+    
+  lookupConstructor : scope * string -> list((path * (string * SCONS)))
+  lookupConstructor(s, x) = ps :-
+    query constructor filter (P | I)* and { x' :- x == x' } min $ < P and true in s |-> ps.
+    
+  resolveConstructor : scope * string -> SCONS
+  resolveConstructor(s, x) = T :- {x'}
+    lookupConstructor(s, x) == [(_, (x', T))|_] | error $[Undefined constructor [x].],
+    @x.ref := x'.
+    
+  declareConstructor : scope * string * SCONS
+  declareConstructor(s, x, T) :- {ps}
+    !constructor[x, T] in s,
+    query constructor filter (I | P)* and { x' :- x' == x } min and false in s |-> ps,
+    try { ps == [_] } | error $[Constructor [x] is already declared in this module or an imported module.].
+    
+  // declare that the given type can be injected in the given type
+  declareInjection : scope * MTYPE * STYPE
+  declareInjection(s, from, to) :-
+    !injection[from, to] in s.
+    
+  hasInjection : scope * MTYPE * STYPE
+  hasInjection(s, from, to) :- {ps}
+    query injection filter (I | P)* and { (a, b) :- a == from, b == to } min and false in s |-> ps,
+    ps != [].

--- a/lwb/metalang/dynamix/dynamix/build.gradle.kts
+++ b/lwb/metalang/dynamix/dynamix/build.gradle.kts
@@ -1,5 +1,7 @@
 import mb.spoofax.compiler.adapter.*
+import mb.spoofax.compiler.adapter.data.*
 import mb.spoofax.compiler.util.*
+import mb.spoofax.core.language.command.*
 import mb.spoofax.common.*
 
 plugins {
@@ -26,11 +28,18 @@ dependencies {
   annotationProcessor("org.derive4j:derive4j")
 }
 
+val packageId = "mb.dynamix"
+val taskPackageId = "$packageId.task"
+val spoofaxTaskPackageId = "$taskPackageId.spoofax"
+val debugTaskPackageId = "$taskPackageId.debug"
+val commandPackageId = "$packageId.command"
+
 languageProject {
   shared {
     name("Dynamix")
     defaultClassPrefix("Dynamix")
     defaultPackageId("mb.dynamix")
+    addFileExtensions("dx")
   }
   compilerInput {
     withParser().run {
@@ -40,9 +49,12 @@ languageProject {
     withConstraintAnalyzer().run {
       enableNaBL2(false)
       enableStatix(true)
-      multiFile(false) // TODO(molenzwiebel): Dynamix multi-file support
+      multiFile(true)
     }
-    withStrategoRuntime()
+    withStrategoRuntime().run {
+      addStrategyPackageIds("dynamix.strategies")
+      addInteropRegisterersByReflection("dynamix.strategies.InteropRegisterer")
+    }
   }
 }
 spoofax2BasedLanguageProject {
@@ -54,7 +66,7 @@ spoofax2BasedLanguageProject {
     }
     withStrategoRuntime().run {
       copyCtree(true)
-      copyClasses(false)
+      copyClasses(true)
     }
     project.languageSpecificationDependency(GradleDependency.project(":dynamix.spoofax2"))
   }
@@ -62,9 +74,16 @@ spoofax2BasedLanguageProject {
 
 languageAdapterProject {
   compilerInput {
-    withParser()
+    withParser().run {
+      // Wrap Parse task
+      extendParseTaskDef(spoofaxTaskPackageId, "DynamixParseWrapper")
+    }
     withStyler()
-    withConstraintAnalyzer()
+    withConstraintAnalyzer().run {
+      // Wrap AnalyzeMulti and rename base task
+      baseAnalyzeMultiTaskDef(spoofaxTaskPackageId, "BaseDynamixAnalyzeMulti")
+      extendAnalyzeMultiTaskDef(spoofaxTaskPackageId, "DynamixAnalyzeMultiWrapper")
+    }
     withStrategoRuntime()
     withReferenceResolution().run {
       resolveStrategy("editor-resolve")
@@ -72,13 +91,15 @@ languageAdapterProject {
     withHover().run {
       hoverStrategy("editor-hover")
     }
+    withGetSourceFiles().run {
+      extendGetSourceFilesTaskDef(spoofaxTaskPackageId, "DynamixGetSourceFiles")
+      baseGetSourceFilesTaskDef(spoofaxTaskPackageId, "BaseDynamixGetSourceFiles")
+    }
     project.configureCompilerInput()
   }
 }
-fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {
-  val packageId = "mb.dynamix"
-  val taskPackageId = "$packageId.task"
 
+fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {
   // Symbols
   addLineCommentSymbols("//")
   addBlockCommentSymbols(BlockCommentSymbols("/*", "*/"))
@@ -89,10 +110,44 @@ fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {
   baseComponent(packageId, "BaseDynamixComponent")
   extendComponent(packageId, "DynamixComponent")
 
-  /*// Manual multi-file check implementation.
-  isMultiFile(false) // TODO(molenzwiebel): Dynamix multi-file support
-  val spoofaxTaskPackageId = "$taskPackageId.spoofax"
-  baseCheckTaskDef(spoofaxTaskPackageId, "BaseDynamixCheck")
-  extendCheckTaskDef(spoofaxTaskPackageId, "DynamixCheck")*/
-  isMultiFile(false)
+  addTaskDefs(taskPackageId, "DynamixCompileModule")
+  addTaskDefs(taskPackageId, "DynamixCompileProject")
+  addTaskDefs(taskPackageId, "DynamixCompileAndMergeProject")
+  addTaskDefs(taskPackageId, "DynamixPrettyPrint")
+
+  isMultiFile(true)
+
+  val showMerged = TypeInfo.of(debugTaskPackageId, "DynamixShowMerged")
+  addTaskDefs(
+    showMerged
+  )
+
+  val showMergedCommand = CommandDefRepr.builder()
+    .type(commandPackageId, showMerged.id() + "Command")
+    .taskDefType(showMerged)
+    .argType(showMerged.appendToId(".Args"))
+    .displayName("Show normalized merged form")
+    .description("Shows the normalized and merged form in which definitions and calls are fully qualified")
+    .addSupportedExecutionTypes(CommandExecutionType.ManualOnce, CommandExecutionType.ManualContinuous)
+    .addAllParams(listOf(
+      ParamRepr.of("rootDirectory", TypeInfo.of("mb.resource.hierarchical", "ResourcePath"), true, ArgProviderRepr.enclosingContext(EnclosingCommandContextType.Project)),
+      ParamRepr.of("file", TypeInfo.of("mb.resource", "ResourceKey"), true, ArgProviderRepr.context(CommandContextType.File))
+    ))
+    .build()
+  val showMergedCommandMenuItem = CommandActionRepr.builder()
+    .manualOnce(showMergedCommand)
+    .fileRequired()
+    .enclosingProjectRequired()
+    .buildItem()
+
+  val commands = listOf(
+    showMergedCommand
+  )
+  addAllCommandDefs(commands)
+
+  val menuItems = listOf(
+    MenuItemRepr.menu("Evaluate", listOf(showMergedCommandMenuItem))
+  )
+  addAllMainMenuItems(menuItems)
+  addAllEditorContextMenuItems(menuItems)
 }

--- a/lwb/metalang/dynamix/dynamix/build.gradle.kts
+++ b/lwb/metalang/dynamix/dynamix/build.gradle.kts
@@ -1,0 +1,98 @@
+import mb.spoofax.compiler.adapter.*
+import mb.spoofax.compiler.util.*
+import mb.spoofax.common.*
+
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.spoofax2.language")
+  id("org.metaborg.spoofax.compiler.gradle.adapter")
+}
+
+fun compositeBuild(name: String) = "$group:$name:$version"
+
+dependencies {
+  api(compositeBuild("spoofax.common"))
+  api(compositeBuild("spoofax.compiler"))
+  api(compositeBuild("spoofax.compiler.dagger"))
+
+  compileOnly("org.derive4j:derive4j-annotation")
+
+  // Required because @Nullable has runtime retention (which includes classfile retention), and the Java compiler requires access to it.
+  compileOnly("com.google.code.findbugs:jsr305")
+
+  compileOnly("org.checkerframework:checker-qual-android")
+  compileOnly("org.immutables:value-annotations")
+  annotationProcessor("org.immutables:value")
+  annotationProcessor("org.derive4j:derive4j")
+}
+
+languageProject {
+  shared {
+    name("Dynamix")
+    defaultClassPrefix("Dynamix")
+    defaultPackageId("mb.dynamix")
+  }
+  compilerInput {
+    withParser().run {
+      startSymbol("Start")
+    }
+    withStyler()
+    withConstraintAnalyzer().run {
+      enableNaBL2(false)
+      enableStatix(true)
+      multiFile(false) // TODO(molenzwiebel): Dynamix multi-file support
+    }
+    withStrategoRuntime()
+  }
+}
+spoofax2BasedLanguageProject {
+  compilerInput {
+    withParser()
+    withStyler()
+    withConstraintAnalyzer().run {
+      copyStatix(true)
+    }
+    withStrategoRuntime().run {
+      copyCtree(true)
+      copyClasses(false)
+    }
+    project.languageSpecificationDependency(GradleDependency.project(":dynamix.spoofax2"))
+  }
+}
+
+languageAdapterProject {
+  compilerInput {
+    withParser()
+    withStyler()
+    withConstraintAnalyzer()
+    withStrategoRuntime()
+    withReferenceResolution().run {
+      resolveStrategy("editor-resolve")
+    }
+    withHover().run {
+      hoverStrategy("editor-hover")
+    }
+    project.configureCompilerInput()
+  }
+}
+fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {
+  val packageId = "mb.dynamix"
+  val taskPackageId = "$packageId.task"
+
+  // Symbols
+  addLineCommentSymbols("//")
+  addBlockCommentSymbols(BlockCommentSymbols("/*", "*/"))
+  addBracketSymbols(BracketSymbols('[', ']'))
+  addBracketSymbols(BracketSymbols('{', '}'))
+  addBracketSymbols(BracketSymbols('(', ')'))
+
+  baseComponent(packageId, "BaseDynamixComponent")
+  extendComponent(packageId, "DynamixComponent")
+
+  /*// Manual multi-file check implementation.
+  isMultiFile(false) // TODO(molenzwiebel): Dynamix multi-file support
+  val spoofaxTaskPackageId = "$taskPackageId.spoofax"
+  baseCheckTaskDef(spoofaxTaskPackageId, "BaseDynamixCheck")
+  extendCheckTaskDef(spoofaxTaskPackageId, "DynamixCheck")*/
+  isMultiFile(false)
+}

--- a/lwb/metalang/dynamix/dynamix/spoofaxc.lock
+++ b/lwb/metalang/dynamix/dynamix/spoofaxc.lock
@@ -1,0 +1,5 @@
+shared.defaultArtifactId=dynamix
+shared.defaultClassPrefix=Dynamix
+shared.defaultGroupId=org.metaborg
+shared.defaultPackageId=mb.dynamix
+shared.defaultVersion=0.1.0

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/DynamixComponent.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/DynamixComponent.java
@@ -1,0 +1,23 @@
+package mb.dynamix;
+
+import dagger.Component;
+import mb.dynamix.task.spoofax.DynamixConfigFunctionWrapper;
+import mb.log.dagger.LoggerComponent;
+import mb.resource.dagger.ResourceServiceComponent;
+import mb.spoofax.core.platform.PlatformComponent;
+
+@DynamixScope
+@Component(
+    modules = {
+        DynamixModule.class
+    },
+    dependencies = {
+        LoggerComponent.class,
+        DynamixResourcesComponent.class,
+        ResourceServiceComponent.class,
+        PlatformComponent.class
+    }
+)
+public interface DynamixComponent extends BaseDynamixComponent {
+    DynamixConfigFunctionWrapper getDynamixConfigFunctionWrapper();
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixCompileAndMergeProject.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixCompileAndMergeProject.java
@@ -1,0 +1,63 @@
+package mb.dynamix.task;
+
+import mb.common.result.Result;
+import mb.dynamix.DynamixClassLoaderResources;
+import mb.dynamix.DynamixScope;
+import mb.pie.api.ExecContext;
+import mb.pie.api.Interactivity;
+import mb.pie.api.None;
+import mb.pie.api.TaskDef;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.hierarchical.ResourcePath;
+import mb.stratego.common.StrategoRuntime;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Compiles a Dynamix project and merges the specification files into one.
+ */
+@DynamixScope
+public class DynamixCompileAndMergeProject implements TaskDef<ResourcePath, Result<IStrategoTerm, ?>> {
+    private final DynamixClassLoaderResources classLoaderResources;
+    private final DynamixCompileProject compileProject;
+    private final DynamixGetStrategoRuntimeProvider getStrategoRuntimeProvider;
+
+    @Inject public DynamixCompileAndMergeProject(
+        DynamixClassLoaderResources classLoaderResources,
+        DynamixCompileProject compileProject,
+        DynamixGetStrategoRuntimeProvider getStrategoRuntimeProvider
+    ) {
+        this.classLoaderResources = classLoaderResources;
+        this.compileProject = compileProject;
+        this.getStrategoRuntimeProvider = getStrategoRuntimeProvider;
+    }
+
+    @Override
+    public String getId() {
+        return getClass().getName();
+    }
+
+    @Override public boolean shouldExecWhenAffected(ResourcePath input, Set<?> tags) {
+        return tags.isEmpty() || tags.contains(Interactivity.NonInteractive);
+    }
+
+    @Override
+    public Result<IStrategoTerm, ?> exec(ExecContext context, ResourcePath rootDirectory) throws Exception {
+        context.require(classLoaderResources.tryGetAsNativeResource(getClass()), ResourceStampers.hashFile());
+
+        final StrategoRuntime strategoRuntime = context.require(getStrategoRuntimeProvider, None.instance).getValue().get();
+        final ITermFactory termFactory = strategoRuntime.getTermFactory();
+
+        return context.require(compileProject, rootDirectory).mapThrowing(compileProjectResult -> {
+            final List<IStrategoTerm> localSpecs = compileProjectResult.stream().map(p -> p.spec).collect(Collectors.toList());
+            final IStrategoList inputList = termFactory.makeList(localSpecs);
+            return strategoRuntime.invoke("dx--merge-specifications", inputList);
+        });
+    }
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixCompileModule.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixCompileModule.java
@@ -1,0 +1,148 @@
+package mb.dynamix.task;
+
+import mb.aterm.common.InvalidAstShapeException;
+import mb.common.option.Option;
+import mb.common.result.Result;
+import mb.dynamix.DynamixClassLoaderResources;
+import mb.dynamix.DynamixScope;
+import mb.dynamix.task.spoofax.DynamixConfigFunctionWrapper;
+import mb.pie.api.ExecContext;
+import mb.pie.api.Interactivity;
+import mb.pie.api.None;
+import mb.pie.api.TaskDef;
+import mb.pie.api.stamp.output.OutputStampers;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.hierarchical.ResourcePath;
+import mb.stratego.common.StrategoException;
+import mb.stratego.common.StrategoRuntime;
+import mb.stratego.common.StrategoUtil;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.terms.util.TermUtils;
+
+import javax.inject.Inject;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Set;
+
+@DynamixScope
+public class DynamixCompileModule implements TaskDef<DynamixCompileModule.Input, Result<Option<DynamixCompileModule.Output>, ?>> {
+    public static class Input implements Serializable {
+        public final ResourcePath rootDirectory;
+        public final ResourcePath file;
+
+        public Input(ResourcePath rootDirectory, ResourcePath file) {
+            this.rootDirectory = rootDirectory;
+            this.file = file;
+        }
+
+        @Override public boolean equals(@Nullable Object o) {
+            if(this == o) return true;
+            if(o == null || getClass() != o.getClass()) return false;
+            final Input input = (Input)o;
+            if(!rootDirectory.equals(input.rootDirectory)) return false;
+            return file.equals(input.file);
+        }
+
+        @Override public int hashCode() {
+            int result = rootDirectory.hashCode();
+            result = 31 * result + file.hashCode();
+            return result;
+        }
+
+        @Override public String toString() {
+            return "DynamixCompileModule.Input{" +
+                "rootDirectory=" + rootDirectory +
+                ", file=" + file +
+                '}';
+        }
+    }
+
+    public static class Output implements Serializable {
+        public final String relativeOutputPath;
+        public final IStrategoTerm spec;
+
+        public Output(String relativeOutputPath, IStrategoTerm spec) {
+            this.relativeOutputPath = relativeOutputPath;
+            this.spec = spec;
+        }
+
+        @Override public boolean equals(@Nullable Object o) {
+            if(this == o) return true;
+            if(o == null || getClass() != o.getClass()) return false;
+            final Output output = (Output)o;
+            return relativeOutputPath.equals(output.relativeOutputPath) && spec.equals(output.spec);
+        }
+
+        @Override public int hashCode() {
+            return Objects.hash(relativeOutputPath, spec);
+        }
+
+        @Override public String toString() {
+            return "Output{" +
+                "relativeOutputPath='" + relativeOutputPath + '\'' +
+                ", spec=" + spec +
+                '}';
+        }
+    }
+
+    private final DynamixClassLoaderResources classLoaderResources;
+    private final DynamixConfigFunctionWrapper configFunctionWrapper;
+    private final DynamixAnalyzeFile analyzeFile;
+    private final DynamixGetStrategoRuntimeProvider getStrategoRuntimeProvider;
+
+    @Inject public DynamixCompileModule(
+        DynamixClassLoaderResources classLoaderResources,
+        DynamixConfigFunctionWrapper configFunctionWrapper,
+        DynamixAnalyzeFile analyzeFile,
+        DynamixGetStrategoRuntimeProvider getStrategoRuntimeProvider
+    ) {
+        this.classLoaderResources = classLoaderResources;
+        this.configFunctionWrapper = configFunctionWrapper;
+        this.analyzeFile = analyzeFile;
+        this.getStrategoRuntimeProvider = getStrategoRuntimeProvider;
+    }
+
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override
+    public Result<Option<Output>, ?> exec(ExecContext context, DynamixCompileModule.Input input) throws Exception {
+        context.require(classLoaderResources.tryGetAsNativeResource(getClass()), ResourceStampers.hashFile());
+        context.require(classLoaderResources.tryGetAsNativeResource(Input.class), ResourceStampers.hashFile());
+        context.require(classLoaderResources.tryGetAsNativeResource(Output.class), ResourceStampers.hashFile());
+
+        final ResourcePath rootDirectory = input.rootDirectory;
+        final ResourcePath file = input.file;
+        final StrategoRuntime strategoRuntime = context.require(getStrategoRuntimeProvider, None.instance).getValue().get();
+
+        context.require(configFunctionWrapper.get(), rootDirectory).ifOk(o -> o.ifSome(config -> {
+            // TODO: only require the origin that is needed to compile this module?
+            config.sourceFileOrigins.forEach(origin -> context.require(origin, OutputStampers.inconsequential()));
+        }));
+
+        return context.require(analyzeFile, new DynamixAnalyzeFile.Input(rootDirectory, file)).flatMapOrElse(output -> {
+            try {
+                final IStrategoTerm term = StrategoUtil.createLegacyBuilderInputTerm(strategoRuntime.getTermFactory(), output.ast, file, rootDirectory);
+                final IStrategoTerm outputTerm = strategoRuntime.addContextObject(output.context).invoke("dx--generate-aterm", term);
+
+                // we expect an output of (<output path>, term)
+                final String relativeOutputPath = TermUtils.asJavaStringAt(outputTerm, 0)
+                    .orElseThrow(() -> new InvalidAstShapeException("string as first subterm", outputTerm));
+                if(outputTerm.getSubtermCount() < 2) {
+                    throw new InvalidAstShapeException("term with two subterms", outputTerm);
+                }
+                final IStrategoTerm spec = outputTerm.getSubterm(1);
+                return Result.ofOk(Option.ofSome(new Output(relativeOutputPath, spec)));
+            } catch(StrategoException e) {
+                return Result.ofErr(e); // TODO: better error/exception?
+            }
+        }, Result::ofErr); // TODO: better error/exception?
+    }
+
+    @Override public boolean shouldExecWhenAffected(Input input, Set<?> tags) {
+        return tags.isEmpty() || tags.contains(Interactivity.NonInteractive);
+    }
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixCompileProject.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixCompileProject.java
@@ -7,6 +7,7 @@ import mb.common.result.Result;
 import mb.common.util.ListView;
 import mb.dynamix.DynamixClassLoaderResources;
 import mb.dynamix.DynamixScope;
+import mb.dynamix.task.spoofax.DynamixGetSourceFiles;
 import mb.pie.api.ExecContext;
 import mb.pie.api.Interactivity;
 import mb.pie.api.TaskDef;

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixCompileProject.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixCompileProject.java
@@ -1,0 +1,69 @@
+package mb.dynamix.task;
+
+import mb.common.message.KeyedMessages;
+import mb.common.option.Option;
+import mb.common.result.MessagesException;
+import mb.common.result.Result;
+import mb.common.util.ListView;
+import mb.dynamix.DynamixClassLoaderResources;
+import mb.dynamix.DynamixScope;
+import mb.pie.api.ExecContext;
+import mb.pie.api.Interactivity;
+import mb.pie.api.TaskDef;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.hierarchical.ResourcePath;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Set;
+
+@DynamixScope
+public class DynamixCompileProject implements TaskDef<ResourcePath, Result<ListView<DynamixCompileModule.Output>, ?>> {
+    private final DynamixClassLoaderResources classLoaderResources;
+    private final DynamixCheckMulti check;
+    private final DynamixGetSourceFiles getSourceFiles;
+    private final DynamixCompileModule compileModule;
+
+
+    @Inject public DynamixCompileProject(
+        DynamixClassLoaderResources classLoaderResources,
+        DynamixCheckMulti check,
+        DynamixGetSourceFiles getSourceFiles,
+        DynamixCompileModule compileModule
+    ) {
+        this.classLoaderResources = classLoaderResources;
+        this.check = check;
+        this.getSourceFiles = getSourceFiles;
+        this.compileModule = compileModule;
+    }
+
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override
+    public Result<ListView<DynamixCompileModule.Output>, ?> exec(ExecContext context, ResourcePath input) throws Exception {
+        context.require(classLoaderResources.tryGetAsNativeResource(getClass()), ResourceStampers.hashFile());
+
+        final KeyedMessages messages = context.require(check, input);
+        if(messages.containsError()) {
+            return Result.ofErr(new MessagesException(messages, "Cannot compile Dynamix files of '" + input + "' because checking produced errors"));
+        }
+
+        final ArrayList<DynamixCompileModule.Output> compileModuleOutputs = new ArrayList<>();
+        for(ResourcePath sourceFile : context.require(getSourceFiles, input)) {
+            final Result<Option<DynamixCompileModule.Output>, ?> result = context.require(compileModule, new DynamixCompileModule.Input(input, sourceFile));
+            if(result.isErr()) {
+                return Result.ofErr(result.unwrapErr());
+            }
+            result.ifOk(o -> o.ifSome(compileModuleOutputs::add));
+        }
+
+        return Result.ofOk(ListView.of(compileModuleOutputs));
+    }
+
+    @Override public boolean shouldExecWhenAffected(ResourcePath input, Set<?> tags) {
+        return tags.isEmpty() || tags.contains(Interactivity.NonInteractive);
+    }
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixConfig.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixConfig.java
@@ -1,0 +1,73 @@
+package mb.dynamix.task;
+
+import mb.common.util.ListView;
+import mb.pie.api.STask;
+import mb.resource.hierarchical.ResourcePath;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.Serializable;
+import java.util.LinkedHashSet;
+
+public class DynamixConfig implements Serializable {
+    public final ResourcePath rootDirectory;
+    public final ResourcePath mainFile;
+    public final ListView<ResourcePath> sourcePaths;
+    public final ListView<ResourcePath> includePaths;
+    public final ListView<STask<?>> sourceFileOrigins;
+
+    public DynamixConfig(
+        ResourcePath rootDirectory,
+        ResourcePath mainFile,
+        ListView<ResourcePath> sourcePaths,
+        ListView<ResourcePath> includePaths,
+        ListView<STask<?>> sourceFileOrigins
+    ) {
+        this.rootDirectory = rootDirectory;
+        this.mainFile = mainFile;
+        this.sourcePaths = sourcePaths;
+        this.includePaths = includePaths;
+        this.sourceFileOrigins = sourceFileOrigins;
+    }
+
+    public static DynamixConfig createDefault(ResourcePath rootDirectory) {
+        final ResourcePath sourceDirectory = rootDirectory.appendRelativePath("src");
+        return new DynamixConfig(rootDirectory, sourceDirectory.appendRelativePath("main.dx"), ListView.of(sourceDirectory), ListView.of(), ListView.of());
+    }
+
+    public LinkedHashSet<ResourcePath> sourceAndIncludePaths() {
+        final LinkedHashSet<ResourcePath> sourceAndIncludePaths = new LinkedHashSet<>();
+        sourcePaths.addAllTo(sourceAndIncludePaths);
+        includePaths.addAllTo(sourceAndIncludePaths);
+        return sourceAndIncludePaths;
+    }
+
+    @Override public boolean equals(@Nullable Object o) {
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        final DynamixConfig that = (DynamixConfig)o;
+        if(!rootDirectory.equals(that.rootDirectory)) return false;
+        if(!mainFile.equals(that.mainFile)) return false;
+        if(!sourcePaths.equals(that.sourcePaths)) return false;
+        if(!includePaths.equals(that.includePaths)) return false;
+        return sourceFileOrigins.equals(that.sourceFileOrigins);
+    }
+
+    @Override public int hashCode() {
+        int result = rootDirectory.hashCode();
+        result = 31 * result + mainFile.hashCode();
+        result = 31 * result + sourcePaths.hashCode();
+        result = 31 * result + includePaths.hashCode();
+        result = 31 * result + sourceFileOrigins.hashCode();
+        return result;
+    }
+
+    @Override public String toString() {
+        return "DynamixConfig{" +
+            "rootDirectory=" + rootDirectory +
+            ", mainFile=" + mainFile +
+            ", sourcePaths=" + sourcePaths +
+            ", includePaths=" + includePaths +
+            ", sourceFileOrigins=" + sourceFileOrigins +
+            '}';
+    }
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixPrettyPrint.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/DynamixPrettyPrint.java
@@ -1,0 +1,17 @@
+package mb.dynamix.task;
+
+import mb.dynamix.DynamixScope;
+import mb.stratego.pie.AstStrategoTransformTaskDef;
+
+import javax.inject.Inject;
+
+@DynamixScope
+public class DynamixPrettyPrint extends AstStrategoTransformTaskDef {
+    @Inject public DynamixPrettyPrint(DynamixGetStrategoRuntimeProvider getStrategoRuntimeProvider) {
+        super(getStrategoRuntimeProvider, "pp-dynamix-string");
+    }
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/debug/DynamixShowMerged.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/debug/DynamixShowMerged.java
@@ -1,0 +1,97 @@
+package mb.dynamix.task.debug;
+
+import mb.dynamix.DynamixScope;
+import mb.dynamix.task.DynamixAnalyzeFile;
+import mb.dynamix.task.DynamixGetStrategoRuntimeProvider;
+import mb.pie.api.ExecContext;
+import mb.pie.api.None;
+import mb.pie.api.TaskDef;
+import mb.resource.ResourceKey;
+import mb.resource.hierarchical.ResourcePath;
+import mb.spoofax.core.language.command.CommandFeedback;
+import mb.spoofax.core.language.command.ShowFeedback;
+import mb.stratego.common.StrategoException;
+import mb.stratego.common.StrategoRuntime;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.Serializable;
+
+@DynamixScope
+public class DynamixShowMerged implements TaskDef<DynamixShowMerged.Args, CommandFeedback> {
+    public static final class Args implements Serializable {
+        public final ResourcePath rootDirectory;
+        public final ResourceKey file;
+
+        public Args(ResourcePath rootDirectory, ResourceKey file) {
+            this.rootDirectory = rootDirectory;
+            this.file = file;
+        }
+
+        @Override public boolean equals(@Nullable Object o) {
+            if(this == o) return true;
+            if(o == null || getClass() != o.getClass()) return false;
+            Args input = (Args)o;
+            if(!rootDirectory.equals(input.rootDirectory)) return false;
+            return file.equals(input.file);
+        }
+
+        @Override public int hashCode() {
+            int result = rootDirectory.hashCode();
+            result = 31 * result + file.hashCode();
+            return result;
+        }
+
+        @Override public String toString() {
+            return "DynamixShowMerged{" +
+                "rootDirectory=" + rootDirectory +
+                ", file=" + file +
+                '}';
+        }
+    }
+
+    private final DynamixAnalyzeFile analyzeFile;
+    private final DynamixGetStrategoRuntimeProvider getStrategoRuntimeProvider;
+
+    @Inject public DynamixShowMerged(
+        DynamixAnalyzeFile analyzeFile,
+        DynamixGetStrategoRuntimeProvider getStrategoRuntimeProvider
+    ) {
+        this.analyzeFile = analyzeFile;
+        this.getStrategoRuntimeProvider = getStrategoRuntimeProvider;
+    }
+
+    @Override public CommandFeedback exec(ExecContext context, Args args) throws IOException {
+        final ResourceKey file = args.file;
+        return context.require(analyzeFile, new DynamixAnalyzeFile.Input(args.rootDirectory, file)).mapOrElse(
+            output -> {
+                try {
+                    final StrategoRuntime strategoRuntime = context.require(getStrategoRuntimeProvider, None.instance).getValue().get().addContextObject(output.context);
+
+                    final IStrategoTerm compiled = strategoRuntime.invoke("dx--to-merged", output.ast);
+                    final IStrategoTerm formatted = strategoRuntime.invoke("pp-dynamix-string", compiled);
+
+                    return CommandFeedback.of(ShowFeedback.showText(((IStrategoString)formatted).stringValue(), "Merged representation for '" + file + "'"));
+                } catch(StrategoException e) {
+                    final StringBuilder errorSB = new StringBuilder();
+
+                    Throwable ex = e;
+                    while(ex != null) {
+                        errorSB.append(ex.getMessage() + "\n");
+                        ex = ex.getCause();
+                    }
+
+                    return CommandFeedback.of(ShowFeedback.showText(errorSB.toString(), "Evaluation error for '" + file + "'"));
+                }
+            },
+            e -> CommandFeedback.ofTryExtractMessagesFrom(e, file)
+        );
+    }
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/spoofax/DynamixAnalyzeMultiWrapper.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/spoofax/DynamixAnalyzeMultiWrapper.java
@@ -1,0 +1,66 @@
+package mb.dynamix.task.spoofax;
+
+import mb.common.message.KeyedMessages;
+import mb.common.message.Message;
+import mb.common.util.ListView;
+import mb.common.util.MapView;
+import mb.common.util.MultiMapView;
+import mb.constraint.common.ConstraintAnalyzer;
+import mb.constraint.common.ConstraintAnalyzerContext;
+import mb.constraint.common.ConstraintAnalyzerException;
+import mb.constraint.pie.ConstraintAnalyzeMultiTaskDef;
+import mb.pie.api.ExecContext;
+import mb.resource.ResourceKey;
+import mb.resource.ResourceService;
+import mb.resource.hierarchical.ResourcePath;
+import mb.spoofax2.common.primitive.generic.Spoofax2ProjectContext;
+import mb.dynamix.DynamixConstraintAnalyzer;
+import mb.dynamix.DynamixScope;
+import mb.dynamix.task.DynamixConfig;
+import mb.stratego.common.StrategoRuntime;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+@DynamixScope
+public class DynamixAnalyzeMultiWrapper extends ConstraintAnalyzeMultiTaskDef {
+    private final DynamixConstraintAnalyzer constraintAnalyzer;
+    private final ResourceService resourceService;
+    private final Provider<StrategoRuntime> strategoRuntimeProvider;
+    private final DynamixConfigFunctionWrapper configFunctionWrapper;
+
+    @Inject
+    public DynamixAnalyzeMultiWrapper(
+        DynamixConstraintAnalyzer constraintAnalyzer,
+        ResourceService resourceService,
+        Provider<StrategoRuntime> strategoRuntimeProvider,
+        DynamixConfigFunctionWrapper configFunctionWrapper
+    ) {
+        this.constraintAnalyzer = constraintAnalyzer;
+        this.resourceService = resourceService;
+        this.strategoRuntimeProvider = strategoRuntimeProvider;
+        this.configFunctionWrapper = configFunctionWrapper;
+    }
+
+    @Override
+    public String getId() {
+        return getClass().getName();
+    }
+
+    @Override
+    protected ConstraintAnalyzer.MultiFileResult analyze(ExecContext context, ResourcePath root, MapView<ResourceKey, IStrategoTerm> asts, ConstraintAnalyzerContext constraintAnalyzerContext) throws ConstraintAnalyzerException {
+        return configFunctionWrapper.get().apply(context, root).mapThrowingOrElse(
+            o -> o.mapThrowingOrElse(
+                c -> constraintAnalyzer.analyze(root, asts, constraintAnalyzerContext, strategoRuntimeProvider.get().addContextObject(createProjectContext(c)), resourceService),
+                ConstraintAnalyzer.MultiFileResult::new // Dynamix is not configured, do not need to analyze. // TODO: redirect to base analysis?
+            ),
+            e -> new ConstraintAnalyzer.MultiFileResult(KeyedMessages.of(ListView.of(new Message("Cannot check Dynamix files; reading configuration failed unexpectedly", e)), root))
+        );
+    }
+
+    private Spoofax2ProjectContext createProjectContext(DynamixConfig config) {
+        final String languageId = "dynamix";
+        return new Spoofax2ProjectContext(config.rootDirectory, MultiMapView.of(languageId, config.sourcePaths), MultiMapView.of(languageId, config.includePaths));
+    }
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/spoofax/DynamixConfigFunctionWrapper.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/spoofax/DynamixConfigFunctionWrapper.java
@@ -1,0 +1,65 @@
+package mb.dynamix.task.spoofax;
+
+import mb.common.option.Option;
+import mb.common.result.Result;
+import mb.dynamix.DynamixScope;
+import mb.dynamix.task.DynamixConfig;
+import mb.pie.api.ExecContext;
+import mb.pie.api.Function;
+import mb.resource.hierarchical.ResourcePath;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import javax.inject.Inject;
+
+@DynamixScope
+public class DynamixConfigFunctionWrapper {
+    private @Nullable Function<ResourcePath, ? extends Result<Option<DynamixConfig>, ?>> function = null;
+
+
+    @Inject public DynamixConfigFunctionWrapper() {
+    }
+
+
+    public Function<ResourcePath, ? extends Result<Option<DynamixConfig>, ?>> get() {
+        if(function == null) {
+            function = DynamixDefaultAnalyzeConfigFunction.instance;
+        }
+        return function;
+    }
+
+    public void set(Function<ResourcePath, ? extends Result<Option<DynamixConfig>, ?>> function) {
+        if(this.function != null) {
+            throw new IllegalStateException("Function in DynamixDefaultAnalyzeConfigFunction was already set or used. After setting or using the function, it may not be changed any more to guarantee sound incrementality");
+        }
+        this.function = function;
+    }
+
+
+    private static class DynamixDefaultAnalyzeConfigFunction implements Function<ResourcePath, Result<Option<DynamixConfig>, ?>> {
+        private static final DynamixDefaultAnalyzeConfigFunction instance = new DynamixDefaultAnalyzeConfigFunction();
+
+        private DynamixDefaultAnalyzeConfigFunction() {
+        }
+
+        @Override
+        public Result<Option<DynamixConfig>, ?> apply(ExecContext context, ResourcePath rootDirectory) {
+            return Result.ofOk(Option.ofSome(DynamixConfig.createDefault(rootDirectory)));
+        }
+
+        @Override public boolean equals(@Nullable Object other) {
+            return this == other || other != null && this.getClass() == other.getClass();
+        }
+
+        @Override public int hashCode() {
+            return 0;
+        }
+
+        @Override public String toString() {
+            return "DynamixDefaultAnalyzeConfigFunction()";
+        }
+
+        private Object readResolve() {
+            return instance;
+        }
+    }
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/spoofax/DynamixGetSourceFiles.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/spoofax/DynamixGetSourceFiles.java
@@ -1,0 +1,62 @@
+package mb.dynamix.task.spoofax;
+
+import mb.common.util.ListView;
+import mb.dynamix.DynamixClassLoaderResources;
+import mb.dynamix.DynamixScope;
+import mb.pie.api.ExecContext;
+import mb.pie.api.TaskDef;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.hierarchical.ResourcePath;
+import mb.resource.hierarchical.match.ResourceMatcher;
+import mb.resource.hierarchical.match.path.PathMatcher;
+import mb.resource.hierarchical.walk.ResourceWalker;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.ArrayList;
+
+@DynamixScope
+public class DynamixGetSourceFiles implements TaskDef<ResourcePath, ListView<ResourcePath>> {
+    private final DynamixClassLoaderResources classLoaderResources;
+    private final DynamixConfigFunctionWrapper configFunctionWrapper;
+    private final BaseDynamixGetSourceFiles baseGetSourceFiles;
+
+    @Inject
+    public DynamixGetSourceFiles(
+        DynamixClassLoaderResources classLoaderResources,
+        DynamixConfigFunctionWrapper configFunctionWrapper,
+        BaseDynamixGetSourceFiles baseGetSourceFiles
+    ) {
+        this.classLoaderResources = classLoaderResources;
+        this.configFunctionWrapper = configFunctionWrapper;
+        this.baseGetSourceFiles = baseGetSourceFiles;
+    }
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override public ListView<ResourcePath> exec(ExecContext context, ResourcePath rootDirectory) throws IOException {
+        context.require(classLoaderResources.tryGetAsNativeResource(getClass()), ResourceStampers.hashFile());
+        return configFunctionWrapper.get().apply(context, rootDirectory).mapThrowingOrElse(
+            o -> o.mapThrowingOrElse(
+                config -> {
+                    final ArrayList<ResourcePath> sourceFiles = new ArrayList<>();
+                    final ResourceWalker walker = ResourceWalker.ofPath(PathMatcher.ofNoHidden());
+
+                    // All .dx files in source and include directories.
+                    final ResourceMatcher dxMatcher = ResourceMatcher.ofPath(PathMatcher.ofExtension("dx")).and(ResourceMatcher.ofFile());
+                    for(ResourcePath path : config.sourceAndIncludePaths()) {
+                        context
+                            .require(path, ResourceStampers.modifiedDirRec(walker, dxMatcher))
+                            .walkForEach(walker, dxMatcher, f -> sourceFiles.add(f.getPath()));
+                    }
+
+                    return ListView.of(sourceFiles);
+                },
+                () -> context.require(baseGetSourceFiles, rootDirectory)
+            ),
+            e -> context.require(baseGetSourceFiles, rootDirectory)
+        );
+    }
+}

--- a/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/spoofax/DynamixParseWrapper.java
+++ b/lwb/metalang/dynamix/dynamix/src/main/java/mb/dynamix/task/spoofax/DynamixParseWrapper.java
@@ -1,0 +1,44 @@
+package mb.dynamix.task.spoofax;
+
+import mb.common.result.Result;
+import mb.dynamix.DynamixClassLoaderResources;
+import mb.dynamix.DynamixParser;
+import mb.dynamix.DynamixScope;
+import mb.dynamix.task.DynamixParse;
+import mb.jsglr.common.JsglrParseException;
+import mb.jsglr.common.JsglrParseOutput;
+import mb.jsglr.pie.JsglrParseTaskInput;
+import mb.pie.api.ExecContext;
+import mb.pie.api.stamp.output.OutputStampers;
+import mb.pie.api.stamp.resource.ResourceStampers;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+@DynamixScope
+public class DynamixParseWrapper extends DynamixParse {
+    private final DynamixClassLoaderResources classLoaderResources;
+    private final DynamixConfigFunctionWrapper configFunctionWrapper;
+
+    @Inject public DynamixParseWrapper(
+        DynamixClassLoaderResources classLoaderResources,
+        Provider<DynamixParser> parserProvider,
+        DynamixConfigFunctionWrapper configFunctionWrapper
+    ) {
+        super(classLoaderResources, parserProvider);
+        this.classLoaderResources = classLoaderResources;
+        this.configFunctionWrapper = configFunctionWrapper;
+    }
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override
+    public Result<JsglrParseOutput, JsglrParseException> exec(ExecContext context, JsglrParseTaskInput input) throws Exception {
+        context.require(classLoaderResources.tryGetAsNativeResource(getClass()), ResourceStampers.hashFile());
+        // TODO: instead of requiring all origins for each file to parse, only require the origins that corresponds to a certain file?
+        input.rootDirectoryHint().ifPresent(d -> configFunctionWrapper.get().apply(context, d).ifOk(o -> o.ifSome(c -> c.sourceFileOrigins.forEach((origin -> context.require(origin, OutputStampers.inconsequential()))))));
+        return super.exec(context, input);
+    }
+}

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.eclipse/build.gradle.kts
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.eclipse/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.eclipse")
+}
+
+languageEclipseProject {
+  adapterProject.set(project(":sdf3_ext_dynamix"))
+  compilerInput {
+    languageGroup("mb.spoofax.lwb")
+  }
+}

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/.gitignore
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/.gitignore
@@ -1,0 +1,11 @@
+/.cache
+/bin
+/src-gen
+/target
+
+/.classpath
+/.project
+/.settings
+/.factorypath
+
+/.polyglot.metaborg.yaml

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/README.md
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/README.md
@@ -1,0 +1,4 @@
+# SDF3 extension for Dynamix
+
+This project generates:
+- Dynamix signatures in the `src-gen/dynamix/signatures` folder

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/build.gradle.kts
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/build.gradle.kts
@@ -1,0 +1,24 @@
+import org.metaborg.core.language.*
+
+plugins {
+  id("org.metaborg.devenv.spoofax.gradle.langspec")
+  `maven-publish`
+}
+
+val spoofax2DevenvVersion: String by ext
+spoofaxLanguageSpecification {
+  addSourceDependenciesFromMetaborgYaml.set(false)
+  addCompileDependenciesFromMetaborgYaml.set(false)
+  addLanguageContributionsFromMetaborgYaml.set(false)
+  languageContributions.add(LanguageContributionIdentifier(LanguageIdentifier("$group", "org.metaborg.meta.lang.template", LanguageVersion.parse("$version")), "TemplateLang"))
+}
+dependencies {
+  compileLanguage("org.metaborg.devenv:org.metaborg.meta.lang.esv:$spoofax2DevenvVersion")
+  sourceLanguage("org.metaborg.devenv:org.metaborg.meta.lang.template:$spoofax2DevenvVersion")
+  sourceLanguage("org.metaborg.devenv:statix.lang:$spoofax2DevenvVersion")
+
+  sourceLanguage("org.metaborg.devenv:meta.lib.spoofax:$spoofax2DevenvVersion")
+  sourceLanguage("org.metaborg.devenv:statix.runtime:$spoofax2DevenvVersion")
+
+  sourceLanguage(project(":dynamix.spoofax2"))
+}

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/editor/Main.esv
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/editor/Main.esv
@@ -1,0 +1,9 @@
+module Main
+
+language
+
+  context  : none
+  provider : target/metaborg/stratego.ctree
+  on save  : generate-statix
+  on save  : generate-stratego
+

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/metaborg.yaml
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/metaborg.yaml
@@ -1,0 +1,54 @@
+---
+id: org.metaborg:sdf3.ext.dynamix:${metaborgVersion}
+name: Sdf3ExtDynamix
+metaborgVersion: 2.6.0-SNAPSHOT
+
+dependencies:
+  compile:
+  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}
+  source:
+  - org.metaborg:meta.lib.spoofax:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lib.analysis:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.nabl2.shared:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.nabl2.runtime:${metaborgVersion}
+  - org.metaborg:statix.lang:${metaborgVersion}
+  - org.metaborg:statix.runtime:${metaborgVersion}
+  - org.metaborg:stratego.lang:${metaborgVersion}
+  # TODO: not hardcoded version?
+  - org.metaborg:dynamix:0.1.0-SNAPSHOT
+pardonedLanguages:
+- EditorService
+- Stratego-Sugar
+- SDF
+contributions:
+- name: TemplateLang
+  id: org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+generates:
+- language: Stratego-Sugar
+  directory: src-gen
+- language: StatixLang
+  directory: src-gen/statix
+language:
+  sdf:
+    enabled: false
+  stratego:
+    format: ctree
+    args:
+    - -la
+    - stratego-lib
+    - -la
+    - stratego-sglr
+    - -la
+    - stratego-gpp
+    - -la
+    - stratego-xtc
+    - -la
+    - stratego-aterm
+    - -la
+    - stratego-sdf
+    - -la
+    - strc
+exports:
+- language: ATerm
+  directory: src-gen/statix

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/pom.xml
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>sdf3.ext.dynamix</artifactId>
+  <name>sdf3.ext.dynamix</name>
+  <packaging>spoofax-language</packaging>
+
+  <parent>
+    <groupId>org.metaborg</groupId>
+    <artifactId>parent.language</artifactId>
+    <version>2.5.16</version>
+  </parent>
+  
+</project>

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/trans/editor.str
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/trans/editor.str
@@ -1,0 +1,1 @@
+module editor

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/trans/sdf3extdynamix.str
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix.spoofax2/trans/sdf3extdynamix.str
@@ -1,0 +1,11 @@
+module sdf3extdynamix
+
+imports
+  signatures/TemplateLang-sig
+  signatures/modules/Modules-sig
+
+  signatures/dynamix-sig
+
+rules
+  // todo
+  generate-dynamix-signature: Module(Unparameterized(name), _, _) -> Program($[signatures/[name]-sig], [])

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix/build.gradle.kts
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix/build.gradle.kts
@@ -1,0 +1,50 @@
+import mb.spoofax.compiler.adapter.*
+import mb.spoofax.compiler.util.*
+
+plugins {
+  id("org.metaborg.gradle.config.java-library")
+  id("org.metaborg.spoofax.compiler.gradle.spoofax2.language")
+  id("org.metaborg.spoofax.compiler.gradle.adapter")
+}
+
+fun compositeBuild(name: String) = "$group:$name:$version"
+
+dependencies {
+
+}
+
+languageProject {
+  shared {
+    name("Sdf3ExtDynamix")
+    defaultClassPrefix("Sdf3ExtDynamix")
+    defaultPackageId("mb.sdf3_ext_dynamix")
+    fileExtensions(listOf()) // No file extensions.
+  }
+  compilerInput {
+    withStrategoRuntime()
+  }
+}
+spoofax2BasedLanguageProject {
+  compilerInput {
+    withStrategoRuntime().run {
+      copyCtree(true)
+      copyClasses(false)
+    }
+    project.languageSpecificationDependency(GradleDependency.project(":sdf3_ext_dynamix.spoofax2"))
+  }
+}
+
+languageAdapterProject {
+  compilerInput {
+    withStrategoRuntime()
+    project.configureCompilerInput()
+  }
+}
+fun AdapterProjectCompiler.Input.Builder.configureCompilerInput() {
+  val packageId = "mb.sdf3_ext_dynamix"
+  val taskPackageId = "$packageId.task"
+
+  addTaskDefs(
+    TypeInfo.of(taskPackageId, "Sdf3ExtDynamixGenerateDynamix")
+  )
+}

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix/spoofaxc.lock
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix/spoofaxc.lock
@@ -1,0 +1,5 @@
+shared.defaultArtifactId=sdf3extdynamix
+shared.defaultClassPrefix=Sdf3ExtDynamix
+shared.defaultGroupId=org.metaborg
+shared.defaultPackageId=mb.sdf3_ext_dynamix
+shared.defaultVersion=0.1.0

--- a/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix/src/main/java/mb/sdf3_ext_dynamix/task/Sdf3ExtDynamixGenerateDynamix.java
+++ b/lwb/metalang/sdf3_ext_dynamix/sdf3_ext_dynamix/src/main/java/mb/sdf3_ext_dynamix/task/Sdf3ExtDynamixGenerateDynamix.java
@@ -1,0 +1,26 @@
+package mb.sdf3_ext_dynamix.task;
+
+import mb.common.result.Result;
+import mb.pie.api.Interactivity;
+import mb.pie.api.Supplier;
+import mb.sdf3_ext_dynamix.Sdf3ExtDynamixScope;
+import mb.stratego.pie.AstStrategoTransformTaskDef;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+@Sdf3ExtDynamixScope
+public class Sdf3ExtDynamixGenerateDynamix extends AstStrategoTransformTaskDef {
+    @Inject public Sdf3ExtDynamixGenerateDynamix(Sdf3ExtDynamixGetStrategoRuntimeProvider getStrategoRuntimeProvider) {
+        super(getStrategoRuntimeProvider, "generate-dynamix-signature");
+    }
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override public boolean shouldExecWhenAffected(Supplier<? extends Result<IStrategoTerm, ?>> input, Set<?> tags) {
+        return tags.isEmpty() || tags.contains(Interactivity.NonInteractive);
+    }
+}

--- a/lwb/settings.gradle.kts
+++ b/lwb/settings.gradle.kts
@@ -47,6 +47,11 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
   includeProject("dynamix.intellij")
   includeProject("dynamix.spoofax2")
 }
+"metalang/sdf3_ext_dynamix".run {
+  includeProject("sdf3_ext_dynamix")
+  includeProject("sdf3_ext_dynamix.eclipse")
+  includeProject("sdf3_ext_dynamix.spoofax2")
+}
 "metalang/sdf3".run {
   includeProject("sdf3")
   includeProject("sdf3.cli")

--- a/lwb/settings.gradle.kts
+++ b/lwb/settings.gradle.kts
@@ -40,6 +40,13 @@ fun String.includeProject(id: String, path: String = "$this/$id") {
   includeProject("cfg.intellij")
   includeProject("cfg.spoofax2")
 }
+"metalang/dynamix".run {
+  includeProject("dynamix")
+  includeProject("dynamix.cli")
+  includeProject("dynamix.eclipse")
+  includeProject("dynamix.intellij")
+  includeProject("dynamix.spoofax2")
+}
 "metalang/sdf3".run {
   includeProject("sdf3")
   includeProject("sdf3.cli")

--- a/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3Compiler.java
+++ b/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3Compiler.java
@@ -18,6 +18,7 @@ import mb.pie.api.StatelessSerializableFunction;
 import mb.resource.dagger.ResourceServiceComponent;
 import mb.sdf3.Sdf3Component;
 import mb.sdf3.task.spec.Sdf3SpecConfig;
+import mb.sdf3_ext_dynamix.Sdf3ExtDynamixComponent;
 import mb.sdf3_ext_statix.Sdf3ExtStatixComponent;
 import mb.spoofax.compiler.dagger.DaggerSpoofaxCompilerComponent;
 import mb.spoofax.compiler.dagger.SpoofaxCompilerComponent;
@@ -56,6 +57,7 @@ public class Spoofax3Compiler implements AutoCloseable {
     public final DynamixComponent dynamixComponent;
 
     public final Sdf3ExtStatixComponent sdf3ExtStatixComponent;
+    public final Sdf3ExtDynamixComponent sdf3ExtDynamixComponent;
 
     public final StrategoLibComponent strategolibComponent;
     public final StrategoLibResourcesComponent strategolibResourcesComponent;
@@ -83,6 +85,7 @@ public class Spoofax3Compiler implements AutoCloseable {
         DynamixComponent dynamixComponent,
 
         Sdf3ExtStatixComponent sdf3ExtStatixComponent,
+        Sdf3ExtDynamixComponent sdf3ExtDynamixComponent,
 
         StrategoLibComponent strategoLibComponent,
         StrategoLibResourcesComponent strategoLibResourcesComponent,
@@ -108,6 +111,7 @@ public class Spoofax3Compiler implements AutoCloseable {
         this.statixComponent = statixComponent;
         this.dynamixComponent = dynamixComponent;
         this.sdf3ExtStatixComponent = sdf3ExtStatixComponent;
+        this.sdf3ExtDynamixComponent = sdf3ExtDynamixComponent;
         this.strategolibComponent = strategoLibComponent;
         this.strategolibResourcesComponent = strategoLibResourcesComponent;
         this.gppComponent = gppComponent;
@@ -172,6 +176,7 @@ public class Spoofax3Compiler implements AutoCloseable {
         DynamixComponent dynamixComponent,
 
         Sdf3ExtStatixComponent sdf3ExtStatixComponent,
+        Sdf3ExtDynamixComponent sdf3ExtDynamixComponent,
 
         StrategoLibComponent strategoLibComponent,
         StrategoLibResourcesComponent strategoLibResourcesComponent,
@@ -200,6 +205,7 @@ public class Spoofax3Compiler implements AutoCloseable {
             .dynamixComponent(dynamixComponent)
 
             .sdf3ExtStatixComponent(sdf3ExtStatixComponent)
+            .sdf3ExtDynamixComponent(sdf3ExtDynamixComponent)
 
             .strategoLibComponent(strategoLibComponent)
             .strategoLibResourcesComponent(strategoLibResourcesComponent)
@@ -223,6 +229,7 @@ public class Spoofax3Compiler implements AutoCloseable {
             dynamixComponent,
 
             sdf3ExtStatixComponent,
+            sdf3ExtDynamixComponent,
 
             strategoLibComponent,
             strategoLibResourcesComponent,

--- a/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3Compiler.java
+++ b/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3Compiler.java
@@ -3,6 +3,8 @@ package mb.spoofax.lwb.compiler.dagger;
 import mb.cfg.CfgComponent;
 import mb.common.option.Option;
 import mb.common.result.Result;
+import mb.dynamix.DynamixComponent;
+import mb.dynamix.task.DynamixConfig;
 import mb.esv.EsvComponent;
 import mb.esv.task.EsvConfig;
 import mb.gpp.GppComponent;
@@ -22,6 +24,8 @@ import mb.spoofax.compiler.dagger.SpoofaxCompilerComponent;
 import mb.spoofax.compiler.dagger.SpoofaxCompilerModule;
 import mb.spoofax.compiler.util.TemplateCompiler;
 import mb.spoofax.core.platform.PlatformComponent;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixConfig;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixConfigureException;
 import mb.spoofax.lwb.compiler.esv.EsvConfigureException;
 import mb.spoofax.lwb.compiler.esv.SpoofaxEsvConfig;
 import mb.spoofax.lwb.compiler.sdf3.SpoofaxSdf3Config;
@@ -49,6 +53,7 @@ public class Spoofax3Compiler implements AutoCloseable {
     public final StrategoComponent strategoComponent;
     public final EsvComponent esvComponent;
     public final StatixComponent statixComponent;
+    public final DynamixComponent dynamixComponent;
 
     public final Sdf3ExtStatixComponent sdf3ExtStatixComponent;
 
@@ -75,6 +80,7 @@ public class Spoofax3Compiler implements AutoCloseable {
         StrategoComponent strategoComponent,
         EsvComponent esvComponent,
         StatixComponent statixComponent,
+        DynamixComponent dynamixComponent,
 
         Sdf3ExtStatixComponent sdf3ExtStatixComponent,
 
@@ -100,6 +106,7 @@ public class Spoofax3Compiler implements AutoCloseable {
         this.strategoComponent = strategoComponent;
         this.esvComponent = esvComponent;
         this.statixComponent = statixComponent;
+        this.dynamixComponent = dynamixComponent;
         this.sdf3ExtStatixComponent = sdf3ExtStatixComponent;
         this.strategolibComponent = strategoLibComponent;
         this.strategolibResourcesComponent = strategoLibResourcesComponent;
@@ -143,6 +150,13 @@ public class Spoofax3Compiler implements AutoCloseable {
                     return r.map(o -> o.flatMap(SpoofaxStatixConfig::getStatixConfig));
                 }
             }));
+        this.dynamixComponent.getDynamixConfigFunctionWrapper().set(this.component.getSpoofaxDynamixConfigure().createFunction().mapOutput(
+            new StatelessSerializableFunction<Result<Option<SpoofaxDynamixConfig>, SpoofaxDynamixConfigureException>, Result<Option<DynamixConfig>, SpoofaxDynamixConfigureException>>() {
+                @Override
+                public Result<Option<DynamixConfig>, SpoofaxDynamixConfigureException> apply(Result<Option<SpoofaxDynamixConfig>, SpoofaxDynamixConfigureException> r) {
+                    return r.map(o -> o.flatMap(SpoofaxDynamixConfig::getDynamixConfig));
+                }
+            }));
     }
 
     public static Spoofax3Compiler createDefault(
@@ -155,6 +169,7 @@ public class Spoofax3Compiler implements AutoCloseable {
         StrategoComponent strategoComponent,
         EsvComponent esvComponent,
         StatixComponent statixComponent,
+        DynamixComponent dynamixComponent,
 
         Sdf3ExtStatixComponent sdf3ExtStatixComponent,
 
@@ -182,6 +197,7 @@ public class Spoofax3Compiler implements AutoCloseable {
             .strategoComponent(strategoComponent)
             .esvComponent(esvComponent)
             .statixComponent(statixComponent)
+            .dynamixComponent(dynamixComponent)
 
             .sdf3ExtStatixComponent(sdf3ExtStatixComponent)
 
@@ -204,6 +220,7 @@ public class Spoofax3Compiler implements AutoCloseable {
             strategoComponent,
             esvComponent,
             statixComponent,
+            dynamixComponent,
 
             sdf3ExtStatixComponent,
 

--- a/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3CompilerComponent.java
+++ b/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3CompilerComponent.java
@@ -2,6 +2,7 @@ package mb.spoofax.lwb.compiler.dagger;
 
 import dagger.Component;
 import mb.cfg.CfgComponent;
+import mb.dynamix.DynamixComponent;
 import mb.esv.EsvComponent;
 import mb.gpp.GppComponent;
 import mb.gpp.GppResourcesComponent;
@@ -19,6 +20,8 @@ import mb.spoofax.lwb.compiler.CheckLanguageSpecification;
 import mb.spoofax.lwb.compiler.CompileLanguage;
 import mb.spoofax.lwb.compiler.CompileLanguageSpecification;
 import mb.spoofax.lwb.compiler.cfg.SpoofaxCfgCheck;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixCheck;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixConfigure;
 import mb.spoofax.lwb.compiler.esv.SpoofaxEsvCheck;
 import mb.spoofax.lwb.compiler.esv.SpoofaxEsvConfigure;
 import mb.spoofax.lwb.compiler.generator.LanguageProjectGenerator;
@@ -49,6 +52,7 @@ import java.util.Set;
         StrategoComponent.class,
         EsvComponent.class,
         StatixComponent.class,
+        DynamixComponent.class,
 
         Sdf3ExtStatixComponent.class,
 
@@ -83,6 +87,10 @@ public interface Spoofax3CompilerComponent extends TaskDefsProvider {
     SpoofaxStatixCheck getSpoofaxStatixCheck();
 
     SpoofaxStatixConfigure getSpoofaxStatixConfigure();
+
+    SpoofaxDynamixCheck getSpoofaxDynamixCheck();
+
+    SpoofaxDynamixConfigure getSpoofaxDynamixConfigure();
 
     SpoofaxStrategoCheck getSpoofaxStrategoCheck();
 

--- a/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3CompilerComponent.java
+++ b/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3CompilerComponent.java
@@ -15,6 +15,7 @@ import mb.pie.api.TaskDef;
 import mb.pie.dagger.TaskDefsProvider;
 import mb.resource.dagger.ResourceServiceComponent;
 import mb.sdf3.Sdf3Component;
+import mb.sdf3_ext_dynamix.Sdf3ExtDynamixComponent;
 import mb.sdf3_ext_statix.Sdf3ExtStatixComponent;
 import mb.spoofax.lwb.compiler.CheckLanguageSpecification;
 import mb.spoofax.lwb.compiler.CompileLanguage;
@@ -55,6 +56,7 @@ import java.util.Set;
         DynamixComponent.class,
 
         Sdf3ExtStatixComponent.class,
+        Sdf3ExtDynamixComponent.class,
 
         StrategoLibComponent.class,
         StrategoLibResourcesComponent.class,

--- a/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3CompilerModule.java
+++ b/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/Spoofax3CompilerModule.java
@@ -11,6 +11,9 @@ import mb.spoofax.lwb.compiler.CheckLanguageSpecification;
 import mb.spoofax.lwb.compiler.CompileLanguage;
 import mb.spoofax.lwb.compiler.CompileLanguageSpecification;
 import mb.spoofax.lwb.compiler.cfg.SpoofaxCfgCheck;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixCheck;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixCompile;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixConfigure;
 import mb.spoofax.lwb.compiler.esv.SpoofaxEsvCheck;
 import mb.spoofax.lwb.compiler.esv.SpoofaxEsvCompile;
 import mb.spoofax.lwb.compiler.esv.SpoofaxEsvConfigure;
@@ -68,6 +71,10 @@ public class Spoofax3CompilerModule {
         SpoofaxStatixCheck spoofaxStatixCheck,
         SpoofaxStatixCompile spoofaxStatixCompile,
 
+        SpoofaxDynamixConfigure spoofaxDynamixConfigure,
+        SpoofaxDynamixCheck spoofaxDynamixCheck,
+        SpoofaxDynamixCompile spoofaxDynamixCompile,
+
         SpoofaxStrategoConfigure spoofaxStrategoConfigure,
         SpoofaxStrategoCheck spoofaxStrategoCheck,
         SpoofaxStrategoCompile spoofaxStrategoCompile,
@@ -93,6 +100,10 @@ public class Spoofax3CompilerModule {
         taskDefs.add(spoofaxStatixConfigure);
         taskDefs.add(spoofaxStatixCheck);
         taskDefs.add(spoofaxStatixCompile);
+
+        taskDefs.add(spoofaxDynamixConfigure);
+        taskDefs.add(spoofaxDynamixCheck);
+        taskDefs.add(spoofaxDynamixCompile);
 
         taskDefs.add(spoofaxStrategoConfigure);
         taskDefs.add(spoofaxStrategoCheck);

--- a/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/StandaloneSpoofax3Compiler.java
+++ b/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/StandaloneSpoofax3Compiler.java
@@ -35,6 +35,11 @@ import mb.sdf3.DaggerSdf3Component;
 import mb.sdf3.DaggerSdf3ResourcesComponent;
 import mb.sdf3.Sdf3Component;
 import mb.sdf3.Sdf3ResourcesComponent;
+import mb.sdf3_ext_dynamix.DaggerSdf3ExtDynamixResourcesComponent;
+import mb.sdf3_ext_dynamix.Sdf3ExtDynamixComponent;
+import mb.sdf3_ext_dynamix.DaggerSdf3ExtDynamixComponent;
+
+import mb.sdf3_ext_dynamix.Sdf3ExtDynamixResourcesComponent;
 import mb.sdf3_ext_statix.DaggerSdf3ExtStatixComponent;
 import mb.sdf3_ext_statix.DaggerSdf3ExtStatixResourcesComponent;
 import mb.sdf3_ext_statix.Sdf3ExtStatixComponent;
@@ -97,6 +102,8 @@ public class StandaloneSpoofax3Compiler implements AutoCloseable {
 
         final Sdf3ExtStatixResourcesComponent sdf3ExtStatixResourcesComponent = DaggerSdf3ExtStatixResourcesComponent.create();
         resourceServiceModule.addRegistriesFrom(sdf3ExtStatixResourcesComponent);
+        final Sdf3ExtDynamixResourcesComponent sdf3ExtDynamixResourcesComponent = DaggerSdf3ExtDynamixResourcesComponent.create();
+        resourceServiceModule.addRegistriesFrom(sdf3ExtDynamixResourcesComponent);
 
         final StrategoLibResourcesComponent strategoLibResourcesComponent = DaggerStrategoLibResourcesComponent.create();
         resourceServiceModule.addRegistriesFrom(strategoLibResourcesComponent);
@@ -167,6 +174,14 @@ public class StandaloneSpoofax3Compiler implements AutoCloseable {
             .build();
         pieModule.addTaskDefsFrom(sdf3ExtStatixComponent);
 
+        final Sdf3ExtDynamixComponent sdf3ExtDynamixComponent = DaggerSdf3ExtDynamixComponent.builder()
+            .loggerComponent(loggerComponent)
+            .sdf3ExtDynamixResourcesComponent(sdf3ExtDynamixResourcesComponent)
+            .resourceServiceComponent(resourceServiceComponent)
+            .platformComponent(platformComponent)
+            .build();
+        pieModule.addTaskDefsFrom(sdf3ExtDynamixComponent);
+
         final StrategoLibComponent strategoLibComponent = DaggerStrategoLibComponent.builder()
             .loggerComponent(loggerComponent)
             .strategoLibResourcesComponent(strategoLibResourcesComponent)
@@ -216,6 +231,7 @@ public class StandaloneSpoofax3Compiler implements AutoCloseable {
             .dynamixComponent(dynamixComponent)
 
             .sdf3ExtStatixComponent(sdf3ExtStatixComponent)
+            .sdf3ExtDynamixComponent(sdf3ExtDynamixComponent)
 
             .strategoLibComponent(strategoLibComponent)
             .strategoLibResourcesComponent(strategoLibResourcesComponent)
@@ -240,6 +256,7 @@ public class StandaloneSpoofax3Compiler implements AutoCloseable {
             dynamixComponent,
 
             sdf3ExtStatixComponent,
+            sdf3ExtDynamixComponent,
 
             strategoLibComponent,
             strategoLibResourcesComponent,

--- a/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/StandaloneSpoofax3Compiler.java
+++ b/lwb/spoofax.lwb.compiler.dagger/src/main/java/mb/spoofax/lwb/compiler/dagger/StandaloneSpoofax3Compiler.java
@@ -4,6 +4,10 @@ import mb.cfg.CfgComponent;
 import mb.cfg.CfgResourcesComponent;
 import mb.cfg.DaggerCfgComponent;
 import mb.cfg.DaggerCfgResourcesComponent;
+import mb.dynamix.DaggerDynamixComponent;
+import mb.dynamix.DaggerDynamixResourcesComponent;
+import mb.dynamix.DynamixComponent;
+import mb.dynamix.DynamixResourcesComponent;
 import mb.esv.DaggerEsvComponent;
 import mb.esv.DaggerEsvResourcesComponent;
 import mb.esv.EsvComponent;
@@ -88,6 +92,8 @@ public class StandaloneSpoofax3Compiler implements AutoCloseable {
         resourceServiceModule.addRegistriesFrom(esvResourcesComponent);
         final StatixResourcesComponent statixResourcesComponent = DaggerStatixResourcesComponent.create();
         resourceServiceModule.addRegistriesFrom(statixResourcesComponent);
+        final DynamixResourcesComponent dynamixResourcesComponent = DaggerDynamixResourcesComponent.create();
+        resourceServiceModule.addRegistriesFrom(dynamixResourcesComponent);
 
         final Sdf3ExtStatixResourcesComponent sdf3ExtStatixResourcesComponent = DaggerSdf3ExtStatixResourcesComponent.create();
         resourceServiceModule.addRegistriesFrom(sdf3ExtStatixResourcesComponent);
@@ -145,6 +151,13 @@ public class StandaloneSpoofax3Compiler implements AutoCloseable {
             .platformComponent(platformComponent)
             .build();
         pieModule.addTaskDefsFrom(statixComponent);
+        final DynamixComponent dynamixComponent = DaggerDynamixComponent.builder()
+            .loggerComponent(loggerComponent)
+            .dynamixResourcesComponent(dynamixResourcesComponent)
+            .resourceServiceComponent(resourceServiceComponent)
+            .platformComponent(platformComponent)
+            .build();
+        pieModule.addTaskDefsFrom(dynamixComponent);
 
         final Sdf3ExtStatixComponent sdf3ExtStatixComponent = DaggerSdf3ExtStatixComponent.builder()
             .loggerComponent(loggerComponent)
@@ -200,6 +213,7 @@ public class StandaloneSpoofax3Compiler implements AutoCloseable {
             .strategoComponent(strategoComponent)
             .esvComponent(esvComponent)
             .statixComponent(statixComponent)
+            .dynamixComponent(dynamixComponent)
 
             .sdf3ExtStatixComponent(sdf3ExtStatixComponent)
 
@@ -223,6 +237,7 @@ public class StandaloneSpoofax3Compiler implements AutoCloseable {
             strategoComponent,
             esvComponent,
             statixComponent,
+            dynamixComponent,
 
             sdf3ExtStatixComponent,
 

--- a/lwb/spoofax.lwb.compiler.gradle/src/main/kotlin/mb/spoofax/lwb/compiler/gradle/LanguagePlugin.kt
+++ b/lwb/spoofax.lwb.compiler.gradle/src/main/kotlin/mb/spoofax/lwb/compiler/gradle/LanguagePlugin.kt
@@ -281,6 +281,39 @@ class LanguagePluginInstance(
           })
         }
       }
+      input.dynamix().ifPresent { dynamixConfig ->
+        dynamixConfig.source().caseOf()
+          .files { files ->
+            // Input: all Dynamix files in the main source directory and include directories
+            files.mainSourceDirectory().tryAsLocal("Dynamix files in main source directory") { dir ->
+              inputs.files(project.fileTree(dir) {
+                include("**/*.dx")
+              })
+            }
+            files.includeDirectories().forEach { includeDirectory ->
+              includeDirectory.tryAsLocal("Dynamix files in include directory") { dir ->
+                inputs.files(project.fileTree(dir) {
+                  include("**/*.dx")
+                })
+              }
+            }
+          }
+          .prebuilt { specAtermDirectory ->
+            // Input: prebuilt spec ATerm directory
+            specAtermDirectory.tryAsLocal("Dynamix prebuilt spec ATerm directory") { dir ->
+              inputs.files(project.fileTree(dir) {
+                include("**/*.aterm")
+              })
+            }
+          }
+
+        // Output: output spec ATerm directory
+        dynamixConfig.outputSpecAtermDirectory().tryAsLocal("Dynamix output spec ATerms directory") { dir ->
+          outputs.files(project.fileTree(dir) {
+            include("**/*.aterm")
+          })
+        }
+      }
       input.stratego().ifPresent { strategoConfig ->
         // Input: all Stratego files in the main source directory and include directories
         strategoConfig.source().files.mainSourceDirectory().tryAsLocal("Stratego files in main source directory") { dir ->

--- a/lwb/spoofax.lwb.compiler/build.gradle.kts
+++ b/lwb/spoofax.lwb.compiler/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   api(project(":stratego"))
   api(project(":esv"))
   api(project(":statix"))
+  api(project(":dynamix"))
   api(project(":sdf3_ext_statix"))
 
   api(project(":strategolib"))

--- a/lwb/spoofax.lwb.compiler/build.gradle.kts
+++ b/lwb/spoofax.lwb.compiler/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   api(project(":statix"))
   api(project(":dynamix"))
   api(project(":sdf3_ext_statix"))
+  api(project(":sdf3_ext_dynamix"))
 
   api(project(":strategolib"))
   api(project(":gpp"))

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/CheckLanguageSpecification.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/CheckLanguageSpecification.java
@@ -6,6 +6,7 @@ import mb.pie.api.ExecContext;
 import mb.pie.api.TaskDef;
 import mb.resource.hierarchical.ResourcePath;
 import mb.spoofax.lwb.compiler.cfg.SpoofaxCfgCheck;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixCheck;
 import mb.spoofax.lwb.compiler.esv.SpoofaxEsvCheck;
 import mb.spoofax.lwb.compiler.sdf3.SpoofaxSdf3Check;
 import mb.spoofax.lwb.compiler.statix.SpoofaxStatixCheck;
@@ -28,19 +29,22 @@ public class CheckLanguageSpecification implements TaskDef<ResourcePath, KeyedMe
     private final SpoofaxEsvCheck spoofaxEsvCheck;
     private final SpoofaxStatixCheck spoofaxStatixCheck;
     private final SpoofaxStrategoCheck spoofaxStrategoCheck;
+    private final SpoofaxDynamixCheck spoofaxDynamixCheck;
 
     @Inject public CheckLanguageSpecification(
         SpoofaxCfgCheck spoofaxCfgCheck,
         SpoofaxSdf3Check spoofaxSdf3Check,
         SpoofaxEsvCheck spoofaxEsvCheck,
         SpoofaxStatixCheck spoofaxStatixCheck,
-        SpoofaxStrategoCheck spoofaxStrategoCheck
+        SpoofaxStrategoCheck spoofaxStrategoCheck,
+        SpoofaxDynamixCheck spoofaxDynamixCheck
     ) {
         this.spoofaxCfgCheck = spoofaxCfgCheck;
         this.spoofaxSdf3Check = spoofaxSdf3Check;
         this.spoofaxEsvCheck = spoofaxEsvCheck;
         this.spoofaxStatixCheck = spoofaxStatixCheck;
         this.spoofaxStrategoCheck = spoofaxStrategoCheck;
+        this.spoofaxDynamixCheck = spoofaxDynamixCheck;
     }
 
     @Override public String getId() {
@@ -55,6 +59,7 @@ public class CheckLanguageSpecification implements TaskDef<ResourcePath, KeyedMe
         messagesBuilder.addMessages(context.require(spoofaxEsvCheck, rootDirectory));
         messagesBuilder.addMessages(context.require(spoofaxStatixCheck, rootDirectory));
         messagesBuilder.addMessages(context.require(spoofaxStrategoCheck, rootDirectory));
+        messagesBuilder.addMessages(context.require(spoofaxDynamixCheck, rootDirectory));
         return messagesBuilder.build();
     }
 }

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/CompileLanguageSpecification.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/CompileLanguageSpecification.java
@@ -7,6 +7,7 @@ import mb.pie.api.ExecContext;
 import mb.pie.api.Interactivity;
 import mb.pie.api.TaskDef;
 import mb.resource.hierarchical.ResourcePath;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixCompile;
 import mb.spoofax.lwb.compiler.esv.SpoofaxEsvCompile;
 import mb.spoofax.lwb.compiler.sdf3.SpoofaxSdf3Compile;
 import mb.spoofax.lwb.compiler.statix.SpoofaxStatixCompile;
@@ -47,17 +48,20 @@ public class CompileLanguageSpecification implements TaskDef<ResourcePath, Resul
     private final SpoofaxSdf3Compile spoofaxSdf3Compile;
     private final SpoofaxEsvCompile spoofaxEsvCompile;
     private final SpoofaxStatixCompile spoofaxStatixCompile;
+    private final SpoofaxDynamixCompile spoofaxDynamixCompile;
     private final SpoofaxStrategoCompile spoofaxStrategoCompile;
 
     @Inject public CompileLanguageSpecification(
         SpoofaxSdf3Compile spoofaxSdf3Compile,
         SpoofaxEsvCompile spoofaxEsvCompile,
         SpoofaxStatixCompile spoofaxStatixCompile,
+        SpoofaxDynamixCompile spoofaxDynamixCompile,
         SpoofaxStrategoCompile spoofaxStrategoCompile
     ) {
         this.spoofaxSdf3Compile = spoofaxSdf3Compile;
         this.spoofaxEsvCompile = spoofaxEsvCompile;
         this.spoofaxStatixCompile = spoofaxStatixCompile;
+        this.spoofaxDynamixCompile = spoofaxDynamixCompile;
         this.spoofaxStrategoCompile = spoofaxStrategoCompile;
     }
 
@@ -82,6 +86,10 @@ public class CompileLanguageSpecification implements TaskDef<ResourcePath, Resul
                 context.require(spoofaxStatixCompile, rootDirectory)
                     .ifOk(messagesBuilder::addMessages)
                     .mapErr(CompileLanguageSpecificationException::statixCompileFail)
+            ).and(
+                context.require(spoofaxDynamixCompile, rootDirectory)
+                    .ifOk(messagesBuilder::addMessages)
+                    .mapErr(CompileLanguageSpecificationException::dynamixCompileFail)
             ).and(
                 context.require(spoofaxStrategoCompile, rootDirectory)
                     .ifOk(o -> {

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/CompileLanguageSpecificationException.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/CompileLanguageSpecificationException.java
@@ -1,6 +1,7 @@
 package mb.spoofax.lwb.compiler;
 
 import mb.common.util.ADT;
+import mb.spoofax.lwb.compiler.dynamix.SpoofaxDynamixCompileException;
 import mb.spoofax.lwb.compiler.esv.EsvCompileException;
 import mb.spoofax.lwb.compiler.sdf3.SpoofaxSdf3CompileException;
 import mb.spoofax.lwb.compiler.statix.SpoofaxStatixCompileException;
@@ -17,6 +18,8 @@ public abstract class CompileLanguageSpecificationException extends Exception {
 
         R statixCompileFail(SpoofaxStatixCompileException spoofaxStatixCompileException);
 
+        R dynamixCompileFail(SpoofaxDynamixCompileException spoofaxDynamixCompileException);
+
         R strategoCompileFail(SpoofaxStrategoCompileException spoofaxStrategoCompileException);
     }
 
@@ -30,6 +33,10 @@ public abstract class CompileLanguageSpecificationException extends Exception {
 
     public static CompileLanguageSpecificationException statixCompileFail(SpoofaxStatixCompileException cause) {
         return withCause(CompileLanguageSpecificationExceptions.statixCompileFail(cause), cause);
+    }
+
+    public static CompileLanguageSpecificationException dynamixCompileFail(SpoofaxDynamixCompileException cause) {
+        return withCause(CompileLanguageSpecificationExceptions.dynamixCompileFail(cause), cause);
     }
 
     public static CompileLanguageSpecificationException strategoCompileFail(SpoofaxStrategoCompileException cause) {
@@ -58,6 +65,7 @@ public abstract class CompileLanguageSpecificationException extends Exception {
             .sdf3CompileFail((cause) -> "SDF3 compiler failed")
             .esvCompileFail((cause) -> "ESV compiler failed")
             .statixCompileFail((cause) -> "Statix compiler failed")
+            .dynamixCompileFail((cause) -> "Dynamix compiler failed")
             .strategoCompileFail((cause) -> "Stratego compiler failed")
             .apply(this);
     }

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixCheck.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixCheck.java
@@ -1,0 +1,50 @@
+package mb.spoofax.lwb.compiler.dynamix;
+
+import mb.common.message.KeyedMessages;
+import mb.common.message.Message;
+import mb.common.util.ListView;
+import mb.dynamix.task.DynamixCheckMulti;
+import mb.pie.api.ExecContext;
+import mb.pie.api.TaskDef;
+import mb.resource.hierarchical.ResourcePath;
+
+import javax.inject.Inject;
+
+/**
+ * Check task for Dynamix in the context of the Spoofax LWB compiler.
+ */
+public class SpoofaxDynamixCheck implements TaskDef<ResourcePath, KeyedMessages> {
+    private final SpoofaxDynamixConfigure configure;
+    private final DynamixCheckMulti check;
+
+    @Inject public SpoofaxDynamixCheck(
+        SpoofaxDynamixConfigure configure,
+        DynamixCheckMulti check
+    ) {
+        this.configure = configure;
+        this.check = check;
+    }
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override
+    public KeyedMessages exec(ExecContext context, ResourcePath rootDirectory) {
+        return context.require(configure, rootDirectory).mapOrElse(
+            o -> o.mapOrElse(
+                c -> check(context, c),
+                KeyedMessages::of
+            ),
+            e -> KeyedMessages.ofTryExtractMessagesFrom(e, rootDirectory)
+                .orElse(KeyedMessages.of(ListView.of(new Message("Could not check Dynamix because it could not be configured", e)), rootDirectory))
+        );
+    }
+
+    public KeyedMessages check(ExecContext context, SpoofaxDynamixConfig config) {
+        return config.caseOf()
+            .files((dynamixConfig, outputSpecAtermDirectory) -> context.require(check, dynamixConfig.rootDirectory))
+            .prebuilt((inputSpecAtermDirectory, outputSpecAtermDirectory) -> KeyedMessages.of())
+            ;
+    }
+}

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixCompile.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixCompile.java
@@ -1,0 +1,172 @@
+package mb.spoofax.lwb.compiler.dynamix;
+
+import mb.cfg.task.CfgRootDirectoryToObject;
+import mb.common.message.KeyedMessages;
+import mb.common.message.KeyedMessagesBuilder;
+import mb.common.result.Result;
+import mb.common.util.ListView;
+import mb.dynamix.task.DynamixCheckMulti;
+import mb.dynamix.task.DynamixCompileAndMergeProject;
+import mb.dynamix.task.DynamixCompileModule;
+import mb.dynamix.task.DynamixCompileProject;
+import mb.pie.api.ExecContext;
+import mb.pie.api.Interactivity;
+import mb.pie.api.TaskDef;
+import mb.resource.hierarchical.HierarchicalResource;
+import mb.resource.hierarchical.ResourcePath;
+import mb.resource.hierarchical.match.ResourceMatcher;
+import mb.resource.hierarchical.match.path.PathMatcher;
+import mb.spoofax.lwb.compiler.util.TaskCopyUtil;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Set;
+
+/**
+ * Compilation task for Dynamix in the context of the Spoofax LWB compiler.
+ */
+public class SpoofaxDynamixCompile implements TaskDef<ResourcePath, Result<KeyedMessages, SpoofaxDynamixCompileException>> {
+    private final CfgRootDirectoryToObject cfgRootDirectoryToObject;
+
+    private final SpoofaxDynamixConfigure configure;
+
+    private final DynamixCheckMulti check;
+    private final DynamixCompileProject compileProject;
+    private final DynamixCompileAndMergeProject compileAndMergeProject;
+
+    @Inject public SpoofaxDynamixCompile(
+        CfgRootDirectoryToObject cfgRootDirectoryToObject,
+        SpoofaxDynamixConfigure configure,
+        DynamixCheckMulti check,
+        DynamixCompileProject compileProject,
+        DynamixCompileAndMergeProject compileAndMergeProject
+    ) {
+        this.cfgRootDirectoryToObject = cfgRootDirectoryToObject;
+        this.configure = configure;
+        this.check = check;
+        this.compileProject = compileProject;
+        this.compileAndMergeProject = compileAndMergeProject;
+    }
+
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override
+    public Result<KeyedMessages, SpoofaxDynamixCompileException> exec(ExecContext context, ResourcePath rootDirectory) throws IOException {
+        return context.require(configure, rootDirectory)
+            .mapErr(SpoofaxDynamixCompileException::configureFail)
+            .flatMapThrowing(o -> o.mapThrowingOr(
+                c -> compile(context, rootDirectory, c),
+                Result.ofOk(KeyedMessages.of()) // Dynamix is not configured, nothing to do.
+            ));
+    }
+
+    @Override public boolean shouldExecWhenAffected(ResourcePath input, Set<?> tags) {
+        return tags.isEmpty() || tags.contains(Interactivity.NonInteractive);
+    }
+
+    public Result<KeyedMessages, SpoofaxDynamixCompileException> compile(
+        ExecContext context,
+        ResourcePath rootDirectory,
+        SpoofaxDynamixConfig config
+    ) throws IOException {
+        try {
+            return config.caseOf()
+                .files((dynamixConfig, outputSpecAtermDirectory) -> compileFromSourceFilesCatching(context, rootDirectory, outputSpecAtermDirectory))
+                .prebuilt((inputSpecAtermDirectory, outputSpecAtermDirectory) -> copyPrebuilt(context, inputSpecAtermDirectory, outputSpecAtermDirectory))
+                ;
+        } catch(UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    public Result<KeyedMessages, SpoofaxDynamixCompileException> compileFromSourceFilesCatching(
+        ExecContext context,
+        ResourcePath rootDirectory,
+        ResourcePath outputSpecAtermDirectoryPath
+    ) {
+        try {
+            return compileFromSourceFiles(context, rootDirectory, outputSpecAtermDirectoryPath);
+        } catch(IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public Result<KeyedMessages, SpoofaxDynamixCompileException> compileFromSourceFiles(
+        ExecContext context,
+        ResourcePath rootDirectory,
+        ResourcePath outputSpecAtermDirectoryPath
+    ) throws IOException {
+        final KeyedMessages messages = context.require(check, rootDirectory);
+        if(messages.containsError()) {
+            return Result.ofErr(SpoofaxDynamixCompileException.checkFail(messages));
+        }
+
+        final HierarchicalResource outputDirectory = context.getHierarchicalResource(outputSpecAtermDirectoryPath).ensureDirectoryExists();
+        final KeyedMessagesBuilder messagesBuilder = new KeyedMessagesBuilder();
+        final Result<KeyedMessages, SpoofaxDynamixCompileException> result = context.require(compileProject, rootDirectory)
+            .mapThrowing(o -> {
+                writeAllOutputs(context, o, outputDirectory);
+                return messages;
+            })
+            .ifOk(messagesBuilder::addMessages)
+            .mapErr(SpoofaxDynamixCompileException::compileFail)
+            .and(
+                context.require(compileAndMergeProject, rootDirectory)
+                    .mapThrowing(o -> {
+                        final HierarchicalResource mergedOutputFile = outputDirectory.appendAsRelativePath("src-gen/dynamix/dynamix.merged.aterm").ensureFileExists();
+                        writeOutput(context, o, mergedOutputFile);
+                        return messages;
+                    })
+                    .ifOk(messagesBuilder::addMessages)
+                    .mapErr(SpoofaxDynamixCompileException::compileFail)
+            );
+        if(result.isErr()) return result.ignoreValueIfErr();
+        return Result.ofOk(messagesBuilder.build());
+    }
+
+    public Result<KeyedMessages, SpoofaxDynamixCompileException> copyPrebuilt(
+        ExecContext context,
+        ResourcePath inputSpecAtermDirectoryPath,
+        ResourcePath outputSpecAtermDirectoryPath
+    ) {
+        try {
+            TaskCopyUtil.copyAll(context, inputSpecAtermDirectoryPath, outputSpecAtermDirectoryPath, ResourceMatcher.ofPath(PathMatcher.ofExtension("aterm")));
+        } catch(IOException e) {
+            return Result.ofErr(SpoofaxDynamixCompileException.compileFail(e));
+        }
+        return Result.ofOk(KeyedMessages.of());
+    }
+
+    /**
+     * Writes all compiled Dynamix modules to files.
+     *
+     * @param context              the execution context
+     * @param compileModuleOutputs the compiled Dynamix modules
+     * @param outputDirectory      the path to write the files to
+     * @throws IOException if an I/O exception occurred
+     */
+    private void writeAllOutputs(ExecContext context, ListView<DynamixCompileModule.Output> compileModuleOutputs, HierarchicalResource outputDirectory) throws IOException {
+        for(DynamixCompileModule.Output output : compileModuleOutputs) {
+            final HierarchicalResource outputFile = outputDirectory.appendAsRelativePath(output.relativeOutputPath).ensureFileExists();
+            writeOutput(context, output.spec, outputFile);
+        }
+    }
+
+    /**
+     * Writes an ATerm to a file.
+     *
+     * @param context    the execution context
+     * @param ast        the AST to write
+     * @param outputFile the file to write to
+     * @throws IOException if an I/O exception occurred
+     */
+    private void writeOutput(ExecContext context, IStrategoTerm ast, HierarchicalResource outputFile) throws IOException {
+        outputFile.writeString(ast.toString());
+        context.provide(outputFile);
+    }
+}

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixCompile.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixCompile.java
@@ -1,6 +1,5 @@
 package mb.spoofax.lwb.compiler.dynamix;
 
-import mb.cfg.task.CfgRootDirectoryToObject;
 import mb.common.message.KeyedMessages;
 import mb.common.message.KeyedMessagesBuilder;
 import mb.common.result.Result;
@@ -28,8 +27,6 @@ import java.util.Set;
  * Compilation task for Dynamix in the context of the Spoofax LWB compiler.
  */
 public class SpoofaxDynamixCompile implements TaskDef<ResourcePath, Result<KeyedMessages, SpoofaxDynamixCompileException>> {
-    private final CfgRootDirectoryToObject cfgRootDirectoryToObject;
-
     private final SpoofaxDynamixConfigure configure;
 
     private final DynamixCheckMulti check;
@@ -37,13 +34,11 @@ public class SpoofaxDynamixCompile implements TaskDef<ResourcePath, Result<Keyed
     private final DynamixCompileAndMergeProject compileAndMergeProject;
 
     @Inject public SpoofaxDynamixCompile(
-        CfgRootDirectoryToObject cfgRootDirectoryToObject,
         SpoofaxDynamixConfigure configure,
         DynamixCheckMulti check,
         DynamixCompileProject compileProject,
         DynamixCompileAndMergeProject compileAndMergeProject
     ) {
-        this.cfgRootDirectoryToObject = cfgRootDirectoryToObject;
         this.configure = configure;
         this.check = check;
         this.compileProject = compileProject;

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixCompileException.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixCompileException.java
@@ -1,0 +1,80 @@
+package mb.spoofax.lwb.compiler.dynamix;
+
+import mb.cfg.task.CfgRootDirectoryToObjectException;
+import mb.common.message.HasOptionalMessages;
+import mb.common.message.KeyedMessages;
+import mb.common.util.ADT;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Compilation exception for Dynamix in the context of the Spoofax LWB compiler.
+ */
+@ADT
+public abstract class SpoofaxDynamixCompileException extends Exception implements HasOptionalMessages {
+    public interface Cases<R> {
+        R getLanguageCompilerConfigurationFail(CfgRootDirectoryToObjectException cfgRootDirectoryToObjectException);
+
+        R configureFail(SpoofaxDynamixConfigureException spoofaxDynamixConfigureException);
+
+        R checkFail(KeyedMessages messages);
+
+        R compileFail(Exception cause);
+    }
+
+    public static SpoofaxDynamixCompileException getLanguageCompilerConfigurationFail(CfgRootDirectoryToObjectException cfgRootDirectoryToObjectException) {
+        return withCause(SpoofaxDynamixCompileExceptions.getLanguageCompilerConfigurationFail(cfgRootDirectoryToObjectException), cfgRootDirectoryToObjectException);
+    }
+
+    public static SpoofaxDynamixCompileException configureFail(SpoofaxDynamixConfigureException spoofaxDynamixConfigureException) {
+        return withCause(SpoofaxDynamixCompileExceptions.configureFail(spoofaxDynamixConfigureException), spoofaxDynamixConfigureException);
+    }
+
+    public static SpoofaxDynamixCompileException checkFail(KeyedMessages messages) {
+        return SpoofaxDynamixCompileExceptions.checkFail(messages);
+    }
+
+    public static SpoofaxDynamixCompileException compileFail(Exception cause) {
+        return withCause(SpoofaxDynamixCompileExceptions.compileFail(cause), cause);
+    }
+
+    private static SpoofaxDynamixCompileException withCause(SpoofaxDynamixCompileException e, Exception cause) {
+        e.initCause(cause);
+        return e;
+    }
+
+
+    public abstract <R> R match(Cases<R> cases);
+
+    public SpoofaxDynamixCompileExceptions.CasesMatchers.TotalMatcher_GetLanguageCompilerConfigurationFail cases() {
+        return SpoofaxDynamixCompileExceptions.cases();
+    }
+
+    public SpoofaxDynamixCompileExceptions.CaseOfMatchers.TotalMatcher_GetLanguageCompilerConfigurationFail caseOf() {
+        return SpoofaxDynamixCompileExceptions.caseOf(this);
+    }
+
+
+    @Override public String getMessage() {
+        return caseOf()
+            .getLanguageCompilerConfigurationFail((cause) -> "Getting language compiler configuration failed")
+            .configureFail((cause) -> "Configuring Dynamix failed")
+            .checkFail((messages) -> "Parsing or checking Dynamix source files failed")
+            .compileFail((cause) -> "Dynamix compiler failed unexpectedly")
+            ;
+    }
+
+    @Override public Throwable fillInStackTrace() {
+        return this; // Do nothing so that no stack trace is created, saving memory and CPU time.
+    }
+
+    @Override public Optional<KeyedMessages> getOptionalMessages() {
+        return SpoofaxDynamixCompileExceptions.getMessages(this);
+    }
+
+
+    @Override public abstract int hashCode();
+
+    @Override public abstract boolean equals(@Nullable Object obj);
+}

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixConfig.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixConfig.java
@@ -1,0 +1,52 @@
+package mb.spoofax.lwb.compiler.dynamix;
+
+import mb.common.option.Option;
+import mb.common.util.ADT;
+import mb.dynamix.task.DynamixConfig;
+import mb.resource.hierarchical.ResourcePath;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * Configuration for Dynamix in the context of the Spoofax LWB compiler.
+ */
+@ADT
+public abstract class SpoofaxDynamixConfig implements Serializable {
+    public interface Cases<R> {
+        R files(DynamixConfig dynamixConfig, ResourcePath outputSpecAtermDirectory);
+
+        R prebuilt(ResourcePath inputSpecAtermDirectory, ResourcePath outputSpecAtermDirectory);
+    }
+
+    public static SpoofaxDynamixConfig files(DynamixConfig dynamixConfig, ResourcePath outputSpecAtermDirectory) {
+        return SpoofaxDynamixConfigs.files(dynamixConfig, outputSpecAtermDirectory);
+    }
+
+    public static SpoofaxDynamixConfig prebuilt(ResourcePath inputSpecAtermDirectory, ResourcePath outputSpecAtermDirectory) {
+        return SpoofaxDynamixConfigs.prebuilt(inputSpecAtermDirectory, outputSpecAtermDirectory);
+    }
+
+
+    public abstract <R> R match(SpoofaxDynamixConfig.Cases<R> cases);
+
+    public static SpoofaxDynamixConfigs.CasesMatchers.TotalMatcher_Files cases() {
+        return SpoofaxDynamixConfigs.cases();
+    }
+
+    public SpoofaxDynamixConfigs.CaseOfMatchers.TotalMatcher_Files caseOf() {
+        return SpoofaxDynamixConfigs.caseOf(this);
+    }
+
+
+    public Option<DynamixConfig> getDynamixConfig() {
+        return Option.ofOptional(SpoofaxDynamixConfigs.getDynamixConfig(this));
+    }
+
+
+    @Override public abstract int hashCode();
+
+    @Override public abstract boolean equals(@Nullable Object obj);
+
+    @Override public abstract String toString();
+}

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixConfigure.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixConfigure.java
@@ -1,0 +1,137 @@
+package mb.spoofax.lwb.compiler.dynamix;
+
+import mb.cfg.metalang.CfgDynamixConfig;
+import mb.cfg.metalang.CfgDynamixSource;
+import mb.cfg.task.CfgRootDirectoryToObject;
+import mb.cfg.task.CfgRootDirectoryToObjectException;
+import mb.cfg.task.CfgToObject;
+import mb.common.option.Option;
+import mb.common.result.Result;
+import mb.common.util.ListView;
+import mb.dynamix.task.DynamixConfig;
+import mb.pie.api.ExecContext;
+import mb.pie.api.Interactivity;
+import mb.pie.api.STask;
+import mb.pie.api.StatelessSerializableFunction;
+import mb.pie.api.TaskDef;
+import mb.pie.api.exec.UncheckedInterruptedException;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.hierarchical.HierarchicalResource;
+import mb.resource.hierarchical.ResourcePath;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Configuration task for Dynamix in the context of the Spoofax LWB compiler.
+ */
+public class SpoofaxDynamixConfigure implements TaskDef<ResourcePath, Result<Option<SpoofaxDynamixConfig>, SpoofaxDynamixConfigureException>> {
+    private final CfgRootDirectoryToObject cfgRootDirectoryToObject;
+
+    @Inject public SpoofaxDynamixConfigure(
+        CfgRootDirectoryToObject cfgRootDirectoryToObject
+    ) {
+        this.cfgRootDirectoryToObject = cfgRootDirectoryToObject;
+    }
+
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+
+    @Override
+    public Result<Option<SpoofaxDynamixConfig>, SpoofaxDynamixConfigureException> exec(ExecContext context, ResourcePath rootDirectory) throws Exception {
+        return context.requireMapping(cfgRootDirectoryToObject, rootDirectory, new DynamixConfigMapper())
+            .mapErr(SpoofaxDynamixConfigureException::getLanguageCompilerConfigurationFail)
+            .<Option<SpoofaxDynamixConfig>, Exception>flatMapThrowing(o -> Result.transpose(o.mapThrowing(c -> configure(context, rootDirectory, c))));
+    }
+
+    @Override public boolean shouldExecWhenAffected(ResourcePath input, Set<?> tags) {
+        return tags.isEmpty() || tags.contains(Interactivity.NonInteractive);
+    }
+
+    public Result<SpoofaxDynamixConfig, SpoofaxDynamixConfigureException> configure(
+        ExecContext context,
+        ResourcePath rootDirectory,
+        CfgDynamixConfig cfgDynamixConfig
+    ) throws IOException, InterruptedException {
+        try {
+            return cfgDynamixConfig.source().caseOf()
+                .files((files -> configureSourceFilesCatching(context, rootDirectory, cfgDynamixConfig, files)))
+                .prebuilt((specAtermDirectory) -> configurePrebuilt(cfgDynamixConfig, specAtermDirectory))
+                ;
+        } catch(UncheckedIOException e) {
+            throw e.getCause();
+        } // No need to unwrap UncheckedInterruptedException here, PIE handles UncheckedInterruptedException.
+    }
+
+    public Result<SpoofaxDynamixConfig, SpoofaxDynamixConfigureException> configureSourceFilesCatching(
+        ExecContext context,
+        ResourcePath rootDirectory,
+        CfgDynamixConfig cfgDynamixConfig,
+        CfgDynamixSource.Files files
+    ) {
+        try {
+            return configureSourceFiles(context, rootDirectory, cfgDynamixConfig, files);
+        } catch(IOException e) {
+            throw new UncheckedIOException(e);
+        } catch(InterruptedException e) {
+            throw new UncheckedInterruptedException(e);
+        }
+    }
+
+    public Result<SpoofaxDynamixConfig, SpoofaxDynamixConfigureException> configureSourceFiles(
+        ExecContext context,
+        ResourcePath rootDirectory,
+        CfgDynamixConfig cfgDynamixConfig,
+        CfgDynamixSource.Files files
+    ) throws IOException, InterruptedException {
+        final HierarchicalResource mainSourceDirectory = context.require(files.mainSourceDirectory(), ResourceStampers.<HierarchicalResource>exists());
+        if(!mainSourceDirectory.exists() || !mainSourceDirectory.isDirectory()) {
+            return Result.ofErr(SpoofaxDynamixConfigureException.mainSourceDirectoryFail(mainSourceDirectory.getPath()));
+        }
+        final HierarchicalResource mainFile = context.require(files.mainFile(), ResourceStampers.<HierarchicalResource>exists());
+        if(!mainFile.exists() || !mainFile.isFile()) {
+            return Result.ofErr(SpoofaxDynamixConfigureException.mainFileFail(mainFile.getPath()));
+        }
+        // TODO: check include directories.
+        // TODO: check source directories (if added to input).
+
+        // Gather origins for provided Dynamix files.
+        final ArrayList<STask<?>> sourceFileOrigins = new ArrayList<>();
+        // Gather include directories. Use LinkedHashSet to remove duplicates while keeping insertion order.
+        final LinkedHashSet<ResourcePath> includeDirectories = new LinkedHashSet<>();
+        includeDirectories.addAll(files.includeDirectories());
+
+        // TODO: compilation
+
+        final DynamixConfig dynamixConfig = new DynamixConfig(
+            rootDirectory,
+            mainFile.getPath(),
+            ListView.of(mainSourceDirectory.getPath()),
+            ListView.copyOf(includeDirectories),
+            ListView.of(sourceFileOrigins)
+        );
+        return Result.ofOk(SpoofaxDynamixConfig.files(dynamixConfig, cfgDynamixConfig.outputSpecAtermDirectory()));
+    }
+
+    public Result<SpoofaxDynamixConfig, SpoofaxDynamixConfigureException> configurePrebuilt(
+        CfgDynamixConfig cfgDynamixConfig,
+        ResourcePath inputSpecAtermDirectory
+    ) {
+        return Result.ofOk(SpoofaxDynamixConfig.prebuilt(inputSpecAtermDirectory, cfgDynamixConfig.outputSpecAtermDirectory()));
+    }
+
+    // todo: compilation
+
+    private static class DynamixConfigMapper extends StatelessSerializableFunction<Result<CfgToObject.Output, CfgRootDirectoryToObjectException>, Result<Option<CfgDynamixConfig>, CfgRootDirectoryToObjectException>> {
+        @Override
+        public Result<Option<CfgDynamixConfig>, CfgRootDirectoryToObjectException> apply(Result<CfgToObject.Output, CfgRootDirectoryToObjectException> result) {
+            return result.map(o -> Option.ofOptional(o.compileLanguageInput.compileLanguageSpecificationInput().dynamix()));
+        }
+    }
+}

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixConfigureException.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixConfigureException.java
@@ -1,0 +1,82 @@
+package mb.spoofax.lwb.compiler.dynamix;
+
+import mb.cfg.task.CfgRootDirectoryToObjectException;
+import mb.common.util.ADT;
+import mb.resource.ResourceKey;
+import mb.resource.hierarchical.ResourcePath;
+import mb.spoofax.lwb.compiler.sdf3.SpoofaxSdf3ConfigureException;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Configuration exception for Dynamix in the context of the Spoofax LWB compiler.
+ */
+@ADT
+public abstract class SpoofaxDynamixConfigureException extends Exception {
+    public interface Cases<R> {
+        R getLanguageCompilerConfigurationFail(CfgRootDirectoryToObjectException cfgRootDirectoryToObjectException);
+
+        R mainSourceDirectoryFail(ResourcePath mainSourceDirectory);
+
+        R mainFileFail(ResourceKey mainFile);
+
+        R sdf3ConfigureFail(SpoofaxSdf3ConfigureException spoofaxSdf3ConfigureException);
+
+        R sdf3ExtDynamixGenInjFail(Exception cause);
+    }
+
+    public static SpoofaxDynamixConfigureException getLanguageCompilerConfigurationFail(CfgRootDirectoryToObjectException cfgRootDirectoryToObjectException) {
+        return withCause(SpoofaxDynamixConfigureExceptions.getLanguageCompilerConfigurationFail(cfgRootDirectoryToObjectException), cfgRootDirectoryToObjectException);
+    }
+
+    public static SpoofaxDynamixConfigureException mainSourceDirectoryFail(ResourcePath sourceDirectory) {
+        return SpoofaxDynamixConfigureExceptions.mainSourceDirectoryFail(sourceDirectory);
+    }
+
+    public static SpoofaxDynamixConfigureException mainFileFail(ResourceKey mainFile) {
+        return SpoofaxDynamixConfigureExceptions.mainFileFail(mainFile);
+    }
+
+    public static SpoofaxDynamixConfigureException sdf3ConfigureFail(SpoofaxSdf3ConfigureException spoofaxSdf3ConfigureException) {
+        return withCause(SpoofaxDynamixConfigureExceptions.sdf3ConfigureFail(spoofaxSdf3ConfigureException), spoofaxSdf3ConfigureException);
+    }
+
+    public static SpoofaxDynamixConfigureException sdf3ExtDynamixGenInjFail(Exception cause) {
+        return withCause(SpoofaxDynamixConfigureExceptions.sdf3ExtDynamixGenInjFail(cause), cause);
+    }
+
+    private static SpoofaxDynamixConfigureException withCause(SpoofaxDynamixConfigureException e, Exception cause) {
+        e.initCause(cause);
+        return e;
+    }
+
+
+    public abstract <R> R match(Cases<R> cases);
+
+    public static SpoofaxDynamixConfigureExceptions.CasesMatchers.TotalMatcher_GetLanguageCompilerConfigurationFail cases() {
+        return SpoofaxDynamixConfigureExceptions.cases();
+    }
+
+    public SpoofaxDynamixConfigureExceptions.CaseOfMatchers.TotalMatcher_GetLanguageCompilerConfigurationFail caseOf() {
+        return SpoofaxDynamixConfigureExceptions.caseOf(this);
+    }
+
+
+    @Override public String getMessage() {
+        return caseOf()
+            .getLanguageCompilerConfigurationFail((cause) -> "Getting language compiler configuration failed")
+            .mainSourceDirectoryFail((mainSourceDirectory) -> "Dynamix main source directory '" + mainSourceDirectory + "' does not exist or is not a directory")
+            .mainFileFail((mainFile) -> "Dynamix main file '" + mainFile + "' does not exist or is not a file")
+            .sdf3ConfigureFail(cause -> "Configuring SDF3 failed")
+            .sdf3ExtDynamixGenInjFail(cause -> "SDF3 to Dynamix signature generator failed")
+            ;
+    }
+
+    @Override public Throwable fillInStackTrace() {
+        return this; // Do nothing so that no stack trace is created, saving memory and CPU time.
+    }
+
+
+    @Override public abstract int hashCode();
+
+    @Override public abstract boolean equals(@Nullable Object obj);
+}

--- a/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixGenerationUtil.java
+++ b/lwb/spoofax.lwb.compiler/src/main/java/mb/spoofax/lwb/compiler/dynamix/SpoofaxDynamixGenerationUtil.java
@@ -1,0 +1,43 @@
+package mb.spoofax.lwb.compiler.dynamix;
+
+import mb.common.result.Result;
+import mb.dynamix.task.DynamixPrettyPrint;
+import mb.pie.api.ExecContext;
+import mb.pie.api.STask;
+import mb.pie.api.stamp.resource.ResourceStampers;
+import mb.resource.hierarchical.HierarchicalResource;
+import mb.resource.hierarchical.ResourcePath;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.terms.util.TermUtils;
+
+import javax.inject.Inject;
+
+/**
+ * Dynamix generation utilities in the context of the Spoofax LWB compiler.
+ */
+public class SpoofaxDynamixGenerationUtil {
+    private final DynamixPrettyPrint prettyPrint;
+
+    @Inject public SpoofaxDynamixGenerationUtil(DynamixPrettyPrint prettyPrint) {
+        this.prettyPrint = prettyPrint;
+    }
+
+    public void writePrettyPrintedFile(
+        ExecContext context,
+        ResourcePath generatesSourcesDirectory,
+        STask<Result<IStrategoTerm, ?>> supplier
+    ) throws Exception {
+        final Result<IStrategoTerm, ? extends Exception> result = context.require(supplier);
+        final IStrategoTerm ast = result.unwrap();
+        final String moduleName = TermUtils.toJavaStringAt(ast, 0); // output is `Program(mid, contents)`, extract mid
+
+        final Result<IStrategoTerm, ? extends Exception> prettyPrintedResult = context.require(prettyPrint, supplier);
+        final IStrategoTerm prettyPrintedTerm = prettyPrintedResult.unwrap();
+        final String prettyPrinted = TermUtils.toJavaString(prettyPrintedTerm);
+
+        final HierarchicalResource file = context.getHierarchicalResource(generatesSourcesDirectory.appendRelativePath(moduleName).appendToLeaf(".dx"));
+        file.ensureFileExists();
+        file.writeString(prettyPrinted);
+        context.provide(file, ResourceStampers.hashFile());
+    }
+}


### PR DESCRIPTION
Initial dummy/WIP implementation of Dynamix languages within Spoofax 3.

List of things that still need to be done/reviewed (this is mainly a list for me):
- dynamix.runtime project, Spoofax2
- Move stx/sdf/str to dynamix subfolder for namespacing
- Namespace stratego functions to `dx-`/`dx--`
- Review moving of dynamix projects to a separate repository (spoofax.pie is ok for now)
- Review version of imported source language for spoofax2 projects (currently 0.0.1-snapshot)
- Consider extracting tim to separate meta-language, source imports
