### PR TITLE
Remove ECJ dependency

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
   // Set versions for plugins to use, only applying them in subprojects (apply false here).
   id("org.metaborg.devenv.spoofax.gradle.langspec") version "0.1.32" apply false
-  id("de.set.ecj") version "1.4.1" apply false
   id("org.metaborg.coronium.bundle") version "0.3.16" apply false
   id("biz.aQute.bnd.builder") version "5.3.0" apply false
   id("org.jetbrains.intellij") version "1.4.0" apply false

--- a/example/mod/mod.spoofaxcore/build.gradle.kts
+++ b/example/mod/mod.spoofaxcore/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   id("org.metaborg.devenv.spoofax.gradle.langspec")
-  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
   `maven-publish`
 }
 
@@ -11,11 +10,4 @@ dependencies {
   compileLanguage("org.metaborg.devenv:statix.lang:$spoofax2DevenvVersion")
   sourceLanguage("org.metaborg.devenv:meta.lib.spoofax:$spoofax2DevenvVersion")
   sourceLanguage("org.metaborg.devenv:statix.runtime:$spoofax2DevenvVersion")
-}
-
-ecj {
-  toolVersion = "3.21.0"
-}
-tasks.withType<JavaCompile> { // ECJ does not support headerOutputDirectory (-h argument).
-  options.headerOutputDirectory.convention(provider { null })
 }

--- a/example/multilang/spoofaxcore/minisdf.spoofaxcore/build.gradle.kts
+++ b/example/multilang/spoofaxcore/minisdf.spoofaxcore/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   id("org.metaborg.devenv.spoofax.gradle.langspec")
-  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
   `maven-publish`
 }
 
@@ -19,13 +18,6 @@ dependencies {
   sourceLanguage("org.metaborg.devenv:statix.runtime:$spoofax2DevenvVersion")
   sourceLanguage(project(":signature-interface.spoofaxcore"))
   sourceLanguage(project(":module-interface.spoofaxcore"))
-}
-
-ecj {
-  toolVersion = "3.21.0"
-}
-tasks.withType<JavaCompile> { // ECJ does not support headerOutputDirectory (-h argument).
-  options.headerOutputDirectory.convention(provider { null })
 }
 
 afterEvaluate {

--- a/example/multilang/spoofaxcore/ministr.spoofaxcore/build.gradle.kts
+++ b/example/multilang/spoofaxcore/ministr.spoofaxcore/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   id("org.metaborg.devenv.spoofax.gradle.langspec")
-  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
   `maven-publish`
 }
 
@@ -19,13 +18,6 @@ dependencies {
   sourceLanguage("org.metaborg.devenv:statix.runtime:$spoofax2DevenvVersion")
   sourceLanguage(project(":signature-interface.spoofaxcore"))
   sourceLanguage(project(":module-interface.spoofaxcore"))
-}
-
-ecj {
-  toolVersion = "3.21.0"
-}
-tasks.withType<JavaCompile> { // ECJ does not support headerOutputDirectory (-h argument).
-  options.headerOutputDirectory.convention(provider { null })
 }
 
 afterEvaluate {

--- a/example/multilang/spoofaxcore/module-interface.spoofaxcore/build.gradle.kts
+++ b/example/multilang/spoofaxcore/module-interface.spoofaxcore/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   id("org.metaborg.devenv.spoofax.gradle.langspec")
-  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
   `maven-publish`
 }
 
@@ -8,14 +7,6 @@ val spoofax2DevenvVersion: String by ext
 dependencies {
   compileLanguage("org.metaborg.devenv:statix.lang:$spoofax2DevenvVersion")
   sourceLanguage(project(":signature-interface.spoofaxcore"))
-}
-
-ecj {
-  toolVersion = "3.21.0"
-}
-
-tasks.withType<JavaCompile> { // ECJ does not support headerOutputDirectory (-h argument).
-  options.headerOutputDirectory.convention(provider { null })
 }
 
 afterEvaluate {

--- a/example/multilang/spoofaxcore/signature-interface.spoofaxcore/build.gradle.kts
+++ b/example/multilang/spoofaxcore/signature-interface.spoofaxcore/build.gradle.kts
@@ -1,17 +1,9 @@
 plugins {
   id("org.metaborg.devenv.spoofax.gradle.langspec")
-  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
   `maven-publish`
 }
 
 val spoofax2DevenvVersion: String by ext
 dependencies {
   compileLanguage("org.metaborg.devenv:statix.lang:$spoofax2DevenvVersion")
-}
-
-ecj {
-  toolVersion = "3.21.0"
-}
-tasks.withType<JavaCompile> { // ECJ does not support headerOutputDirectory (-h argument).
-  options.headerOutputDirectory.convention(provider { null })
 }

--- a/example/tiger/spoofaxcore/tiger.spoofaxcore/build.gradle.kts
+++ b/example/tiger/spoofaxcore/tiger.spoofaxcore/build.gradle.kts
@@ -1,12 +1,4 @@
 plugins {
   id("org.metaborg.devenv.spoofax.gradle.langspec")
-  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
   `maven-publish`
-}
-
-ecj {
-  toolVersion = "3.21.0"
-}
-tasks.withType<JavaCompile> { // ECJ does not support headerOutputDirectory (-h argument).
-  options.headerOutputDirectory.convention(provider { null })
 }

--- a/lwb.distrib/build.gradle.kts
+++ b/lwb.distrib/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
   // Set versions for plugins to use, only applying them in subprojects (apply false here).
   id("org.metaborg.devenv.spoofax.gradle.langspec") version "0.1.32" apply false
-  id("de.set.ecj") version "1.4.1" apply false
   id("org.metaborg.coronium.bundle") version "0.3.16" apply false
   id("org.metaborg.coronium.feature") version "0.3.16" apply false
   id("org.metaborg.coronium.repository") version "0.3.16" apply false

--- a/lwb/build.gradle.kts
+++ b/lwb/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
   `kotlin-dsl` apply false
 
   id("org.metaborg.devenv.spoofax.gradle.langspec") version "0.1.32" apply false
-  id("de.set.ecj") version "1.4.1" apply false
   id("org.metaborg.coronium.bundle") version "0.3.16" apply false
   id("org.metaborg.coronium.feature") version "0.3.16" apply false
   id("org.metaborg.coronium.repository") version "0.3.16" apply false


### PR DESCRIPTION
This PR removes the ECJ build dependency because [the plugin](https://github.com/TwoStone/gradle-eclipse-compiler-plugin) is severely out of date, deprecated, and not supported in recent Gradle versions.

Related PRs:
- [SDF](https://github.com/metaborg/sdf/pull/66)
- [ESV](https://github.com/metaborg/esv/pull/5)
- [Statix](https://github.com/metaborg/nabl/pull/105)
- [spoofax.gradle](https://github.com/metaborg/spoofax.gradle/pull/2)
- [Stratego](https://github.com/metaborg/stratego/pull/35)
- [Releng](https://github.com/metaborg/spoofax-deploy/pull/45)
- [SPT](https://github.com/metaborg/spt/pull/41)